### PR TITLE
Trivial: fix compiler error in Eclipse

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/tls/DeferredHash.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/DeferredHash.java
@@ -126,7 +126,7 @@ class DeferredHash
     {
         void updateDigest(Digest d)
         {
-            d.update(buf, 0, count);
+            d.update(this.buf, 0, count);
         }
     }
 }


### PR DESCRIPTION
Make buffer access explicit to avoid spurious compiler warning in Eclipse with shadowed field.
