### PR TITLE
ECNamedCurveTable infrastructure and users

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/x9/ECNamedCurveTable.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x9/ECNamedCurveTable.java
@@ -1,18 +1,102 @@
 package org.bouncycastle.asn1.x9;
 
 import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Vector;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.cryptopro.ECGOST3410NamedCurves;
 import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.teletrust.TeleTrusTNamedCurves;
+import org.bouncycastle.asn1.ua.DSTU4145NamedCurves;
+import org.bouncycastle.asn1.x9.X962NamedCurves;
+import org.bouncycastle.asn1.x9.X9ECParameters;
+import org.bouncycastle.crypto.params.ECDomainParameters;
 
 /**
  * A general class that reads all X9.62 style EC curve tables.
+ *
+ * TODO: ECGOST3410NamedCurves + DSTU4145NamedCurves need to be updated and included here.
  */
 public class ECNamedCurveTable
 {
+
+    // Runtime registered new named/OIDs/parameters 
+
+    private static final HashMap objIds = new HashMap(); // String -> OID
+    private static final HashMap names  = new HashMap(); // OID -> String
+    private static final HashMap params = new HashMap(); // OID -> X9ECParameters
+
+
+    /*
+      // pre-loading in init would be nice, except that different
+      // name sources have different styles of lookups -- some
+      // canonicalize to lowercase, at least one to uppercase.
+
+    private static Boolean initDone = Boolean.FALSE;
+
+    private static void _init()
+    {
+        synchronized (initDone) {
+            if (!initDone) {
+                for (final Enumeration en = X962NamedCurves.getNames(); en.hasMoreElements() ; ) {
+                    // These names are lowercase..
+                    final String name = (String)en.nextElement();
+                    final ASN1ObjectIdentifier oid = X962NamedCurves.getOID(name);
+
+                    objIds.put(name, oid);
+                    names.put(oid,name);
+
+                    final X9ECParameters xp = X962NamedCurves.getByOID(oid);
+
+                    params.put(oid, xp);
+                }
+                for (final Enumeration en = SECNamedCurves.getNames(); en.hasMoreElements() ; ) {
+                    // These names are lowercase..
+                    final String name = (String)en.nextElement();
+                    final ASN1ObjectIdentifier oid = SECNamedCurves.getOID(name);
+
+                    objIds.put(name, oid);
+                    names.put(oid,name);
+
+                    final X9ECParameters xp = SECNamedCurves.getByOID(oid);
+
+                    params.put(oid, xp);
+                }
+                for (final Enumeration en = TeleTrusTNamedCurves.getNames(); en.hasMoreElements() ; ) {
+                    // These names are lowercase..
+                    final String name = (String)en.nextElement();
+                    final ASN1ObjectIdentifier oid = TeleTrusTNamedCurves.getOID(name);
+
+                    objIds.put(name, oid);
+                    names.put(oid,name);
+
+                    final X9ECParameters xp = TeleTrusTNamedCurves.getByOID(oid);
+
+                    params.put(oid, xp);
+                }
+                for (final Enumeration en = NISTNamedCurves.getNames(); en.hasMoreElements() ; ) {
+                    // These names are UPPERCASE..
+                    final String name = ((String)en.nextElement()).toLowerCase();
+                    final ASN1ObjectIdentifier oid = NISTNamedCurves.getOID(name);
+
+                    objIds.put(name, oid);
+                    names.put(oid,name);
+
+                    final X9ECParameters xp = NISTNamedCurves.getByOID(oid);
+
+                    params.put(oid, xp);
+                }
+
+
+                initDone = Boolean.TRUE;
+            }
+        }
+    }
+    */
+
     /**
      * return a X9ECParameters object representing the passed in named
      * curve. The routine returns null if the curve is not present.
@@ -20,28 +104,36 @@ public class ECNamedCurveTable
      * @param name the name of the curve requested
      * @return an X9ECParameters object or null if the curve is not available.
      */
-    public static X9ECParameters getByName(
-        String name)
+    public static X9ECParameters getByName( final String name )
     {
-        X9ECParameters ecP = X962NamedCurves.getByName(name);
+        X9ECParameters   ecP = X962NamedCurves.getByName(name);
+        if (ecP == null) ecP = SECNamedCurves.getByName(name);
+        if (ecP == null) ecP = TeleTrusTNamedCurves.getByName(name);
+        if (ecP == null) ecP = NISTNamedCurves.getByName(name);
+        // if (ecP == null) {
+        //   ECDomainParameters dp = ECGOST3410NamedCurves.getByName(name);
+        //   if (dp != null) ecP = new X9ECParameters(dp); // TODO - modify ECGOST.. to be compatible with all others
+        // }
 
-        if (ecP == null)
-        {
-            ecP = SECNamedCurves.getByName(name);
-        }
-
-        if (ecP == null)
-        {
-            ecP = TeleTrusTNamedCurves.getByName(name);
-        }
-
-        if (ecP == null)
-        {
-            ecP = NISTNamedCurves.getByName(name);
-        }
+        if (ecP == null) ecP = _getByName(name);
 
         return ecP;
     }
+
+    private static X9ECParameters _getByName( final String name )
+    {
+        final ASN1ObjectIdentifier oid;
+        synchronized (objIds) {
+            oid = (ASN1ObjectIdentifier)objIds.get(name.toLowerCase());
+        }
+
+        if (oid != null) {
+            return _getByOID(oid);
+        }
+
+        return null;
+    }
+
 
     /**
      * return a X9ECParameters object representing the passed in named
@@ -50,48 +142,132 @@ public class ECNamedCurveTable
      * @param oid the object id of the curve requested
      * @return an X9ECParameters object or null if the curve is not available.
      */
-    public static X9ECParameters getByOID(
-        ASN1ObjectIdentifier oid)
+    public static X9ECParameters getByOID( final ASN1ObjectIdentifier oid )
     {
-        X9ECParameters ecP = X962NamedCurves.getByOID(oid);
+        X9ECParameters   ecP = X962NamedCurves.getByOID(oid);
+        if (ecP == null) ecP = SECNamedCurves.getByOID(oid);
+        if (ecP == null) ecP = TeleTrusTNamedCurves.getByOID(oid);
 
-        if (ecP == null)
-        {
-            ecP = SECNamedCurves.getByOID(oid);
-        }
+        // NISTNamedCurves are aliases of SECNamedCurves, thus no need to OID lookup
 
-        if (ecP == null)
-        {
-            ecP = TeleTrusTNamedCurves.getByOID(oid);
-        }
+        // if (ecP == null) {
+        //    ECDomainParameters dp = ECGOST3410NamedCurves.getByOID(oid);
+        //    if (dp != null) ecP = new X9ECParameters(dp); // TODO - modify ECGOST.. to be compatible with all others
+        // }
+
+        if (ecP == null) ecP = _getByOID(oid);
 
         return ecP;
     }
 
+
+    private static X9ECParameters _getByOID( final ASN1ObjectIdentifier oid )
+    {
+        synchronized (params) {
+            return (X9ECParameters)params.get(oid);
+        }
+    }
+
+
     /**
-     * return an enumeration of the names of the available curves.
+     * Return an enumeration of the names of the available curves.
+     * This enumeration is safe against modifications of the storage.
      *
      * @return an enumeration of the names of the available curves.
      */
     public static Enumeration getNames()
     {
-        Vector v = new Vector();
+        final Vector v = new Vector();
 
         addEnumeration(v, X962NamedCurves.getNames());
         addEnumeration(v, SECNamedCurves.getNames());
         addEnumeration(v, NISTNamedCurves.getNames());
         addEnumeration(v, TeleTrusTNamedCurves.getNames());
+        // addEnumeration(v, ECGOST3410NamedCurves.getNames());
+
+        synchronized (objIds) {
+            final Iterator keys = objIds.keySet().iterator();
+            while (keys.hasNext()) {
+                v.addElement(keys.next());
+            }
+        }
 
         return v.elements();
     }
 
-    private static void addEnumeration(
-        Vector v,
-        Enumeration e)
+    private static void addEnumeration( final Vector v,
+                                        final Enumeration e )
     {
-        while (e.hasMoreElements())
-        {
+        while (e.hasMoreElements()) {
             v.addElement(e.nextElement());
+        }
+    }
+
+    /**
+     * return the object identifier signified by the passed in name. Null
+     * if there is no object identifier associated with name.
+     *
+     * @return the object identifier associated with name, if present.
+     */
+    public static ASN1ObjectIdentifier getOID( final String name )
+    {
+        ASN1ObjectIdentifier oid = X962NamedCurves.getOID(name);
+        if (oid == null)     oid = SECNamedCurves.getOID(name);
+        if (oid == null)     oid = TeleTrusTNamedCurves.getOID(name);
+        if (oid == null)     oid = NISTNamedCurves.getOID(name);
+        // if (oid == null)     oid = ECGOST3410NamedCurves.getOID(name);
+
+        if (oid == null) {
+            synchronized (objIds) {
+                oid = (ASN1ObjectIdentifier)objIds.get(name.toLowerCase());
+            }
+        }
+        return oid;
+    }
+
+    /**
+     * return the named curve name represented by the given object identifier.
+     */
+    public static String getName( final ASN1ObjectIdentifier oid )
+    {
+        String            name = X962NamedCurves.getName(oid);
+        if (name == null) name = SECNamedCurves.getName(oid);
+        if (name == null) name = TeleTrusTNamedCurves.getName(oid);
+        if (name == null) name = NISTNamedCurves.getName(oid);
+        // if (name == null) name = ECGOST3410NamedCurves.getName(oid);
+        if (name == null) {
+            synchronized (names) {
+                name = (String)names.get(oid);
+            }
+        }
+        return name;
+    }
+
+
+    /**
+     * Brainpool Prime curves have special getter for their OIDs
+     */
+
+    public static ASN1ObjectIdentifier getOID( final short curvesize, final boolean twisted )
+    {
+        return TeleTrusTNamedCurves.getOID(curvesize, twisted);
+    }
+
+
+
+    /**
+     * Register new curve to system wide set
+     */
+    public static void register(final String name, final ASN1ObjectIdentifier oid, final X9ECParameters xp)
+    {
+        synchronized(names) {
+            names.put(oid, name);
+        }
+        synchronized(objIds) {
+            objIds.put(name, oid);
+        }
+        synchronized(params) {
+            params.put(oid, xp);
         }
     }
 }

--- a/core/src/main/java/org/bouncycastle/crypto/util/PrivateKeyFactory.java
+++ b/core/src/main/java/org/bouncycastle/crypto/util/PrivateKeyFactory.java
@@ -10,7 +10,6 @@ import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.oiw.ElGamalParameter;
 import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.DHParameter;
@@ -18,11 +17,9 @@ import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.pkcs.RSAPrivateKey;
 import org.bouncycastle.asn1.sec.ECPrivateKey;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
-import org.bouncycastle.asn1.teletrust.TeleTrusTNamedCurves;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.DSAParameter;
-import org.bouncycastle.asn1.x9.X962NamedCurves;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X962Parameters;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
@@ -130,22 +127,7 @@ public class PrivateKeyFactory
             if (params.isNamedCurve())
             {
                 ASN1ObjectIdentifier oid = ASN1ObjectIdentifier.getInstance(params.getParameters());
-                x9 = X962NamedCurves.getByOID(oid);
-
-                if (x9 == null)
-                {
-                    x9 = SECNamedCurves.getByOID(oid);
-
-                    if (x9 == null)
-                    {
-                        x9 = NISTNamedCurves.getByOID(oid);
-
-                        if (x9 == null)
-                        {
-                            x9 = TeleTrusTNamedCurves.getByOID(oid);
-                        }
-                    }
-                }
+                x9 = ECNamedCurveTable.getByOID(oid);
             }
             else
             {

--- a/core/src/main/java/org/bouncycastle/crypto/util/PublicKeyFactory.java
+++ b/core/src/main/java/org/bouncycastle/crypto/util/PublicKeyFactory.java
@@ -12,14 +12,11 @@ import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.oiw.ElGamalParameter;
 import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.DHParameter;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.RSAPublicKey;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
-import org.bouncycastle.asn1.teletrust.TeleTrusTNamedCurves;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.DSAParameter;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
@@ -27,7 +24,7 @@ import org.bouncycastle.asn1.x509.X509ObjectIdentifiers;
 import org.bouncycastle.asn1.x9.DHDomainParameters;
 import org.bouncycastle.asn1.x9.DHPublicKey;
 import org.bouncycastle.asn1.x9.DHValidationParms;
-import org.bouncycastle.asn1.x9.X962NamedCurves;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X962Parameters;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.asn1.x9.X9ECPoint;
@@ -166,22 +163,7 @@ public class PublicKeyFactory
             if (params.isNamedCurve())
             {
                 ASN1ObjectIdentifier oid = (ASN1ObjectIdentifier)params.getParameters();
-                x9 = X962NamedCurves.getByOID(oid);
-
-                if (x9 == null)
-                {
-                    x9 = SECNamedCurves.getByOID(oid);
-
-                    if (x9 == null)
-                    {
-                        x9 = NISTNamedCurves.getByOID(oid);
-
-                        if (x9 == null)
-                        {
-                            x9 = TeleTrusTNamedCurves.getByOID(oid);
-                        }
-                    }
-                }
+                x9 = ECNamedCurveTable.getByOID(oid);
             }
             else
             {

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/BCECPrivateKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/BCECPrivateKey.java
@@ -226,6 +226,11 @@ public class BCECPrivateKey
 
             if (ecP == null) // GOST Curve
             {
+                // TODO: This special treatment of GOST3410 should be removed;
+                //       The ecP has getECDomainParameters() method returning the same data,
+                //       and only difference is that GOST3410 does not contain X9 FieldID
+                //       (but it is trivial to add too)
+
                 ECDomainParameters gParam = ECGOST3410NamedCurves.getByOID(oid);
                 EllipticCurve ellipticCurve = EC5Util.convertCurve(gParam.getCurve(), gParam.getSeed());
 

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/KeyPairGeneratorSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/KeyPairGeneratorSpi.java
@@ -10,10 +10,7 @@ import java.security.spec.ECGenParameterSpec;
 import java.util.Hashtable;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
-import org.bouncycastle.asn1.teletrust.TeleTrusTNamedCurves;
-import org.bouncycastle.asn1.x9.X962NamedCurves;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
@@ -148,46 +145,18 @@ public abstract class KeyPairGeneratorSpi
                     curveName = ((ECNamedCurveGenParameterSpec)params).getName();
                 }
 
-                X9ECParameters  ecP = X962NamedCurves.getByName(curveName);
-                if (ecP == null)
-                {
-                    ecP = SECNamedCurves.getByName(curveName);
-                    if (ecP == null)
-                    {
-                        ecP = NISTNamedCurves.getByName(curveName);
-                    }
-                    if (ecP == null)
-                    {
-                        ecP = TeleTrusTNamedCurves.getByName(curveName);
-                    }
-                    if (ecP == null)
-                    {
-                        // See if it's actually an OID string (SunJSSE ServerHandshaker setupEphemeralECDHKeys bug)
-                        try
-                        {
-                            ASN1ObjectIdentifier oid = new ASN1ObjectIdentifier(curveName);
-                            ecP = X962NamedCurves.getByOID(oid);
-                            if (ecP == null)
-                            {
-                                ecP = SECNamedCurves.getByOID(oid);
-                            }
-                            if (ecP == null)
-                            {
-                                ecP = NISTNamedCurves.getByOID(oid);
-                            }
-                            if (ecP == null)
-                            {
-                                ecP = TeleTrusTNamedCurves.getByOID(oid);
-                            }
-                            if (ecP == null)
-                            {
-                                throw new InvalidAlgorithmParameterException("unknown curve OID: " + curveName);
-                            }
+                X9ECParameters  ecP = ECNamedCurveTable.getByName(curveName);
+                if (ecP == null) {
+                    // See if it's actually an OID string (SunJSSE ServerHandshaker setupEphemeralECDHKeys bug)
+                    try {
+                        ASN1ObjectIdentifier oid = new ASN1ObjectIdentifier(curveName);
+                        ecP = ECNamedCurveTable.getByOID(oid);
+                        if (ecP == null) {
+                            throw new InvalidAlgorithmParameterException("unknown curve OID: " + curveName);
                         }
-                        catch (IllegalArgumentException ex)
-                        {
-                            throw new InvalidAlgorithmParameterException("unknown curve name: " + curveName);
-                        }
+                    }
+                    catch (IllegalArgumentException ex) {
+                        throw new InvalidAlgorithmParameterException("unknown curve name: " + curveName);
                     }
                 }
 

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/util/ECUtil.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/util/ECUtil.java
@@ -5,13 +5,9 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.cryptopro.ECGOST3410NamedCurves;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
-import org.bouncycastle.asn1.teletrust.TeleTrusTNamedCurves;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.asn1.x9.X962NamedCurves;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.params.ECDomainParameters;
@@ -213,74 +209,18 @@ public class ECUtil
         throw new InvalidKeyException("can't identify EC private key.");
     }
 
-    public static ASN1ObjectIdentifier getNamedCurveOid(
-        String name)
+    public static ASN1ObjectIdentifier getNamedCurveOid( final String name )
     {
-        ASN1ObjectIdentifier oid = X962NamedCurves.getOID(name);
-        
-        if (oid == null)
-        {
-            oid = SECNamedCurves.getOID(name);
-            if (oid == null)
-            {
-                oid = NISTNamedCurves.getOID(name);
-            }
-            if (oid == null)
-            {
-                oid = TeleTrusTNamedCurves.getOID(name);
-            }
-            if (oid == null)
-            {
-                oid = ECGOST3410NamedCurves.getOID(name);
-            }
-        }
-
-        return oid;
+        return ECNamedCurveTable.getOID(name);
     }
     
-    public static X9ECParameters getNamedCurveByOid(
-        ASN1ObjectIdentifier oid)
+    public static X9ECParameters getNamedCurveByOid( final ASN1ObjectIdentifier oid )
     {
-        X9ECParameters params = X962NamedCurves.getByOID(oid);
-        
-        if (params == null)
-        {
-            params = SECNamedCurves.getByOID(oid);
-            if (params == null)
-            {
-                params = NISTNamedCurves.getByOID(oid);
-            }
-            if (params == null)
-            {
-                params = TeleTrusTNamedCurves.getByOID(oid);
-            }
-        }
-
-        return params;
+        return ECNamedCurveTable.getByOID(oid);
     }
 
-    public static String getCurveName(
-        ASN1ObjectIdentifier oid)
+    public static String getCurveName( final ASN1ObjectIdentifier oid )
     {
-        String name = X962NamedCurves.getName(oid);
-        
-        if (name == null)
-        {
-            name = SECNamedCurves.getName(oid);
-            if (name == null)
-            {
-                name = NISTNamedCurves.getName(oid);
-            }
-            if (name == null)
-            {
-                name = TeleTrusTNamedCurves.getName(oid);
-            }
-            if (name == null)
-            {
-                name = ECGOST3410NamedCurves.getName(oid);
-            }
-        }
-
-        return name;
+        return ECNamedCurveTable.getName( oid );
     }
 }

--- a/prov/src/main/java/org/bouncycastle/jce/ECNamedCurveTable.java
+++ b/prov/src/main/java/org/bouncycastle/jce/ECNamedCurveTable.java
@@ -1,21 +1,18 @@
 package org.bouncycastle.jce;
 
-import java.util.Enumeration;
-import java.util.Vector;
-
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
-import org.bouncycastle.asn1.teletrust.TeleTrusTNamedCurves;
-import org.bouncycastle.asn1.x9.X962NamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 
+
 /**
- * a table of locally supported named curves.
+ * Extension on org.bouncycastle.asn1.x9.ECNamedCurveTable sharing same
+ * static methods and datasets.
+ * <p>
+ * Pickup JCE resident ECNamedCurveParameterSpec for named curve.
  */
-public class ECNamedCurveTable
-{
+public class ECNamedCurveTable extends org.bouncycastle.asn1.x9.ECNamedCurveTable {
+
     /**
      * return a parameter spec representing the passed in named
      * curve. The routine returns null if the curve is not present.
@@ -23,97 +20,51 @@ public class ECNamedCurveTable
      * @param name the name of the curve requested
      * @return a parameter spec for the curve, null if it is not available.
      */
-    public static ECNamedCurveParameterSpec getParameterSpec(
-        String  name)
+    public static ECNamedCurveParameterSpec getParameterSpec( final String  name )
     {
-        X9ECParameters  ecP = X962NamedCurves.getByName(name);
-        if (ecP == null)
-        {
-            try
-            {
-                ecP = X962NamedCurves.getByOID(new ASN1ObjectIdentifier(name));
+        X9ECParameters  ecP = getByName(name);
+        if (ecP == null) {
+            try {
+                ecP = getByOID(new ASN1ObjectIdentifier(name));
             }
-            catch (IllegalArgumentException e)
-            {
+            catch (IllegalArgumentException e) {
                 // ignore - not an oid
             }
         }
         
-        if (ecP == null)
-        {
-            ecP = SECNamedCurves.getByName(name);
-            if (ecP == null)
-            {
-                try
-                {
-                    ecP = SECNamedCurves.getByOID(new ASN1ObjectIdentifier(name));
-                }
-                catch (IllegalArgumentException e)
-                {
-                    // ignore - not an oid
-                }
-            }
+        if (ecP == null) {
+            return null; // Nothing found
         }
 
-        if (ecP == null)
-        {
-            ecP = TeleTrusTNamedCurves.getByName(name);
-            if (ecP == null)
-            {
-                try
-                {
-                    ecP = TeleTrusTNamedCurves.getByOID(new ASN1ObjectIdentifier(name));
-                }
-                catch (IllegalArgumentException e)
-                {
-                    // ignore - not an oid
-                }
-            }
-        }
-
-        if (ecP == null)
-        {
-            ecP = NISTNamedCurves.getByName(name);
-        }
-        
-        if (ecP == null)
-        {
-            return null;
-        }
-
-        return new ECNamedCurveParameterSpec(
-                                        name,
-                                        ecP.getCurve(),
-                                        ecP.getG(),
-                                        ecP.getN(),
-                                        ecP.getH(),
-                                        ecP.getSeed());
+        return new ECNamedCurveParameterSpec( name,
+                                              ecP.getCurve(),
+                                              ecP.getG(),
+                                              ecP.getN(),
+                                              ecP.getH(),
+                                              ecP.getSeed());
     }
 
     /**
-     * return an enumeration of the names of the available curves.
-     *
-     * @return an enumeration of the names of the available curves.
+     * return a parameter spec representing the passed in named
+     * curve. The routine returns null if the curve is not present.
+     * 
+     * @param oid the OID of the curve requested
+     * @return a parameter spec for the curve, null if it is not available.
      */
-    public static Enumeration getNames()
+    public static ECNamedCurveParameterSpec getParameterSpec( final ASN1ObjectIdentifier oid )
     {
-        Vector v = new Vector();
-        
-        addEnumeration(v, X962NamedCurves.getNames());
-        addEnumeration(v, SECNamedCurves.getNames());
-        addEnumeration(v, NISTNamedCurves.getNames());
-        addEnumeration(v, TeleTrusTNamedCurves.getNames());
-
-        return v.elements();
-    }
-
-    private static void addEnumeration(
-        Vector v, 
-        Enumeration e)
-    {
-        while (e.hasMoreElements())
-        {
-            v.addElement(e.nextElement());
+        final X9ECParameters ecP = getByOID(oid);
+        if (ecP == null) {
+            return null; // Nothing found
         }
+
+        final String name = getName(oid);
+
+        return new ECNamedCurveParameterSpec( name,
+                                              ecP.getCurve(),
+                                              ecP.getG(),
+                                              ecP.getN(),
+                                              ecP.getH(),
+                                              ecP.getSeed());
     }
 }

--- a/prov/src/main/jdk1.4/org/bouncycastle/jcajce/provider/asymmetric/ec/KeyPairGeneratorSpi.java
+++ b/prov/src/main/jdk1.4/org/bouncycastle/jcajce/provider/asymmetric/ec/KeyPairGeneratorSpi.java
@@ -8,10 +8,7 @@ import java.security.spec.AlgorithmParameterSpec;
 import java.util.Hashtable;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
-import org.bouncycastle.asn1.teletrust.TeleTrusTNamedCurves;
-import org.bouncycastle.asn1.x9.X962NamedCurves;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
@@ -119,46 +116,18 @@ public abstract class KeyPairGeneratorSpi
 
                 curveName = ((ECNamedCurveGenParameterSpec)params).getName();
 
-                X9ECParameters  ecP = X962NamedCurves.getByName(curveName);
-                if (ecP == null)
-                {
-                    ecP = SECNamedCurves.getByName(curveName);
-                    if (ecP == null)
-                    {
-                        ecP = NISTNamedCurves.getByName(curveName);
-                    }
-                    if (ecP == null)
-                    {
-                        ecP = TeleTrusTNamedCurves.getByName(curveName);
-                    }
-                    if (ecP == null)
-                    {
-                        // See if it's actually an OID string (SunJSSE ServerHandshaker setupEphemeralECDHKeys bug)
-                        try
-                        {
-                            ASN1ObjectIdentifier oid = new ASN1ObjectIdentifier(curveName);
-                            ecP = X962NamedCurves.getByOID(oid);
-                            if (ecP == null)
-                            {
-                                ecP = SECNamedCurves.getByOID(oid);
-                            }
-                            if (ecP == null)
-                            {
-                                ecP = NISTNamedCurves.getByOID(oid);
-                            }
-                            if (ecP == null)
-                            {
-                                ecP = TeleTrusTNamedCurves.getByOID(oid);
-                            }
-                            if (ecP == null)
-                            {
-                                throw new InvalidAlgorithmParameterException("unknown curve OID: " + curveName);
-                            }
+                X9ECParameters  ecP = ECNamedCurveTable.getByName(curveName);
+                if (ecP == null) {
+                    // See if it's actually an OID string (SunJSSE ServerHandshaker setupEphemeralECDHKeys bug)
+                    try {
+                        ASN1ObjectIdentifier oid = new ASN1ObjectIdentifier(curveName);
+                        ecP = ECNamedCurveTable.getByOID(oid);
+                        if (ecP == null) {
+                            throw new InvalidAlgorithmParameterException("unknown curve OID: " + curveName);
                         }
-                        catch (IllegalArgumentException ex)
-                        {
-                            throw new InvalidAlgorithmParameterException("unknown curve name: " + curveName);
-                        }
+                    }
+                    catch (IllegalArgumentException ex) {
+                        throw new InvalidAlgorithmParameterException("unknown curve name: " + curveName);
                     }
                 }
 

--- a/prov/src/main/jdk1.4/org/bouncycastle/jcajce/provider/asymmetric/util/ECUtil.java
+++ b/prov/src/main/jdk1.4/org/bouncycastle/jcajce/provider/asymmetric/util/ECUtil.java
@@ -5,11 +5,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.cryptopro.ECGOST3410NamedCurves;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
-import org.bouncycastle.asn1.teletrust.TeleTrusTNamedCurves;
-import org.bouncycastle.asn1.x9.X962NamedCurves;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.params.ECDomainParameters;
@@ -150,71 +146,18 @@ public class ECUtil
     public static ASN1ObjectIdentifier getNamedCurveOid(
         String name)
     {
-        ASN1ObjectIdentifier oid = X962NamedCurves.getOID(name);
-        
-        if (oid == null)
-        {
-            oid = SECNamedCurves.getOID(name);
-            if (oid == null)
-            {
-                oid = NISTNamedCurves.getOID(name);
-            }
-            if (oid == null)
-            {
-                oid = TeleTrusTNamedCurves.getOID(name);
-            }
-            if (oid == null)
-            {
-                oid = ECGOST3410NamedCurves.getOID(name);
-            }
-        }
-
-        return oid;
+        return ECNamedCurveTable.getOID(name);
     }
     
     public static X9ECParameters getNamedCurveByOid(
         ASN1ObjectIdentifier oid)
     {
-        X9ECParameters params = X962NamedCurves.getByOID(oid);
-        
-        if (params == null)
-        {
-            params = SECNamedCurves.getByOID(oid);
-            if (params == null)
-            {
-                params = NISTNamedCurves.getByOID(oid);
-            }
-            if (params == null)
-            {
-                params = TeleTrusTNamedCurves.getByOID(oid);
-            }
-        }
-
-        return params;
+        return ECNamedCurveTable.getByOID(oid);
     }
 
     public static String getCurveName(
         ASN1ObjectIdentifier oid)
     {
-        String name = X962NamedCurves.getName(oid);
-        
-        if (name == null)
-        {
-            name = SECNamedCurves.getName(oid);
-            if (name == null)
-            {
-                name = NISTNamedCurves.getName(oid);
-            }
-            if (name == null)
-            {
-                name = TeleTrusTNamedCurves.getName(oid);
-            }
-            if (name == null)
-            {
-                name = ECGOST3410NamedCurves.getName(oid);
-            }
-        }
-
-        return name;
+        return ECNamedCurveTable.getName(oid);
     }
 }


### PR DESCRIPTION
First iteration of ECNamedCurveTable infrastructure calling all
instances of named curve registries, and all applications using
this instead of repeating same code all over the place -- with
slight variations in call order..
