### PR TITLE
Align behaviour of CTR and SIC modes in the JCE API.

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/util/BaseBlockCipher.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/util/BaseBlockCipher.java
@@ -249,19 +249,13 @@ public class BaseBlockCipher
             cipher = new BufferedGenericBlockCipher(
                 new OpenPGPCFBBlockCipher(baseEngine));
         }
-        else if (modeName.startsWith("SIC"))
+        else if (modeName.startsWith("SIC") || modeName.startsWith("CTR"))
         {
             ivLength = baseEngine.getBlockSize();
             if (ivLength < 16)
             {
                 throw new IllegalArgumentException("Warning: SIC-Mode can become a twotime-pad if the blocksize of the cipher is too small. Use a cipher with a block size of at least 128 bits (e.g. AES)");
             }
-            cipher = new BufferedGenericBlockCipher(new BufferedBlockCipher(
-                        new SICBlockCipher(baseEngine)));
-        }
-        else if (modeName.startsWith("CTR"))
-        {
-            ivLength = baseEngine.getBlockSize();
             cipher = new BufferedGenericBlockCipher(new BufferedBlockCipher(
                         new SICBlockCipher(baseEngine)));
         }


### PR DESCRIPTION
CTR and SIC are implemented with the same underlying engine, so make their behaviour in the JCE API consistent (previously SIC would fail on 64 bit block ciphers, while CTR would not).
