### PR TITLE
Correct length of JCE automatic IV for OCB

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/util/BaseBlockCipher.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/util/BaseBlockCipher.java
@@ -285,7 +285,8 @@ public class BaseBlockCipher
         {
             if (engineProvider != null)
             {
-                ivLength = baseEngine.getBlockSize();
+                // Nonce restricted to max 120 bits over 128 bit block cipher since draft-irtf-cfrg-ocb-03
+                ivLength = 15;
                 cipher = new AEADGenericBlockCipher(new OCBBlockCipher(baseEngine, engineProvider.get()));
             }
             else


### PR DESCRIPTION
Correct the length of the automatically generated IV for OCB mode in JCE provider to maximum 15 bytes.

Since draft-irtf-cfrg-ocb-03, OCB is defined for nonces of up to 15 bytes.
