### PR TITLE
Correct length of JCE automatic IV for CCM

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/util/BaseBlockCipher.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/util/BaseBlockCipher.java
@@ -278,7 +278,7 @@ public class BaseBlockCipher
         }
         else if (modeName.startsWith("CCM"))
         {
-            ivLength = baseEngine.getBlockSize();
+            ivLength = 13; // CCM nonce 7..13 bytes
             cipher = new AEADGenericBlockCipher(new CCMBlockCipher(baseEngine));
         }
         else if (modeName.startsWith("OCB"))


### PR DESCRIPTION
Correct the length of automatically generated IVs for CCM mode in JCE provider to the maximum of 13 bytes.
