### PR TITLE
Fix building - no careless recursive copy

### DIFF
--- a/ant/bc+-build.xml
+++ b/ant/bc+-build.xml
@@ -217,6 +217,8 @@
             <sequential>
                 <copy toDir="@{toDir}">
                      <fileset dir="${basedir}">
+                         <exclude name="build" />
+                         <exclude name="build/**/*" />
                          <include name="**/*.html" />
                      </fileset>
                 </copy>


### PR DESCRIPTION
Do not pick up *.html files from build/ subtree, when copying from level
above it. Repeated ant invocations caused expanding tree copy of javadoc
html files.
