### PR TITLE
Prevent CMAC from accepting IV

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/macs/CMac.java
+++ b/core/src/main/java/org/bouncycastle/crypto/macs/CMac.java
@@ -5,6 +5,7 @@ import org.bouncycastle.crypto.CipherParameters;
 import org.bouncycastle.crypto.Mac;
 import org.bouncycastle.crypto.modes.CBCBlockCipher;
 import org.bouncycastle.crypto.paddings.ISO7816d4Padding;
+import org.bouncycastle.crypto.params.KeyParameter;
 
 /**
  * CMAC - as specified at www.nuee.nagoya-u.ac.jp/labs/tiwata/omac/omac.html
@@ -121,7 +122,7 @@ public class CMac implements Mac
 
     public void init(CipherParameters params)
     {
-        if (params != null)
+        if (params instanceof KeyParameter)
         {
             cipher.init(true, params);
     
@@ -130,6 +131,10 @@ public class CMac implements Mac
             cipher.processBlock(ZEROES, 0, L, 0);
             Lu = doubleLu(L);
             Lu2 = doubleLu(Lu);
+        } else if (params != null)
+        {
+            // CMAC mode does not permit IV to underlying CBC mode
+            throw new IllegalArgumentException("CMac mode only permits key to be set.");
         }
 
         reset();

--- a/core/src/test/java/org/bouncycastle/crypto/test/CMacTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/CMacTest.java
@@ -2,9 +2,11 @@ package org.bouncycastle.crypto.test;
 
 import org.bouncycastle.crypto.BlockCipher;
 import org.bouncycastle.crypto.Mac;
+import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.engines.AESFastEngine;
 import org.bouncycastle.crypto.macs.CMac;
 import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
 import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
@@ -247,6 +249,21 @@ public class CMacTest
         {
             fail("Failed - expected " + new String(Hex.encode(output_k256_m64))
                 + " got " + new String(Hex.encode(out)));
+        }
+        
+        testExceptions();
+    }
+
+    private void testExceptions()
+    {
+        try 
+        {
+            CMac mac = new CMac(new AESEngine());
+            mac.init(new ParametersWithIV(new KeyParameter(new byte[16]), new byte[16]));
+            fail("CMac does not accept IV");
+        } catch(IllegalArgumentException e)
+        {
+            // Expected
         }
     }
 


### PR DESCRIPTION
CMAC is defined with an all zero IV (Page 9 of NIST SP 800-38B), so block any init parameters other than KeyParameter being passed to underlying CBC mode.
