### PR TITLE
Allow CAST6 and Noekeon to be used with OCB mode in JCE.

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/CAST6.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/CAST6.java
@@ -1,6 +1,8 @@
 package org.bouncycastle.jcajce.provider.symmetric;
 
+import org.bouncycastle.crypto.BlockCipher;
 import org.bouncycastle.crypto.CipherKeyGenerator;
+import org.bouncycastle.crypto.engines.AESFastEngine;
 import org.bouncycastle.crypto.engines.CAST6Engine;
 import org.bouncycastle.crypto.macs.GMac;
 import org.bouncycastle.crypto.modes.GCMBlockCipher;
@@ -8,6 +10,7 @@ import org.bouncycastle.jcajce.provider.config.ConfigurableProvider;
 import org.bouncycastle.jcajce.provider.symmetric.util.BaseBlockCipher;
 import org.bouncycastle.jcajce.provider.symmetric.util.BaseKeyGenerator;
 import org.bouncycastle.jcajce.provider.symmetric.util.BaseMac;
+import org.bouncycastle.jcajce.provider.symmetric.util.BlockCipherProvider;
 
 public final class CAST6
 {
@@ -20,7 +23,13 @@ public final class CAST6
     {
         public ECB()
         {
-            super(new CAST6Engine());
+            super(new BlockCipherProvider()
+            {
+                public BlockCipher get()
+                {
+                    return new CAST6Engine();
+                }
+            });
         }
     }
 

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/Noekeon.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/Noekeon.java
@@ -7,7 +7,9 @@ import java.security.spec.AlgorithmParameterSpec;
 
 import javax.crypto.spec.IvParameterSpec;
 
+import org.bouncycastle.crypto.BlockCipher;
 import org.bouncycastle.crypto.CipherKeyGenerator;
+import org.bouncycastle.crypto.engines.AESFastEngine;
 import org.bouncycastle.crypto.engines.NoekeonEngine;
 import org.bouncycastle.crypto.macs.GMac;
 import org.bouncycastle.crypto.modes.GCMBlockCipher;
@@ -16,6 +18,7 @@ import org.bouncycastle.jcajce.provider.symmetric.util.BaseAlgorithmParameterGen
 import org.bouncycastle.jcajce.provider.symmetric.util.BaseBlockCipher;
 import org.bouncycastle.jcajce.provider.symmetric.util.BaseKeyGenerator;
 import org.bouncycastle.jcajce.provider.symmetric.util.BaseMac;
+import org.bouncycastle.jcajce.provider.symmetric.util.BlockCipherProvider;
 import org.bouncycastle.jcajce.provider.symmetric.util.IvAlgorithmParameters;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
@@ -30,7 +33,13 @@ public final class Noekeon
     {
         public ECB()
         {
-            super(new NoekeonEngine());
+            super(new BlockCipherProvider()
+            {
+                public BlockCipher get()
+                {
+                    return new NoekeonEngine();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
When used via JCE, OCB mode requires a BlockCipherProvider (since it uses two instances of a block cipher), so implement this for CAST6/Noekeon.
