### PR TITLE
Improve JavaDocs on constants defined at 28 files called *ObjectIdentifiers.java

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/bc/BCObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/bc/BCObjectIdentifiers.java
@@ -2,50 +2,70 @@ package org.bouncycastle.asn1.bc;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ *  iso.org.dod.internet.private.enterprise.legion-of-the-bouncy-castle
+ * <p>
+ *  1.3.6.1.4.1.22554
+ */
 public interface BCObjectIdentifiers
 {
     /**
      *  iso.org.dod.internet.private.enterprise.legion-of-the-bouncy-castle
-     *
+     *<p>
      *  1.3.6.1.4.1.22554
      */
     public static final ASN1ObjectIdentifier bc = new ASN1ObjectIdentifier("1.3.6.1.4.1.22554");
 
     /**
      * pbe(1) algorithms
+     * <p>
+     * 1.3.6.1.4.1.22554.1
      */
-    public static final ASN1ObjectIdentifier bc_pbe = new ASN1ObjectIdentifier(bc.getId() + ".1");
+    public static final ASN1ObjectIdentifier bc_pbe        = bc.branch("1");
 
     /**
      * SHA-1(1)
+     * <p>
+     * 1.3.6.1.4.1.22554.1.1
      */
-    public static final ASN1ObjectIdentifier bc_pbe_sha1 = new ASN1ObjectIdentifier(bc_pbe.getId() + ".1");
+    public static final ASN1ObjectIdentifier bc_pbe_sha1   = bc_pbe.branch("1");
 
-    /**
-     * SHA-2(2) . (SHA-256(1)|SHA-384(2)|SHA-512(3)|SHA-224(4))
-     */
-    public static final ASN1ObjectIdentifier bc_pbe_sha256 = new ASN1ObjectIdentifier(bc_pbe.getId() + ".2.1");
-    public static final ASN1ObjectIdentifier bc_pbe_sha384 = new ASN1ObjectIdentifier(bc_pbe.getId() + ".2.2");
-    public static final ASN1ObjectIdentifier bc_pbe_sha512 = new ASN1ObjectIdentifier(bc_pbe.getId() + ".2.3");
-    public static final ASN1ObjectIdentifier bc_pbe_sha224 = new ASN1ObjectIdentifier(bc_pbe.getId() + ".2.4");
+    /** SHA-2.SHA-256; 1.3.6.1.4.1.22554.1.2.1 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha256 = bc_pbe.branch("2.1");
+    /** SHA-2.SHA-384; 1.3.6.1.4.1.22554.1.2.2 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha384 = bc_pbe.branch("2.2");
+    /** SHA-2.SHA-512; 1.3.6.1.4.1.22554.1.2.3 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha512 = bc_pbe.branch("2.3");
+    /** SHA-2.SHA-224; 1.3.6.1.4.1.22554.1.2.4 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha224 = bc_pbe.branch("2.4");
 
     /**
      * PKCS-5(1)|PKCS-12(2)
      */
-    public static final ASN1ObjectIdentifier bc_pbe_sha1_pkcs5 = new ASN1ObjectIdentifier(bc_pbe_sha1.getId() + ".1");
-    public static final ASN1ObjectIdentifier bc_pbe_sha1_pkcs12 = new ASN1ObjectIdentifier(bc_pbe_sha1.getId() + ".2");
+    /** SHA-1.PKCS5;  1.3.6.1.4.1.22554.1.1.1 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha1_pkcs5    = bc_pbe_sha1.branch("1");
+    /** SHA-1.PKCS12; 1.3.6.1.4.1.22554.1.1.2 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha1_pkcs12   = bc_pbe_sha1.branch("2");
 
-    public static final ASN1ObjectIdentifier bc_pbe_sha256_pkcs5 = new ASN1ObjectIdentifier(bc_pbe_sha256.getId() + ".1");
-    public static final ASN1ObjectIdentifier bc_pbe_sha256_pkcs12 = new ASN1ObjectIdentifier(bc_pbe_sha256.getId() + ".2");
+    /** SHA-256.PKCS12; 1.3.6.1.4.1.22554.1.2.1.1 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha256_pkcs5  = bc_pbe_sha256.branch("1");
+    /** SHA-256.PKCS12; 1.3.6.1.4.1.22554.1.2.1.2 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha256_pkcs12 = bc_pbe_sha256.branch("2");
 
     /**
      * AES(1) . (CBC-128(2)|CBC-192(22)|CBC-256(42))
      */
-    public static final ASN1ObjectIdentifier bc_pbe_sha1_pkcs12_aes128_cbc = new ASN1ObjectIdentifier(bc_pbe_sha1_pkcs12.getId() + ".1.2");
-    public static final ASN1ObjectIdentifier bc_pbe_sha1_pkcs12_aes192_cbc = new ASN1ObjectIdentifier(bc_pbe_sha1_pkcs12.getId() + ".1.22");
-    public static final ASN1ObjectIdentifier bc_pbe_sha1_pkcs12_aes256_cbc = new ASN1ObjectIdentifier(bc_pbe_sha1_pkcs12.getId() + ".1.42");
+    /** 1.3.6.1.4.1.22554.1.1.2.1.2 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha1_pkcs12_aes128_cbc   = bc_pbe_sha1_pkcs12.branch("1.2");
+    /** 1.3.6.1.4.1.22554.1.1.2.1.22 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha1_pkcs12_aes192_cbc   = bc_pbe_sha1_pkcs12.branch("1.22");
+    /** 1.3.6.1.4.1.22554.1.1.2.1.42 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha1_pkcs12_aes256_cbc   = bc_pbe_sha1_pkcs12.branch("1.42");
 
-    public static final ASN1ObjectIdentifier bc_pbe_sha256_pkcs12_aes128_cbc = new ASN1ObjectIdentifier(bc_pbe_sha256_pkcs12.getId() + ".1.2");
-    public static final ASN1ObjectIdentifier bc_pbe_sha256_pkcs12_aes192_cbc = new ASN1ObjectIdentifier(bc_pbe_sha256_pkcs12.getId() + ".1.22");
-    public static final ASN1ObjectIdentifier bc_pbe_sha256_pkcs12_aes256_cbc = new ASN1ObjectIdentifier(bc_pbe_sha256_pkcs12.getId() + ".1.42");
+    /** 1.3.6.1.4.1.22554.1.1.2.2.2 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha256_pkcs12_aes128_cbc = bc_pbe_sha256_pkcs12.branch("1.2");
+    /** 1.3.6.1.4.1.22554.1.1.2.2.22 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha256_pkcs12_aes192_cbc = bc_pbe_sha256_pkcs12.branch("1.22");
+    /** 1.3.6.1.4.1.22554.1.1.2.2.42 */
+    public static final ASN1ObjectIdentifier bc_pbe_sha256_pkcs12_aes256_cbc = bc_pbe_sha256_pkcs12.branch("1.42");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/cmp/CMPObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cmp/CMPObjectIdentifiers.java
@@ -6,10 +6,10 @@ public interface CMPObjectIdentifiers
 {
     // RFC 4210
 
-    // id-PasswordBasedMac OBJECT IDENTIFIER ::= {1 2 840 113533 7 66 13}
+    /** id-PasswordBasedMac OBJECT IDENTIFIER ::= {1 2 840 113533 7 66 13} */
     static final ASN1ObjectIdentifier    passwordBasedMac        = new ASN1ObjectIdentifier("1.2.840.113533.7.66.13");
 
-    // id-DHBasedMac OBJECT IDENTIFIER ::= {1 2 840 113533 7 66 30}
+    /** id-DHBasedMac OBJECT IDENTIFIER ::= {1 2 840 113533 7 66 30} */
     static final ASN1ObjectIdentifier    dhBasedMac              = new ASN1ObjectIdentifier("1.2.840.113533.7.66.30");
 
     // Example InfoTypeAndValue contents include, but are not limited
@@ -52,19 +52,36 @@ public interface CMPObjectIdentifiers
     //      dod(6) internet(1) security(5) mechanisms(5) pkix(7)}
     // and
     //   id-it   OBJECT IDENTIFIER ::= {id-pkix 4}
+
+    /** RFC 4120: it-id: PKIX.4 = 1.3.6.1.5.5.7.4 */
+
+    /** RFC 4120: 1.3.6.1.5.5.7.4.1 */
     static final ASN1ObjectIdentifier    it_caProtEncCert        = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.1");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.2 */
     static final ASN1ObjectIdentifier    it_signKeyPairTypes     = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.2");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.3 */
     static final ASN1ObjectIdentifier    it_encKeyPairTypes      = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.3");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.4 */
     static final ASN1ObjectIdentifier    it_preferredSymAlg      = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.4");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.5 */
     static final ASN1ObjectIdentifier    it_caKeyUpdateInfo      = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.5");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.6 */
     static final ASN1ObjectIdentifier    it_currentCRL           = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.6");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.7 */
     static final ASN1ObjectIdentifier    it_unsupportedOIDs      = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.7");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.10 */
     static final ASN1ObjectIdentifier    it_keyPairParamReq      = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.10");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.11 */
     static final ASN1ObjectIdentifier    it_keyPairParamRep      = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.11");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.12 */
     static final ASN1ObjectIdentifier    it_revPassphrase        = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.12");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.13 */
     static final ASN1ObjectIdentifier    it_implicitConfirm      = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.13");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.14 */
     static final ASN1ObjectIdentifier    it_confirmWaitTime      = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.14");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.15 */
     static final ASN1ObjectIdentifier    it_origPKIMessage       = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.15");
+    /** RFC 4120: 1.3.6.1.5.5.7.4.16 */
     static final ASN1ObjectIdentifier    it_suppLangTags         = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.4.16");
 
     // RFC 4211
@@ -81,26 +98,44 @@ public interface CMPObjectIdentifiers
     // arc for Registration Info in CRMF
     // id-regInfo       OBJECT IDENTIFIER ::= { id-pkip id-regInfo(2) }
 
+    /** RFC 4211: it-pkip: PKIX.5 = 1.3.6.1.5.5.7.5 */
+    static final ASN1ObjectIdentifier    id_pkip                 = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5");
+
+    /** RFC 4211: it-regCtrl: 1.3.6.1.5.5.7.5.1 */
+    static final ASN1ObjectIdentifier    id_regCtrl              = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.1");
+    /** RFC 4211: it-regInfo: 1.3.6.1.5.5.7.5.2 */
+    static final ASN1ObjectIdentifier    id_regInfo              = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.2");
+
+
+    /** 1.3.6.1.5.5.7.5.1.1 */
     static final ASN1ObjectIdentifier    regCtrl_regToken        = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.1.1");
+    /** 1.3.6.1.5.5.7.5.1.2 */
     static final ASN1ObjectIdentifier    regCtrl_authenticator   = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.1.2");
+    /** 1.3.6.1.5.5.7.5.1.3 */
     static final ASN1ObjectIdentifier    regCtrl_pkiPublicationInfo = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.1.3");
+    /** 1.3.6.1.5.5.7.5.1.4 */
     static final ASN1ObjectIdentifier    regCtrl_pkiArchiveOptions  = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.1.4");
+    /** 1.3.6.1.5.5.7.5.1.5 */
     static final ASN1ObjectIdentifier    regCtrl_oldCertID       = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.1.5");
+    /** 1.3.6.1.5.5.7.5.1.6 */
     static final ASN1ObjectIdentifier    regCtrl_protocolEncrKey = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.1.6");
 
-    // From RFC4210:
-    // id-regCtrl-altCertTemplate OBJECT IDENTIFIER ::= {id-regCtrl 7}
+    /** From RFC4210:
+     * id-regCtrl-altCertTemplate OBJECT IDENTIFIER ::= {id-regCtrl 7}; 1.3.6.1.5.5.7.1.7 */
     static final ASN1ObjectIdentifier    regCtrl_altCertTemplate = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.1.7");
 
+    /** RFC 4211: it-regInfo-utf8Pairs: 1.3.6.1.5.5.7.5.2.1 */
     static final ASN1ObjectIdentifier    regInfo_utf8Pairs       = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.2.1");
+    /** RFC 4211: it-regInfo-certReq: 1.3.6.1.5.5.7.5.2.1 */
     static final ASN1ObjectIdentifier    regInfo_certReq         = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.5.2.2");
 
-    // id-smime OBJECT IDENTIFIER ::= { iso(1) member-body(2)
-    //         us(840) rsadsi(113549) pkcs(1) pkcs9(9) 16 }
-    //
-    // id-ct   OBJECT IDENTIFIER ::= { id-smime  1 }  -- content types
-    //
-    // id-ct-encKeyWithID OBJECT IDENTIFIER ::= {id-ct 21}
+    /**
+     * 1.2.840.113549.1.9.16.1.21
+     * <p>
+     * id-ct   OBJECT IDENTIFIER ::= { id-smime  1 }  -- content types
+     * <p>
+     * id-ct-encKeyWithID OBJECT IDENTIFIER ::= {id-ct 21}
+     */
     static final ASN1ObjectIdentifier    ct_encKeyWithID         = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16.1.21");
 
 }

--- a/core/src/main/java/org/bouncycastle/asn1/cms/CMSAttributes.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/CMSAttributes.java
@@ -3,11 +3,28 @@ package org.bouncycastle.asn1.cms;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 
+/**
+ * <a href="http://tools.ietf.org/html/rfc5652">RFC 5652</a> CMS attribute OID constants.
+ * <pre>
+ * contentType      ::= 1.2.840.113549.1.9.3
+ * messageDigest    ::= 1.2.840.113549.1.9.4
+ * signingTime      ::= 1.2.840.113549.1.9.5
+ * counterSignature ::= 1.2.840.113549.1.9.6
+ *
+ * contentHint      ::= 1.2.840.113549.1.9.16.2.4 
+ * </pre>
+ */
+
 public interface CMSAttributes
 {
+    /** PKCS#9: 1.2.840.113549.1.9.3 */
     public static final ASN1ObjectIdentifier  contentType = PKCSObjectIdentifiers.pkcs_9_at_contentType;
+    /** PKCS#9: 1.2.840.113549.1.9.4 */
     public static final ASN1ObjectIdentifier  messageDigest = PKCSObjectIdentifiers.pkcs_9_at_messageDigest;
+    /** PKCS#9: 1.2.840.113549.1.9.5 */
     public static final ASN1ObjectIdentifier  signingTime = PKCSObjectIdentifiers.pkcs_9_at_signingTime;
+    /** PKCS#9: 1.2.840.113549.1.9.6 */
     public static final ASN1ObjectIdentifier  counterSignature = PKCSObjectIdentifiers.pkcs_9_at_counterSignature;
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.4 - See <a href="http://tools.ietf.org/html/rfc2634">RFC 2634</a> */
     public static final ASN1ObjectIdentifier  contentHint = PKCSObjectIdentifiers.id_aa_contentHint;
 }

--- a/core/src/main/java/org/bouncycastle/asn1/cms/CMSObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/CMSObjectIdentifiers.java
@@ -5,24 +5,39 @@ import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 
 public interface CMSObjectIdentifiers
 {
+    /** PKCS#7: 1.2.840.113549.1.7.1 */
     static final ASN1ObjectIdentifier    data = PKCSObjectIdentifiers.data;
+    /** PKCS#7: 1.2.840.113549.1.7.2 */
     static final ASN1ObjectIdentifier    signedData = PKCSObjectIdentifiers.signedData;
+    /** PKCS#7: 1.2.840.113549.1.7.3 */
     static final ASN1ObjectIdentifier    envelopedData = PKCSObjectIdentifiers.envelopedData;
+    /** PKCS#7: 1.2.840.113549.1.7.4 */
     static final ASN1ObjectIdentifier    signedAndEnvelopedData = PKCSObjectIdentifiers.signedAndEnvelopedData;
+    /** PKCS#7: 1.2.840.113549.1.7.5 */
     static final ASN1ObjectIdentifier    digestedData = PKCSObjectIdentifiers.digestedData;
+    /** PKCS#7: 1.2.840.113549.1.7.6 */
     static final ASN1ObjectIdentifier    encryptedData = PKCSObjectIdentifiers.encryptedData;
+    /** PKCS#9: 1.2.840.113549.1.9.16.1.2 -- smime ct authData */
     static final ASN1ObjectIdentifier    authenticatedData = PKCSObjectIdentifiers.id_ct_authData;
+    /** PKCS#9: 1.2.840.113549.1.9.16.1.9 -- smime ct compressedData */
     static final ASN1ObjectIdentifier    compressedData = PKCSObjectIdentifiers.id_ct_compressedData;
+    /** PKCS#9: 1.2.840.113549.1.9.16.1.23 -- smime ct authEnvelopedData */
     static final ASN1ObjectIdentifier    authEnvelopedData = PKCSObjectIdentifiers.id_ct_authEnvelopedData;
+    /** PKCS#9: 1.2.840.113549.1.9.16.1.31 -- smime ct timestampedData*/
     static final ASN1ObjectIdentifier    timestampedData = PKCSObjectIdentifiers.id_ct_timestampedData;
 
     /**
      * The other Revocation Info arc
+     * <p>
+     * <pre>
      * id-ri OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
-     *                                   dod(6) internet(1) security(5) mechanisms(5) pkix(7) ri(16) }
+     *        dod(6) internet(1) security(5) mechanisms(5) pkix(7) ri(16) }
+     * </pre>
      */
     static final ASN1ObjectIdentifier    id_ri = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.16");
 
+    /** 1.3.6.1.5.5.7.16.2 */
     static final ASN1ObjectIdentifier    id_ri_ocsp_response = id_ri.branch("2");
+    /** 1.3.6.1.5.5.7.16.4 */
     static final ASN1ObjectIdentifier    id_ri_scvp = id_ri.branch("4");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/crmf/CRMFObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/crmf/CRMFObjectIdentifiers.java
@@ -5,17 +5,25 @@ import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 
 public interface CRMFObjectIdentifiers
 {
+    /** 1.3.6.1.5.5.7 */
     static final ASN1ObjectIdentifier id_pkix = new ASN1ObjectIdentifier("1.3.6.1.5.5.7");
 
     // arc for Internet X.509 PKI protocols and their components
 
-    static final ASN1ObjectIdentifier id_pkip  = id_pkix.branch("5");
+    /** 1.3.6.1.5.5.7.5 */
+    static final ASN1ObjectIdentifier id_pkip    = id_pkix.branch("5");
 
+    /** 1.3.6.1.5.5.7.1 */
     static final ASN1ObjectIdentifier id_regCtrl = id_pkip.branch("1");
-    static final ASN1ObjectIdentifier id_regCtrl_regToken = id_regCtrl.branch("1");
-    static final ASN1ObjectIdentifier id_regCtrl_authenticator = id_regCtrl.branch("2");
+    /** 1.3.6.1.5.5.7.1.1 */
+    static final ASN1ObjectIdentifier id_regCtrl_regToken           = id_regCtrl.branch("1");
+    /** 1.3.6.1.5.5.7.1.2 */
+    static final ASN1ObjectIdentifier id_regCtrl_authenticator      = id_regCtrl.branch("2");
+    /** 1.3.6.1.5.5.7.1.3 */
     static final ASN1ObjectIdentifier id_regCtrl_pkiPublicationInfo = id_regCtrl.branch("3");
-    static final ASN1ObjectIdentifier id_regCtrl_pkiArchiveOptions = id_regCtrl.branch("4");
+    /** 1.3.6.1.5.5.7.1.4 */
+    static final ASN1ObjectIdentifier id_regCtrl_pkiArchiveOptions  = id_regCtrl.branch("4");
 
-    static final ASN1ObjectIdentifier id_ct_encKeyWithID = new ASN1ObjectIdentifier(PKCSObjectIdentifiers.id_ct + ".21");
+    /** 1.2.840.113549.1.9.16.1,21 */
+    static final ASN1ObjectIdentifier id_ct_encKeyWithID = PKCSObjectIdentifiers.id_ct.branch("21");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/cryptopro/CryptoProObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cryptopro/CryptoProObjectIdentifiers.java
@@ -2,47 +2,91 @@ package org.bouncycastle.asn1.cryptopro;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * <pre>
+ * GOST Algorithms OBJECT IDENTIFIERS :
+ *    { iso(1) member-body(2) ru(643) rans(2) cryptopro(2)}
+ * </pre>
+ */
 public interface CryptoProObjectIdentifiers
 {
-    // GOST Algorithms OBJECT IDENTIFIERS :
-    // { iso(1) member-body(2) ru(643) rans(2) cryptopro(2)}
-    static final ASN1ObjectIdentifier    GOST_id              = new ASN1ObjectIdentifier("1.2.643.2.2");
+    /** Base OID: 1.2.643.2.2 */
+    static final ASN1ObjectIdentifier    GOST_id            = new ASN1ObjectIdentifier("1.2.643.2.2");
 
+    /** Gost R3411 OID: 1.2.643.2.2.9 */
     static final ASN1ObjectIdentifier    gostR3411          = GOST_id.branch("9");
+    /** Gost R3411 HMAC OID: 1.2.643.2.2.10 */
     static final ASN1ObjectIdentifier    gostR3411Hmac      = GOST_id.branch("10");
 
-    static final ASN1ObjectIdentifier    gostR28147_cbc     = new ASN1ObjectIdentifier(GOST_id+".21");
+    /** Gost R28147 OID: 1.2.643.2.2.21 */
+    static final ASN1ObjectIdentifier    gostR28147_cbc     = GOST_id.branch("21");
 
+    /** Gost R28147-89-CryotoPro-A-ParamSet OID: 1.2.643.2.2.31.1 */
     static final ASN1ObjectIdentifier    id_Gost28147_89_CryptoPro_A_ParamSet = GOST_id.branch("31.1");
 
-    static final ASN1ObjectIdentifier    gostR3410_94       = new ASN1ObjectIdentifier(GOST_id+".20");
-    static final ASN1ObjectIdentifier    gostR3410_2001     = new ASN1ObjectIdentifier(GOST_id+".19");
-    static final ASN1ObjectIdentifier    gostR3411_94_with_gostR3410_94   = new ASN1ObjectIdentifier(GOST_id+".4");
-    static final ASN1ObjectIdentifier    gostR3411_94_with_gostR3410_2001 = new ASN1ObjectIdentifier(GOST_id+".3");
+    /** Gost R3410-94 OID: 1.2.643.2.2.20 */
+    static final ASN1ObjectIdentifier    gostR3410_94       = GOST_id.branch("20");
+    /** Gost R3410-2001 OID: 1.2.643.2.2.19 */
+    static final ASN1ObjectIdentifier    gostR3410_2001     = GOST_id.branch("19");
 
-    // { iso(1) member-body(2) ru(643) rans(2) cryptopro(2) hashes(30) }
-    static final ASN1ObjectIdentifier    gostR3411_94_CryptoProParamSet = new ASN1ObjectIdentifier(GOST_id+".30.1");
+    /** Gost R3411-94-with-R3410-94 OID: 1.2.643.2.2.4 */
+    static final ASN1ObjectIdentifier    gostR3411_94_with_gostR3410_94   = GOST_id.branch("4");
+    /** Gost R3411-94-with-R3410-2001 OID: 1.2.643.2.2.3 */
+    static final ASN1ObjectIdentifier    gostR3411_94_with_gostR3410_2001 = GOST_id.branch("3");
 
-    // { iso(1) member-body(2) ru(643) rans(2) cryptopro(2) signs(32) }
-    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_A     = new ASN1ObjectIdentifier(GOST_id+".32.2");
-    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_B     = new ASN1ObjectIdentifier(GOST_id+".32.3");
-    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_C     = new ASN1ObjectIdentifier(GOST_id+".32.4");
-    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_D     = new ASN1ObjectIdentifier(GOST_id+".32.5");
+    /**
+     * { iso(1) member-body(2) ru(643) rans(2) cryptopro(2) hashes(30) }
+     * <p>
+     * Gost R3411-94-CryptoProParamSet OID: 1.2.643.2.2.30.1
+     */
+    static final ASN1ObjectIdentifier    gostR3411_94_CryptoProParamSet = GOST_id.branch("30.1");
 
-    // { iso(1) member-body(2) ru(643) rans(2) cryptopro(2) exchanges(33) }
-    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_XchA  = new ASN1ObjectIdentifier(GOST_id+".33.1");
-    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_XchB  = new ASN1ObjectIdentifier(GOST_id+".33.2");
-    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_XchC  = new ASN1ObjectIdentifier(GOST_id+".33.3");
+    /**
+     * { iso(1) member-body(2) ru(643) rans(2) cryptopro(2) signs(32) }
+     * <p>
+     * Gost R3410-94-CryptoPro-A OID: 1.2.643.2.2.32.2
+     */
+    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_A     = GOST_id.branch("32.2");
+    /** Gost R3410-94-CryptoPro-B OID: 1.2.643.2.2.32.3 */
+    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_B     = GOST_id.branch("32.3");
+    /** Gost R3410-94-CryptoPro-C OID: 1.2.643.2.2.32.4 */
+    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_C     = GOST_id.branch("32.4");
+    /** Gost R3410-94-CryptoPro-D OID: 1.2.643.2.2.32.5 */
+    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_D     = GOST_id.branch("32.5");
 
-    //{ iso(1) member-body(2)ru(643) rans(2) cryptopro(2) ecc-signs(35) }
-    static final ASN1ObjectIdentifier    gostR3410_2001_CryptoPro_A = new ASN1ObjectIdentifier(GOST_id+".35.1");
-    static final ASN1ObjectIdentifier    gostR3410_2001_CryptoPro_B = new ASN1ObjectIdentifier(GOST_id+".35.2");
-    static final ASN1ObjectIdentifier    gostR3410_2001_CryptoPro_C = new ASN1ObjectIdentifier(GOST_id+".35.3");
+    /**
+     * { iso(1) member-body(2) ru(643) rans(2) cryptopro(2) exchanges(33) }
+     * <p>
+     * Gost R3410-94-CryptoPro-XchA OID: 1.2.643.2.2.33.1
+     */
+    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_XchA  = GOST_id.branch("33.1");
+    /** Gost R3410-94-CryptoPro-XchB OID: 1.2.643.2.2.33.2 */
+    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_XchB  = GOST_id.branch("33.2");
+    /** Gost R3410-94-CryptoPro-XchC OID: 1.2.643.2.2.33.3 */
+    static final ASN1ObjectIdentifier    gostR3410_94_CryptoPro_XchC  = GOST_id.branch("33.3");
 
-    // { iso(1) member-body(2) ru(643) rans(2) cryptopro(2) ecc-exchanges(36) }
-    static final ASN1ObjectIdentifier    gostR3410_2001_CryptoPro_XchA  = new ASN1ObjectIdentifier(GOST_id+".36.0");
-    static final ASN1ObjectIdentifier    gostR3410_2001_CryptoPro_XchB  = new ASN1ObjectIdentifier(GOST_id+".36.1");
+    /**
+     * { iso(1) member-body(2)ru(643) rans(2) cryptopro(2) ecc-signs(35) }
+     * <p>
+     * Gost R3410-2001-CryptoPro-A OID: 1.2.643.2.2.35.1
+     */
+    static final ASN1ObjectIdentifier    gostR3410_2001_CryptoPro_A = GOST_id.branch("35.1");
+    /** Gost R3410-2001-CryptoPro-B OID: 1.2.643.2.2.35.2 */
+    static final ASN1ObjectIdentifier    gostR3410_2001_CryptoPro_B = GOST_id.branch("35.2");
+    /** Gost R3410-2001-CryptoPro-C OID: 1.2.643.2.2.35.3 */
+    static final ASN1ObjectIdentifier    gostR3410_2001_CryptoPro_C = GOST_id.branch("35.3");
+
+    /**
+     * { iso(1) member-body(2) ru(643) rans(2) cryptopro(2) ecc-exchanges(36) }
+     * <p>
+     * Gost R3410-2001-CryptoPro-XchA OID: 1.2.643.2.2.36.0
+     */
+    static final ASN1ObjectIdentifier    gostR3410_2001_CryptoPro_XchA  = GOST_id.branch("36.0");
+    /** Gost R3410-2001-CryptoPro-XchA OID: 1.2.643.2.2.36.1 */
+    static final ASN1ObjectIdentifier    gostR3410_2001_CryptoPro_XchB  = GOST_id.branch("36.1");
     
-    static final ASN1ObjectIdentifier    gost_ElSgDH3410_default    = new ASN1ObjectIdentifier(GOST_id+".36.0");
-    static final ASN1ObjectIdentifier    gost_ElSgDH3410_1          = new ASN1ObjectIdentifier(GOST_id+".36.1");
+    /** Gost R3410-ElSqDH3410-default OID: 1.2.643.2.2.36.0 */
+    static final ASN1ObjectIdentifier    gost_ElSgDH3410_default    = GOST_id.branch("36.0");
+    /** Gost R3410-ElSqDH3410-1 OID: 1.2.643.2.2.36.1 */
+    static final ASN1ObjectIdentifier    gost_ElSgDH3410_1          = GOST_id.branch("36.1");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/dvcs/DVCSObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/dvcs/DVCSObjectIdentifiers.java
@@ -2,35 +2,28 @@ package org.bouncycastle.asn1.dvcs;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * OIDs for <a href="http://tools.ietf.org/html/rfc3029">RFC 3029</a>
+ * Data Validation and Certification Server Protocols
+ */
 public interface DVCSObjectIdentifiers
 {
+    /** Base OID id-pkix: 1.3.6.1.5.5.7 */
+    static final ASN1ObjectIdentifier id_pkix  = new ASN1ObjectIdentifier("1.3.6.1.5.5.7");
+    /** Base OID id-smime: 1.2.840.113549.1.9.16 */
+    static final ASN1ObjectIdentifier id_smime = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16");
 
-    //    id-pkix     OBJECT IDENTIFIER ::= {iso(1)
-    //                   identified-organization(3) dod(6)
-    //                   internet(1) security(5) mechanisms(5) pkix(7)}
-    //
-    //    id-smime    OBJECT IDENTIFIER ::= { iso(1) member-body(2)
-    //                   us(840) rsadsi(113549) pkcs(1) pkcs-9(9) 16 }
-    public static final ASN1ObjectIdentifier id_pkix = new ASN1ObjectIdentifier("1.3.6.1.5.5.7");
-    public static final ASN1ObjectIdentifier id_smime = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16");
+    /** Authority Information Access for DVCS; id-ad-dcvs;  OID: 1.3.6.1.5.5.7.48.4 */
+    static final ASN1ObjectIdentifier id_ad_dvcs = id_pkix.branch("48.4");
 
-    //    -- Authority Information Access for DVCS
-    //
-    //    id-ad-dvcs  OBJECT IDENTIFIER ::= {id-pkix id-ad(48) 4}
-    public static final ASN1ObjectIdentifier id_ad_dvcs = id_pkix.branch("48.4");
+    /** Key Purpose for DVCS; id-kp-dvcs; OID: 1.3.6.1.5.5.7.3.10 */
+    static final ASN1ObjectIdentifier id_kp_dvcs = id_pkix.branch("3.10");
 
-    //    -- Key Purpose for DVCS
-    //
-    //    id-kp-dvcs  OBJECT IDENTIFIER ::= {id-pkix id-kp(3) 10}
-    public static final ASN1ObjectIdentifier id_kp_dvcs = id_pkix.branch("3.10");
+    /** SMIME eContentType id-ct-DVCSRequestData;   OID: 1.2.840.113549.1.9.16.1.7 */
+    static final ASN1ObjectIdentifier id_ct_DVCSRequestData  = id_smime.branch("1.7");
+    /** SMIME eContentType id-ct-DVCSResponseData;  OID: 1.2.840.113549.1.9.16.1.8 */
+    static final ASN1ObjectIdentifier id_ct_DVCSResponseData = id_smime.branch("1.8");
 
-    //    id-ct-DVCSRequestData  OBJECT IDENTIFIER ::= { id-smime ct(1) 7 }
-    //    id-ct-DVCSResponseData OBJECT IDENTIFIER ::= { id-smime ct(1) 8 }
-    public static final ASN1ObjectIdentifier id_ct_DVCSRequestData = id_smime.branch("1.7");
-    public static final ASN1ObjectIdentifier id_ct_DVCSResponseData = id_smime.branch("1.8");
-
-    //    -- Data validation certificate attribute
-    //
-    //    id-aa-dvcs-dvc OBJECT IDENTIFIER ::= { id-smime aa(2) 29 }
-    public static final ASN1ObjectIdentifier id_aa_dvcs_dvc = id_smime.branch("2.29");
+    /** SMIME DataValidation certificate attribute id-aa-dvcs-dvc;  OID: 1.2.840.113549.1.9.16.2,29 */
+    static final ASN1ObjectIdentifier id_aa_dvcs_dvc = id_smime.branch("2.29");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/eac/EACObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/eac/EACObjectIdentifiers.java
@@ -2,54 +2,109 @@ package org.bouncycastle.asn1.eac;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * German Federal Office for Information Security
+ * (Bundesamt für Sicherheit in der Informationstechnik)
+ * <a href="http://www.bsi.bund.de/">http://www.bsi.bund.de/</a>
+ * <p>
+ * <a href="https://www.bsi.bund.de/EN/Publications/TechnicalGuidelines/TR03110/BSITR03110.html">BSI TR-03110</a>
+ * Technical Guideline Advanced Security Mechanisms for Machine Readable Travel Documents
+ * <p>
+ * <a href="https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03110/TR-03110_v2.1_P3pdf.pdf?__blob=publicationFile">Technical Guideline TR-03110-3</a>
+ * Advanced Security Mechanisms for Machine Readable Travel Documents;
+ * Part 3: Common Specifications.
+ */
+
 public interface EACObjectIdentifiers
 {
-    // bsi-de OBJECT IDENTIFIER ::= {
-    //         itu-t(0) identified-organization(4) etsi(0)
-    //         reserved(127) etsi-identified-organization(0) 7
-    //     }
+    /**
+     * <pre>
+     * bsi-de OBJECT IDENTIFIER ::= {
+     *     itu-t(0) identified-organization(4) etsi(0)
+     *     reserved(127) etsi-identified-organization(0) 7
+     * }
+     * </pre>
+     * OID: 0.4.0.127.0.7
+     */
     static final ASN1ObjectIdentifier    bsi_de      = new ASN1ObjectIdentifier("0.4.0.127.0.7");
 
-    // id-PK OBJECT IDENTIFIER ::= {
-    //         bsi-de protocols(2) smartcard(2) 1
-    //     }
-    static final ASN1ObjectIdentifier    id_PK = bsi_de.branch("2.2.1");
+    /**
+     * <pre>
+     * id-PK OBJECT IDENTIFIER ::= {
+     *     bsi-de protocols(2) smartcard(2) 1
+     * }
+     * </pre>
+     * OID: 0.4.0.127.0.7.2.2.1
+     */
+    static final ASN1ObjectIdentifier    id_PK      = bsi_de.branch("2.2.1");
 
-    static final ASN1ObjectIdentifier    id_PK_DH = id_PK.branch("1");
+    /** OID: 0.4.0.127.0.7.2.2.1.1 */
+    static final ASN1ObjectIdentifier    id_PK_DH   = id_PK.branch("1");
+    /** OID: 0.4.0.127.0.7.2.2.1.2 */
     static final ASN1ObjectIdentifier    id_PK_ECDH = id_PK.branch("2");
 
-    // id-CA OBJECT IDENTIFIER ::= {
-    //         bsi-de protocols(2) smartcard(2) 3
-    //     }
-    static final ASN1ObjectIdentifier    id_CA = bsi_de.branch("2.2.3");
-    static final ASN1ObjectIdentifier    id_CA_DH = id_CA.branch("1");
-    static final ASN1ObjectIdentifier    id_CA_DH_3DES_CBC_CBC = id_CA_DH.branch("1");
-    static final ASN1ObjectIdentifier    id_CA_ECDH = id_CA.branch("2");
+    /**
+     * <pre>
+     * id-CA OBJECT IDENTIFIER ::= {
+     *     bsi-de protocols(2) smartcard(2) 3
+     * }
+     * </pre>
+     * OID: 0.4.0.127.0.7.2.2.3
+     */
+    static final ASN1ObjectIdentifier    id_CA                   = bsi_de.branch("2.2.3");
+    /** OID: 0.4.0.127.0.7.2.2.3.1 */
+    static final ASN1ObjectIdentifier    id_CA_DH                = id_CA.branch("1");
+    /** OID: 0.4.0.127.0.7.2.2.3.1.1 */
+    static final ASN1ObjectIdentifier    id_CA_DH_3DES_CBC_CBC   = id_CA_DH.branch("1");
+    /** OID: 0.4.0.127.0.7.2.2.3.2 */
+    static final ASN1ObjectIdentifier    id_CA_ECDH              = id_CA.branch("2");
+    /** OID: 0.4.0.127.0.7.2.2.3.2.1 */
     static final ASN1ObjectIdentifier    id_CA_ECDH_3DES_CBC_CBC = id_CA_ECDH.branch("1");
 
-    //
-    // id-TA OBJECT IDENTIFIER ::= {
-    //     bsi-de protocols(2) smartcard(2) 2
-    // }
+    /**
+     * <pre>
+     * id-TA OBJECT IDENTIFIER ::= {
+     *     bsi-de protocols(2) smartcard(2) 2
+     * }
+     * </pre>
+     * OID: 0.4.0.127.0.7.2.2.2
+     */
     static final ASN1ObjectIdentifier    id_TA = bsi_de.branch("2.2.2");
 
-    static final ASN1ObjectIdentifier    id_TA_RSA = id_TA.branch("1");
-    static final ASN1ObjectIdentifier    id_TA_RSA_v1_5_SHA_1 = id_TA_RSA .branch("1");
+    /** OID: 0.4.0.127.0.7.2.2.2.1 */
+    static final ASN1ObjectIdentifier    id_TA_RSA              = id_TA.branch("1");
+    /** OID: 0.4.0.127.0.7.2.2.2.1.1 */
+    static final ASN1ObjectIdentifier    id_TA_RSA_v1_5_SHA_1   = id_TA_RSA.branch("1");
+    /** OID: 0.4.0.127.0.7.2.2.2.1.2 */
     static final ASN1ObjectIdentifier    id_TA_RSA_v1_5_SHA_256 = id_TA_RSA.branch("2");
-    static final ASN1ObjectIdentifier    id_TA_RSA_PSS_SHA_1 = id_TA_RSA.branch("3");
-    static final ASN1ObjectIdentifier    id_TA_RSA_PSS_SHA_256 = id_TA_RSA.branch("4");
+    /** OID: 0.4.0.127.0.7.2.2.2.1.3 */
+    static final ASN1ObjectIdentifier    id_TA_RSA_PSS_SHA_1    = id_TA_RSA.branch("3");
+    /** OID: 0.4.0.127.0.7.2.2.2.1.4 */
+    static final ASN1ObjectIdentifier    id_TA_RSA_PSS_SHA_256  = id_TA_RSA.branch("4");
+    /** OID: 0.4.0.127.0.7.2.2.2.1.5 */
     static final ASN1ObjectIdentifier    id_TA_RSA_v1_5_SHA_512 = id_TA_RSA.branch("5");
-    static final ASN1ObjectIdentifier    id_TA_RSA_PSS_SHA_512 = id_TA_RSA.branch("6");
-    static final ASN1ObjectIdentifier    id_TA_ECDSA = id_TA.branch("2");
-    static final ASN1ObjectIdentifier    id_TA_ECDSA_SHA_1 = id_TA_ECDSA.branch("1");
-    static final ASN1ObjectIdentifier    id_TA_ECDSA_SHA_224 = id_TA_ECDSA.branch("2");
-    static final ASN1ObjectIdentifier    id_TA_ECDSA_SHA_256 = id_TA_ECDSA.branch("3");
-    static final ASN1ObjectIdentifier    id_TA_ECDSA_SHA_384 = id_TA_ECDSA.branch("4");
-    static final ASN1ObjectIdentifier    id_TA_ECDSA_SHA_512 = id_TA_ECDSA.branch("5");
+    /** OID: 0.4.0.127.0.7.2.2.2.1.6 */
+    static final ASN1ObjectIdentifier    id_TA_RSA_PSS_SHA_512  = id_TA_RSA.branch("6");
+    /** OID: 0.4.0.127.0.7.2.2.2.2 */
+    static final ASN1ObjectIdentifier    id_TA_ECDSA            = id_TA.branch("2");
+    /** OID: 0.4.0.127.0.7.2.2.2.2.1 */
+    static final ASN1ObjectIdentifier    id_TA_ECDSA_SHA_1      = id_TA_ECDSA.branch("1");
+    /** OID: 0.4.0.127.0.7.2.2.2.2.2 */
+    static final ASN1ObjectIdentifier    id_TA_ECDSA_SHA_224    = id_TA_ECDSA.branch("2");
+    /** OID: 0.4.0.127.0.7.2.2.2.2.3 */
+    static final ASN1ObjectIdentifier    id_TA_ECDSA_SHA_256    = id_TA_ECDSA.branch("3");
+    /** OID: 0.4.0.127.0.7.2.2.2.2.4 */
+    static final ASN1ObjectIdentifier    id_TA_ECDSA_SHA_384    = id_TA_ECDSA.branch("4");
+    /** OID: 0.4.0.127.0.7.2.2.2.2.5 */
+    static final ASN1ObjectIdentifier    id_TA_ECDSA_SHA_512    = id_TA_ECDSA.branch("5");
 
     /**
+     * <pre>
      * id-EAC-ePassport OBJECT IDENTIFIER ::= {
-     * bsi-de applications(3) mrtd(1) roles(2) 1}
+     *     bsi-de applications(3) mrtd(1) roles(2) 1
+     * }
+     * </pre>
+     * OID: 0.4.0.127.0.7.3.1.2.1
      */
     static final ASN1ObjectIdentifier id_EAC_ePassport = bsi_de.branch("3.1.2.1");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/gnu/GNUObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/gnu/GNUObjectIdentifiers.java
@@ -2,29 +2,57 @@ package org.bouncycastle.asn1.gnu;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ *  GNU project OID collection<p>
+ *  { iso(1) identifier-organization(3) dod(6) internet(1) private(4) } == IETF defined things
+ */
 public interface GNUObjectIdentifiers
 {
-    public static final ASN1ObjectIdentifier GNU = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.1"); // GNU Radius
-    public static final ASN1ObjectIdentifier GnuPG = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.2"); // GnuPG (Ägypten)
+    /** 1.3.6.1.4.1.11591.1 -- used by GNU Radius */
+    public static final ASN1ObjectIdentifier GNU      = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.1"); // GNU Radius
+    /** 1.3.6.1.4.1.11591.2 -- used by GNU PG */
+    public static final ASN1ObjectIdentifier GnuPG    = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.2"); // GnuPG (Ägypten)
+    /** 1.3.6.1.4.1.11591.2.1 -- notation */
     public static final ASN1ObjectIdentifier notation = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.2.1"); // notation
+    /** 1.3.6.1.4.1.11591.2.1.1 -- pkaAddress */
     public static final ASN1ObjectIdentifier pkaAddress = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.2.1.1"); // pkaAddress
+    /** 1.3.6.1.4.1.11591.3 -- GNU Radar */
     public static final ASN1ObjectIdentifier GnuRadar = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.3"); // GNU Radar
+    /** 1.3.6.1.4.1.11591.12 -- digestAlgorithm */
     public static final ASN1ObjectIdentifier digestAlgorithm = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.12"); // digestAlgorithm
+    /** 1.3.6.1.4.1.11591.12.2 -- TIGER/192 */
     public static final ASN1ObjectIdentifier Tiger_192 = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.12.2"); // TIGER/192
+    /** 1.3.6.1.4.1.11591.13 -- encryptionAlgorithm */
     public static final ASN1ObjectIdentifier encryptionAlgorithm = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13"); // encryptionAlgorithm
+    /** 1.3.6.1.4.1.11591.13.2 -- Serpent */
     public static final ASN1ObjectIdentifier Serpent = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2"); // Serpent
+    /** 1.3.6.1.4.1.11591.13.2.1 -- Serpent-128-ECB */
     public static final ASN1ObjectIdentifier Serpent_128_ECB = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.1"); // Serpent-128-ECB
+    /** 1.3.6.1.4.1.11591.13.2.2 -- Serpent-128-CBC */
     public static final ASN1ObjectIdentifier Serpent_128_CBC = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.2"); // Serpent-128-CBC
+    /** 1.3.6.1.4.1.11591.13.2.3 -- Serpent-128-OFB */
     public static final ASN1ObjectIdentifier Serpent_128_OFB = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.3"); // Serpent-128-OFB
+    /** 1.3.6.1.4.1.11591.13.2.4 -- Serpent-128-CFB */
     public static final ASN1ObjectIdentifier Serpent_128_CFB = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.4"); // Serpent-128-CFB
+    /** 1.3.6.1.4.1.11591.13.2.21 -- Serpent-192-ECB */
     public static final ASN1ObjectIdentifier Serpent_192_ECB = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.21"); // Serpent-192-ECB
+    /** 1.3.6.1.4.1.11591.13.2.22 -- Serpent-192-CCB */
     public static final ASN1ObjectIdentifier Serpent_192_CBC = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.22"); // Serpent-192-CBC
+    /** 1.3.6.1.4.1.11591.13.2.23 -- Serpent-192-OFB */
     public static final ASN1ObjectIdentifier Serpent_192_OFB = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.23"); // Serpent-192-OFB
+    /** 1.3.6.1.4.1.11591.13.2.24 -- Serpent-192-CFB */
     public static final ASN1ObjectIdentifier Serpent_192_CFB = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.24"); // Serpent-192-CFB
+    /** 1.3.6.1.4.1.11591.13.2.41 -- Serpent-256-ECB */
     public static final ASN1ObjectIdentifier Serpent_256_ECB = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.41"); // Serpent-256-ECB
+    /** 1.3.6.1.4.1.11591.13.2.42 -- Serpent-256-CBC */
     public static final ASN1ObjectIdentifier Serpent_256_CBC = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.42"); // Serpent-256-CBC
+    /** 1.3.6.1.4.1.11591.13.2.43 -- Serpent-256-OFB */
     public static final ASN1ObjectIdentifier Serpent_256_OFB = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.43"); // Serpent-256-OFB
+    /** 1.3.6.1.4.1.11591.13.2.44 -- Serpent-256-CFB */
     public static final ASN1ObjectIdentifier Serpent_256_CFB = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.13.2.44"); // Serpent-256-CFB
+
+    /** 1.3.6.1.4.1.11591.14 -- CRC algorithms */
     public static final ASN1ObjectIdentifier CRC = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.14"); // CRC algorithms
+    /** 1.3.6.1.4.1.11591.14,1 -- CRC32 */
     public static final ASN1ObjectIdentifier CRC32 = new ASN1ObjectIdentifier("1.3.6.1.4.1.11591.14.1"); // CRC 32
 }

--- a/core/src/main/java/org/bouncycastle/asn1/iana/IANAObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/iana/IANAObjectIdentifiers.java
@@ -2,19 +2,59 @@ package org.bouncycastle.asn1.iana;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * IANA:
+ *  { iso(1) identifier-organization(3) dod(6) internet(1) } == IETF defined things
+ */
 public interface IANAObjectIdentifiers
 {
+
+    /** { iso(1) identifier-organization(3) dod(6) internet(1) } == IETF defined things */
+    static final ASN1ObjectIdentifier   internet       = new ASN1ObjectIdentifier("1.3.6.1");
+    /** 1.3.6.1.1: Internet directory: X.500 */
+    static final ASN1ObjectIdentifier   directory      = internet.branch("1");
+    /** 1.3.6.1.2: Internet management */
+    static final ASN1ObjectIdentifier   mgmt           = internet.branch("2");
+    /** 1.3.6.1.3: */
+    static final ASN1ObjectIdentifier   experimental   = internet.branch("3");
+    /** 1.3.6.1.4: */
+    static final ASN1ObjectIdentifier   _private       = internet.branch("4");
+    /** 1.3.6.1.5: Security services */
+    static final ASN1ObjectIdentifier   security       = internet.branch("5");
+    /** 1.3.6.1.6: SNMPv2 -- never really used */
+    static final ASN1ObjectIdentifier   SNMPv2         = internet.branch("6");
+    /** 1.3.6.1.7: mail -- never really used */
+    static final ASN1ObjectIdentifier   mail           = internet.branch("7");
+
+
     // id-SHA1 OBJECT IDENTIFIER ::=    
     // {iso(1) identified-organization(3) dod(6) internet(1) security(5) mechanisms(5) ipsec(8) isakmpOakley(1)}
     //
 
-    static final ASN1ObjectIdentifier    isakmpOakley  = new ASN1ObjectIdentifier("1.3.6.1.5.5.8.1");
 
-    static final ASN1ObjectIdentifier    hmacMD5       = new ASN1ObjectIdentifier(isakmpOakley + ".1");
-    static final ASN1ObjectIdentifier    hmacSHA1     = new ASN1ObjectIdentifier(isakmpOakley + ".2");
+    /** IANA security mechanisms; 1.3.6.1.5.5 */
+    static final ASN1ObjectIdentifier    security_mechanisms  = security.branch("5");
+    /** IANA security nametypes;  1.3.6.1.5.6 */
+    static final ASN1ObjectIdentifier    security_nametypes   = security.branch("6");
+
+    /** PKIX base OID:            1.3.6.1.5.6.6 */
+    static final ASN1ObjectIdentifier    pkix                 = security_mechanisms.branch("6");
+
+
+    /** IPSEC base OID:                        1.3.6.1.5.5.8 */
+    static final ASN1ObjectIdentifier    ipsec                = security_mechanisms.branch("8");
+    /** IPSEC ISAKMP-Oakley OID:               1.3.6.1.5.5.8.1 */
+    static final ASN1ObjectIdentifier    isakmpOakley         = ipsec.branch("1");
+
+    /** IPSEC ISAKMP-Oakley hmacMD5 OID:       1.3.6.1.5.5.8.1.1 */
+    static final ASN1ObjectIdentifier    hmacMD5              = isakmpOakley.branch("1");
+    /** IPSEC ISAKMP-Oakley hmacSHA1 OID:      1.3.6.1.5.5.8.1.2 */
+    static final ASN1ObjectIdentifier    hmacSHA1             = isakmpOakley.branch("2");
     
-    static final ASN1ObjectIdentifier    hmacTIGER     = new ASN1ObjectIdentifier(isakmpOakley + ".3");
+    /** IPSEC ISAKMP-Oakley hmacTIGER OID:     1.3.6.1.5.5.8.1.3 */
+    static final ASN1ObjectIdentifier    hmacTIGER            = isakmpOakley.branch("3");
     
-    static final ASN1ObjectIdentifier    hmacRIPEMD160 = new ASN1ObjectIdentifier(isakmpOakley + ".4");
+    /** IPSEC ISAKMP-Oakley hmacRIPEMD160 OID: 1.3.6.1.5.5.8.1.4 */
+    static final ASN1ObjectIdentifier    hmacRIPEMD160        = isakmpOakley.branch("4");
 
 }

--- a/core/src/main/java/org/bouncycastle/asn1/icao/ICAOObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/icao/ICAOObjectIdentifiers.java
@@ -2,32 +2,48 @@ package org.bouncycastle.asn1.icao;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ *
+ * { ISOITU(2) intorgs(23) icao(136) }
+ */
 public interface ICAOObjectIdentifiers
 {
     //
     // base id
     //
+    /**  2.23.136  */
     static final ASN1ObjectIdentifier    id_icao                   = new ASN1ObjectIdentifier("2.23.136");
 
+    /**  2.23.136.1  */
     static final ASN1ObjectIdentifier    id_icao_mrtd              = id_icao.branch("1");
+    /**  2.23.136.1.1  */
     static final ASN1ObjectIdentifier    id_icao_mrtd_security     = id_icao_mrtd.branch("1");
 
-    // LDS security object, see ICAO Doc 9303-Volume 2-Section IV-A3.2
+    /** LDS security object, see ICAO Doc 9303-Volume 2-Section IV-A3.2<p>
+     *  2.23.136.1.1.1  */
     static final ASN1ObjectIdentifier    id_icao_ldsSecurityObject = id_icao_mrtd_security.branch("1");
 
-    // CSCA master list, see TR CSCA Countersigning and Master List issuance
+    /** CSCA master list, see TR CSCA Countersigning and Master List issuance<p>
+     * 2.23.136.1.1.2
+     */
     static final ASN1ObjectIdentifier    id_icao_cscaMasterList    = id_icao_mrtd_security.branch("2");
+    /** 2.23.136.1.1.3 */
     static final ASN1ObjectIdentifier    id_icao_cscaMasterListSigningKey = id_icao_mrtd_security.branch("3");
 
-    // document type list, see draft TR LDS and PKI Maintenance, par. 3.2.1
+    /** document type list, see draft TR LDS and PKI Maintenance, par. 3.2.1 <p>
+     * 2.23.136.1.1.4
+     */
     static final ASN1ObjectIdentifier    id_icao_documentTypeList  = id_icao_mrtd_security.branch("4");
 
-    // Active Authentication protocol, see draft TR LDS and PKI Maintenance,
-    // par. 5.2.2
+    /** Active Authentication protocol, see draft TR LDS and PKI Maintenance, par. 5.2.2<p>
+     * 2.23.136.1.1.5
+     */
     static final ASN1ObjectIdentifier    id_icao_aaProtocolObject  = id_icao_mrtd_security.branch("5");
 
-    // CSCA name change and key reoll-over, see draft TR LDS and PKI
-    // Maintenance, par. 3.2.1
+    /** CSCA name change and key reoll-over, see draft TR LDS and PKI Maintenance, par. 3.2.1<p>
+     * 2.23.136.1.1.6
+     */
     static final ASN1ObjectIdentifier    id_icao_extensions        = id_icao_mrtd_security.branch("6");
+    /** 2.23.136.1.1.6.1 */
     static final ASN1ObjectIdentifier    id_icao_extensions_namechangekeyrollover = id_icao_extensions.branch("1");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/isismtt/ISISMTTObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/isismtt/ISISMTTObjectIdentifiers.java
@@ -2,11 +2,16 @@ package org.bouncycastle.asn1.isismtt;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * ISISMT -- Industrial Signature Interoperability Specification
+ */
 public interface ISISMTTObjectIdentifiers
 {
 
+    /** 1.3.36.8 */
     static final ASN1ObjectIdentifier id_isismtt = new ASN1ObjectIdentifier("1.3.36.8");
 
+    /** 1.3.36.8.1 */
     static final ASN1ObjectIdentifier id_isismtt_cp = id_isismtt.branch("1");
 
     /**
@@ -15,29 +20,37 @@ public interface ISISMTTObjectIdentifiers
      * Parliament and of the Council of 13 December 1999 on a Community
      * Framework for Electronic Signatures, which additionally conforms the
      * special requirements of the SigG and has been issued by an accredited CA.
+     * <p>
+     * 1.3.36.8.1.1
      */
+
     static final ASN1ObjectIdentifier id_isismtt_cp_accredited = id_isismtt_cp.branch("1");
 
+    /** 1.3.36.8.3 */
     static final ASN1ObjectIdentifier id_isismtt_at = id_isismtt.branch("3");
 
     /**
      * Certificate extensionDate of certificate generation
-     * 
      * <pre>
-     *                DateOfCertGenSyntax ::= GeneralizedTime
+     *     DateOfCertGenSyntax ::= GeneralizedTime
      * </pre>
+     * OID: 1.3.36.8.3.1
      */
     static final ASN1ObjectIdentifier id_isismtt_at_dateOfCertGen = id_isismtt_at.branch("1");
 
     /**
      * Attribute to indicate that the certificate holder may sign in the name of
      * a third person. May also be used as extension in a certificate.
+     * <p>
+     * OID: 1.3.36.8.3.2
      */
     static final ASN1ObjectIdentifier id_isismtt_at_procuration = id_isismtt_at.branch("2");
 
     /**
      * Attribute to indicate admissions to certain professions. May be used as
      * attribute in attribute certificate or as extension in a certificate
+     * <p>
+     * OID: 1.3.36.8.3.3
      */
     static final ASN1ObjectIdentifier id_isismtt_at_admission = id_isismtt_at.branch("3");
 
@@ -47,33 +60,37 @@ public interface ISISMTTObjectIdentifiers
      * MonetaryLimit since January 1, 2004. For the sake of backward
      * compatibility with certificates already in use, SigG conforming
      * components MUST support MonetaryLimit (as well as QcEuLimitValue).
+     * <p>
+     * OID: 1.3.36.8.3.4
      */
     static final ASN1ObjectIdentifier id_isismtt_at_monetaryLimit = id_isismtt_at.branch("4");
 
     /**
      * A declaration of majority. May be used as attribute in attribute
      * certificate or as extension in a certificate
+     * <p>
+     * OID: 1.3.36.8.3.5
      */
     static final ASN1ObjectIdentifier id_isismtt_at_declarationOfMajority = id_isismtt_at.branch("5");
 
     /**
-     * 
      * Serial number of the smart card containing the corresponding private key
-     * 
      * <pre>
-     *                 ICCSNSyntax ::= OCTET STRING (SIZE(8..20))
+     *    ICCSNSyntax ::= OCTET STRING (SIZE(8..20))
      * </pre>
+     * <p>
+     * OID: 1.3.36.8.3.6
      */
     static final ASN1ObjectIdentifier id_isismtt_at_iCCSN = id_isismtt_at.branch("6");
 
     /**
-     * 
      * Reference for a file of a smartcard that stores the public key of this
-     * certificate and that is used as �security anchor�.
-     * 
+     * certificate and that is used as "security anchor".
      * <pre>
-     *      PKReferenceSyntax ::= OCTET STRING (SIZE(20))
+     *    PKReferenceSyntax ::= OCTET STRING (SIZE(20))
      * </pre>
+     * <p>
+     * OID: 1.3.36.8.3.7
      */
     static final ASN1ObjectIdentifier id_isismtt_at_PKReference = id_isismtt_at.branch("7");
 
@@ -81,28 +98,28 @@ public interface ISISMTTObjectIdentifiers
      * Some other restriction regarding the usage of this certificate. May be
      * used as attribute in attribute certificate or as extension in a
      * certificate.
-     * 
      * <pre>
-     *             RestrictionSyntax ::= DirectoryString (SIZE(1..1024))
+     *    RestrictionSyntax ::= DirectoryString (SIZE(1..1024))
      * </pre>
+     * <p>
+     * OID: 1.3.36.8.3.8
      * 
      * @see org.bouncycastle.asn1.isismtt.x509.Restriction
      */
     static final ASN1ObjectIdentifier id_isismtt_at_restriction = id_isismtt_at.branch("8");
 
     /**
-     * 
      * (Single)Request extension: Clients may include this extension in a
      * (single) Request to request the responder to send the certificate in the
      * response message along with the status information. Besides the LDAP
      * service, this extension provides another mechanism for the distribution
      * of certificates, which MAY optionally be provided by certificate
      * repositories.
-     * 
      * <pre>
-     *        RetrieveIfAllowed ::= BOOLEAN
-     *       
+     *    RetrieveIfAllowed ::= BOOLEAN
      * </pre>
+     * <p>
+     * OID: 1.3.36.8.3.9
      */
     static final ASN1ObjectIdentifier id_isismtt_at_retrieveIfAllowed = id_isismtt_at.branch("9");
 
@@ -110,6 +127,8 @@ public interface ISISMTTObjectIdentifiers
      * SingleOCSPResponse extension: The certificate requested by the client by
      * inserting the RetrieveIfAllowed extension in the request, will be
      * returned in this extension.
+     * <p>
+     * OID: 1.3.36.8.3.10
      * 
      * @see org.bouncycastle.asn1.isismtt.ocsp.RequestedCertificate
      */
@@ -117,6 +136,8 @@ public interface ISISMTTObjectIdentifiers
 
     /**
      * Base ObjectIdentifier for naming authorities
+     * <p>
+     * OID: 1.3.36.8.3.11
      */
     static final ASN1ObjectIdentifier id_isismtt_at_namingAuthorities = id_isismtt_at.branch("11");
 
@@ -127,13 +148,17 @@ public interface ISISMTTObjectIdentifiers
      * this extension in the responses.
      * 
      * <pre>
-     *      CertInDirSince ::= GeneralizedTime
+     *    CertInDirSince ::= GeneralizedTime
      * </pre>
+     * <p>
+     * OID: 1.3.36.8.3.12
      */
     static final ASN1ObjectIdentifier id_isismtt_at_certInDirSince = id_isismtt_at.branch("12");
 
     /**
      * Hash of a certificate in OCSP.
+     * <p>
+     * OID: 1.3.36.8.3.13
      * 
      * @see org.bouncycastle.asn1.isismtt.ocsp.CertHash
      */
@@ -141,11 +166,13 @@ public interface ISISMTTObjectIdentifiers
 
     /**
      * <pre>
-     *          NameAtBirth ::= DirectoryString(SIZE(1..64)
+     *    NameAtBirth ::= DirectoryString(SIZE(1..64)
      * </pre>
      * 
      * Used in
      * {@link org.bouncycastle.asn1.x509.SubjectDirectoryAttributes SubjectDirectoryAttributes}
+     * <p>
+     * OID: 1.3.36.8.3.14
      */
     static final ASN1ObjectIdentifier id_isismtt_at_nameAtBirth = id_isismtt_at.branch("14");
 
@@ -155,8 +182,10 @@ public interface ISISMTTObjectIdentifiers
      * extension in a certificate.
      * 
      * <pre>
-     *               AdditionalInformationSyntax ::= DirectoryString (SIZE(1..2048))
+     *    AdditionalInformationSyntax ::= DirectoryString (SIZE(1..2048))
      * </pre>
+     * <p>
+     * OID: 1.3.36.8.3.15
      * 
      * @see org.bouncycastle.asn1.isismtt.x509.AdditionalInformationSyntax
      */
@@ -171,10 +200,11 @@ public interface ISISMTTObjectIdentifiers
      * PKC as base certificate) contains some attribute that restricts the
      * usability of the PKC too. Attribute certificates with restricting content
      * MUST always be included in the signed document.
-     * 
      * <pre>
-     *                   LiabilityLimitationFlagSyntax ::= BOOLEAN
+     *    LiabilityLimitationFlagSyntax ::= BOOLEAN
      * </pre>
+     * <p>
+     * OID: 0.2.262.1.10.12.0
      */
     static final ASN1ObjectIdentifier id_isismtt_at_liabilityLimitationFlag = new ASN1ObjectIdentifier("0.2.262.1.10.12.0");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/kisa/KISAObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/kisa/KISAObjectIdentifiers.java
@@ -2,8 +2,30 @@ package org.bouncycastle.asn1.kisa;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * Korea Information Security Agency (KISA)
+ * ({iso(1) member-body(2) kr(410) kisa(200004)})
+ * <p>
+ * See <a href="http://tools.ietf.org/html/rfc4010">RFC 4010</a>
+ * Use of the SEED Encryption Algorithm
+ * in Cryptographic Message Syntax (CMS),
+ * and <a href="http://tools.ietf.org/html/rfc4269">RFC 4269</a>
+ * The SEED Encryption Algorithm
+ */
 public interface KISAObjectIdentifiers
 {
-    public static final ASN1ObjectIdentifier id_seedCBC = new ASN1ObjectIdentifier("1.2.410.200004.1.4");
-    public static final ASN1ObjectIdentifier id_npki_app_cmsSeed_wrap = new ASN1ObjectIdentifier("1.2.410.200004.7.1.1.1");
+    /** RFC 4010, 4269: id-seedCBC; OID 1.2.410.200004.1.4 */
+    static final ASN1ObjectIdentifier id_seedCBC = new ASN1ObjectIdentifier("1.2.410.200004.1.4");
+
+    /** RFC 4269: id-seedMAC; OID 1.2.410.200004.1.7 */
+    static final ASN1ObjectIdentifier id_seedMAC = new ASN1ObjectIdentifier("1.2.410.200004.1.7");
+
+    /** RFC 4269: pbeWithSHA1AndSEED-CBC; OID 1.2.410.200004.1.15 */
+    static final ASN1ObjectIdentifier pbeWithSHA1AndSEED_CBC = new ASN1ObjectIdentifier("1.2.410.200004.1.15");
+
+    /** RFC 4010: id-npki-app-cmsSeed-wrap; OID 1.2.410.200004.7.1.1.1 */
+    static final ASN1ObjectIdentifier id_npki_app_cmsSeed_wrap = new ASN1ObjectIdentifier("1.2.410.200004.7.1.1.1");
+
+    /** RFC 4010: SeedEncryptionAlgorithmInCMS; OID 1.2.840.113549.1.9.16.0.24 */
+    static final ASN1ObjectIdentifier id_mod_cms_seed = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16.0.24");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/microsoft/MicrosoftObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/microsoft/MicrosoftObjectIdentifiers.java
@@ -2,16 +2,27 @@ package org.bouncycastle.asn1.microsoft;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * Microsoft
+ * <p>
+ * Object identifier base:
+ * <pre>
+ *    iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) microsoft(311)
+ * </pre>
+ * 1.3.6.1.4.1.311
+ */
 public interface MicrosoftObjectIdentifiers
 {
-    //
-    // Microsoft
-    //       iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) microsoft(311)
-    //
+    /** Base OID: 1.3.6.1.4.1.311 */
     static final ASN1ObjectIdentifier    microsoft               = new ASN1ObjectIdentifier("1.3.6.1.4.1.311");
+    /** OID: 1.3.6.1.4.1.311.20.2 */
     static final ASN1ObjectIdentifier    microsoftCertTemplateV1 = microsoft.branch("20.2");
+    /** OID: 1.3.6.1.4.1.311.21.1 */
     static final ASN1ObjectIdentifier    microsoftCaVersion      = microsoft.branch("21.1");
+    /** OID: 1.3.6.1.4.1.311.21.2 */
     static final ASN1ObjectIdentifier    microsoftPrevCaCertHash = microsoft.branch("21.2");
+    /** OID: 1.3.6.1.4.1.311.21.7 */
     static final ASN1ObjectIdentifier    microsoftCertTemplateV2 = microsoft.branch("21.7");
+    /** OID: 1.3.6.1.4.1.311.21.10 */
     static final ASN1ObjectIdentifier    microsoftAppPolicies    = microsoft.branch("21.10");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/misc/MiscObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/misc/MiscObjectIdentifiers.java
@@ -8,40 +8,52 @@ public interface MiscObjectIdentifiers
     // Netscape
     //       iso/itu(2) joint-assign(16) us(840) uscompany(1) netscape(113730) cert-extensions(1) }
     //
+    /** Netscape cert extensions OID base: 2.16.840.1.113730.1  */
     static final ASN1ObjectIdentifier    netscape                = new ASN1ObjectIdentifier("2.16.840.1.113730.1");
+    /** Netscape cert CertType OID: 2.16.840.1.113730.1.1  */
     static final ASN1ObjectIdentifier    netscapeCertType        = netscape.branch("1");
+    /** Netscape cert BaseURL OID: 2.16.840.1.113730.1.2  */
     static final ASN1ObjectIdentifier    netscapeBaseURL         = netscape.branch("2");
+    /** Netscape cert RevocationURL OID: 2.16.840.1.113730.1.3  */
     static final ASN1ObjectIdentifier    netscapeRevocationURL   = netscape.branch("3");
+    /** Netscape cert CARevocationURL OID: 2.16.840.1.113730.1.4  */
     static final ASN1ObjectIdentifier    netscapeCARevocationURL = netscape.branch("4");
+    /** Netscape cert RenewalURL OID: 2.16.840.1.113730.1.7  */
     static final ASN1ObjectIdentifier    netscapeRenewalURL      = netscape.branch("7");
+    /** Netscape cert CApolicyURL OID: 2.16.840.1.113730.1.8  */
     static final ASN1ObjectIdentifier    netscapeCApolicyURL     = netscape.branch("8");
+    /** Netscape cert SSLServerName OID: 2.16.840.1.113730.1.12  */
     static final ASN1ObjectIdentifier    netscapeSSLServerName   = netscape.branch("12");
+    /** Netscape cert CertComment OID: 2.16.840.1.113730.1.13  */
     static final ASN1ObjectIdentifier    netscapeCertComment     = netscape.branch("13");
     
     //
     // Verisign
     //       iso/itu(2) joint-assign(16) us(840) uscompany(1) verisign(113733) cert-extensions(1) }
     //
+    /** Verisign OID base: 2.16.840.1.113733.1 */
     static final ASN1ObjectIdentifier   verisign                = new ASN1ObjectIdentifier("2.16.840.1.113733.1");
 
-    //
-    // CZAG - country, zip, age, and gender
-    //
+    /** Verisign CZAG (Country,Zip,Age,Gender) Extension OID: 2.16.840.1.113733.1.6.3 */
     static final ASN1ObjectIdentifier    verisignCzagExtension   = verisign.branch("6.3");
-    // D&B D-U-N-S number
+    /** Verisign D&B D-U-N-S number Extension OID: 2.16.840.1.113733.1.6.15 */
     static final ASN1ObjectIdentifier    verisignDnbDunsNumber   = verisign.branch("6.15");
 
     //
     // Novell
     //       iso/itu(2) country(16) us(840) organization(1) novell(113719)
     //
+    /** Novell OID base: 2.16.840.1.113719 */
     static final ASN1ObjectIdentifier    novell                  = new ASN1ObjectIdentifier("2.16.840.1.113719");
+    /** Novell SecurityAttribs OID: 2.16.840.1.113719.1.9.4.1 */
     static final ASN1ObjectIdentifier    novellSecurityAttribs   = novell.branch("1.9.4.1");
 
     //
     // Entrust
     //       iso(1) member-body(16) us(840) nortelnetworks(113533) entrust(7)
     //
+    /** NortelNetworks Entrust OID base: 1.2.840.113533.7 */
     static final ASN1ObjectIdentifier    entrust                 = new ASN1ObjectIdentifier("1.2.840.113533.7");
+    /** NortelNetworks Entrust VersionExtension OID: 1.2.840.113533.7.65.0 */
     static final ASN1ObjectIdentifier    entrustVersionExtension = entrust.branch("65.0");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/nist/NISTObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/nist/NISTObjectIdentifiers.java
@@ -2,59 +2,95 @@ package org.bouncycastle.asn1.nist;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ *
+ * NIST:
+ *     iso/itu(2) joint-assign(16) us(840) organization(1) gov(101) csor(3) 
+ */
 public interface NISTObjectIdentifiers
 {
     //
-    // NIST
-    //     iso/itu(2) joint-assign(16) us(840) organization(1) gov(101) csor(3) 
-
-    //
     // nistalgorithms(4)
     //
+    /** 2.16.840.1.101.3.4 -- algorithms */
     static final ASN1ObjectIdentifier    nistAlgorithm           = new ASN1ObjectIdentifier("2.16.840.1.101.3.4");
 
+    /** 2.16.840.1.101.3.4.2 */
     static final ASN1ObjectIdentifier    hashAlgs                = nistAlgorithm.branch("2");
 
+    /** 2.16.840.1.101.3.4.2.1 */
     static final ASN1ObjectIdentifier    id_sha256               = hashAlgs.branch("1");
+    /** 2.16.840.1.101.3.4.2.2 */
     static final ASN1ObjectIdentifier    id_sha384               = hashAlgs.branch("2");
+    /** 2.16.840.1.101.3.4.2.3 */
     static final ASN1ObjectIdentifier    id_sha512               = hashAlgs.branch("3");
+    /** 2.16.840.1.101.3.4.2.4 */
     static final ASN1ObjectIdentifier    id_sha224               = hashAlgs.branch("4");
+    /** 2.16.840.1.101.3.4.2.5 */
     static final ASN1ObjectIdentifier    id_sha512_224           = hashAlgs.branch("5");
+    /** 2.16.840.1.101.3.4.2.6 */
     static final ASN1ObjectIdentifier    id_sha512_256           = hashAlgs.branch("6");
 
-    static final ASN1ObjectIdentifier    aes                     =  nistAlgorithm.branch("1");
+    /** 2.16.840.1.101.3.4.1 */
+    static final ASN1ObjectIdentifier    aes                     = nistAlgorithm.branch("1");
     
+    /** 2.16.840.1.101.3.4.1.1 */
     static final ASN1ObjectIdentifier    id_aes128_ECB           = aes.branch("1"); 
+    /** 2.16.840.1.101.3.4.1.2 */
     static final ASN1ObjectIdentifier    id_aes128_CBC           = aes.branch("2");
+    /** 2.16.840.1.101.3.4.1.3 */
     static final ASN1ObjectIdentifier    id_aes128_OFB           = aes.branch("3"); 
+    /** 2.16.840.1.101.3.4.1.4 */
     static final ASN1ObjectIdentifier    id_aes128_CFB           = aes.branch("4"); 
+    /** 2.16.840.1.101.3.4.1.5 */
     static final ASN1ObjectIdentifier    id_aes128_wrap          = aes.branch("5");
+    /** 2.16.840.1.101.3.4.1.6 */
     static final ASN1ObjectIdentifier    id_aes128_GCM           = aes.branch("6");
+    /** 2.16.840.1.101.3.4.1.7 */
     static final ASN1ObjectIdentifier    id_aes128_CCM           = aes.branch("7");
     
+    /** 2.16.840.1.101.3.4.1.21 */
     static final ASN1ObjectIdentifier    id_aes192_ECB           = aes.branch("21"); 
+    /** 2.16.840.1.101.3.4.1.22 */
     static final ASN1ObjectIdentifier    id_aes192_CBC           = aes.branch("22"); 
+    /** 2.16.840.1.101.3.4.1.23 */
     static final ASN1ObjectIdentifier    id_aes192_OFB           = aes.branch("23"); 
+    /** 2.16.840.1.101.3.4.1.24 */
     static final ASN1ObjectIdentifier    id_aes192_CFB           = aes.branch("24"); 
+    /** 2.16.840.1.101.3.4.1.25 */
     static final ASN1ObjectIdentifier    id_aes192_wrap          = aes.branch("25");
+    /** 2.16.840.1.101.3.4.1.26 */
     static final ASN1ObjectIdentifier    id_aes192_GCM           = aes.branch("26");
+    /** 2.16.840.1.101.3.4.1.27 */
     static final ASN1ObjectIdentifier    id_aes192_CCM           = aes.branch("27");
     
+    /** 2.16.840.1.101.3.4.1.41 */
     static final ASN1ObjectIdentifier    id_aes256_ECB           = aes.branch("41"); 
+    /** 2.16.840.1.101.3.4.1.42 */
     static final ASN1ObjectIdentifier    id_aes256_CBC           = aes.branch("42");
+    /** 2.16.840.1.101.3.4.1.43 */
     static final ASN1ObjectIdentifier    id_aes256_OFB           = aes.branch("43"); 
+    /** 2.16.840.1.101.3.4.1.44 */
     static final ASN1ObjectIdentifier    id_aes256_CFB           = aes.branch("44"); 
+    /** 2.16.840.1.101.3.4.1.45 */
     static final ASN1ObjectIdentifier    id_aes256_wrap          = aes.branch("45"); 
+    /** 2.16.840.1.101.3.4.1.46 */
     static final ASN1ObjectIdentifier    id_aes256_GCM           = aes.branch("46");
+    /** 2.16.840.1.101.3.4.1.47 */
     static final ASN1ObjectIdentifier    id_aes256_CCM           = aes.branch("47");
 
     //
     // signatures
     //
+    /** 2.16.840.1.101.3.4.3 */
     static final ASN1ObjectIdentifier    id_dsa_with_sha2        = nistAlgorithm.branch("3");
 
+    /** 2.16.840.1.101.3.4.3.1 */
     static final ASN1ObjectIdentifier    dsa_with_sha224         = id_dsa_with_sha2.branch("1");
+    /** 2.16.840.1.101.3.4.3.2 */
     static final ASN1ObjectIdentifier    dsa_with_sha256         = id_dsa_with_sha2.branch("2");
+    /** 2.16.840.1.101.3.4.3.3 */
     static final ASN1ObjectIdentifier    dsa_with_sha384         = id_dsa_with_sha2.branch("3");
+    /** 2.16.840.1.101.3.4.3.4 */
     static final ASN1ObjectIdentifier    dsa_with_sha512         = id_dsa_with_sha2.branch("4");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/ntt/NTTObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ntt/NTTObjectIdentifiers.java
@@ -3,15 +3,23 @@ package org.bouncycastle.asn1.ntt;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
 /**
- * From RFC 3657
+ * From <a href="http://tools.ietf.org/html/rfc3657">RFC 3657</a>
+ * Use of the Camellia Encryption Algorithm
+ * in Cryptographic Message Syntax (CMS)
  */
 public interface NTTObjectIdentifiers
 {
-    public static final ASN1ObjectIdentifier id_camellia128_cbc = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.1.2");
-    public static final ASN1ObjectIdentifier id_camellia192_cbc = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.1.3");
-    public static final ASN1ObjectIdentifier id_camellia256_cbc = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.1.4");
+    /** id-camellia128-cbc; OID 1.2.392.200011.61.1.1.1.2 */
+    static final ASN1ObjectIdentifier id_camellia128_cbc = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.1.2");
+    /** id-camellia192-cbc; OID 1.2.392.200011.61.1.1.1.3 */
+    static final ASN1ObjectIdentifier id_camellia192_cbc = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.1.3");
+    /** id-camellia256-cbc; OID 1.2.392.200011.61.1.1.1.4 */
+    static final ASN1ObjectIdentifier id_camellia256_cbc = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.1.4");
 
-    public static final ASN1ObjectIdentifier id_camellia128_wrap = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.3.2");
-    public static final ASN1ObjectIdentifier id_camellia192_wrap = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.3.3");
-    public static final ASN1ObjectIdentifier id_camellia256_wrap = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.3.4");
+    /** id-camellia128-wrap; OID 1.2.392.200011.61.1.1.3.2 */
+    static final ASN1ObjectIdentifier id_camellia128_wrap = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.3.2");
+    /** id-camellia192-wrap; OID 1.2.392.200011.61.1.1.3.3 */
+    static final ASN1ObjectIdentifier id_camellia192_wrap = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.3.3");
+    /** id-camellia256-wrap; OID 1.2.392.200011.61.1.1.3.4 */
+    static final ASN1ObjectIdentifier id_camellia256_wrap = new ASN1ObjectIdentifier("1.2.392.200011.61.1.1.3.4");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/ocsp/OCSPObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ocsp/OCSPObjectIdentifiers.java
@@ -2,21 +2,28 @@ package org.bouncycastle.asn1.ocsp;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * OIDs for <a href="http://tools.ietf.org/html/rfc2560">RFC 2560</a>
+ * Online Certificate Status Protocol - OCSP.
+ */
 public interface OCSPObjectIdentifiers
 {
-    public static final String pkix_ocsp = "1.3.6.1.5.5.7.48.1";
-
-    public static final ASN1ObjectIdentifier id_pkix_ocsp = new ASN1ObjectIdentifier(pkix_ocsp);
-    public static final ASN1ObjectIdentifier id_pkix_ocsp_basic = new ASN1ObjectIdentifier(pkix_ocsp + ".1");
+    /** OID: 1.3.6.1.5.5.7.48.1 */
+    static final ASN1ObjectIdentifier id_pkix_ocsp       = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.48.1");
+    /** OID: 1.3.6.1.5.5.7.48.1.1 */
+    static final ASN1ObjectIdentifier id_pkix_ocsp_basic = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.48.1.1");
     
-    //
-    // extensions
-    //
-    public static final ASN1ObjectIdentifier id_pkix_ocsp_nonce = new ASN1ObjectIdentifier(pkix_ocsp + ".2");
-    public static final ASN1ObjectIdentifier id_pkix_ocsp_crl = new ASN1ObjectIdentifier(pkix_ocsp + ".3");
+    /** OID: 1.3.6.1.5.5.7.48.1.2 */
+    static final ASN1ObjectIdentifier id_pkix_ocsp_nonce = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.48.1.2");
+    /** OID: 1.3.6.1.5.5.7.48.1.3 */
+    static final ASN1ObjectIdentifier id_pkix_ocsp_crl   = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.48.1.3");
     
-    public static final ASN1ObjectIdentifier id_pkix_ocsp_response = new ASN1ObjectIdentifier(pkix_ocsp + ".4");
-    public static final ASN1ObjectIdentifier id_pkix_ocsp_nocheck = new ASN1ObjectIdentifier(pkix_ocsp + ".5");
-    public static final ASN1ObjectIdentifier id_pkix_ocsp_archive_cutoff = new ASN1ObjectIdentifier(pkix_ocsp + ".6");
-    public static final ASN1ObjectIdentifier id_pkix_ocsp_service_locator = new ASN1ObjectIdentifier(pkix_ocsp + ".7");
+    /** OID: 1.3.6.1.5.5.7.48.1.4 */
+    static final ASN1ObjectIdentifier id_pkix_ocsp_response        = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.48.1.4");
+    /** OID: 1.3.6.1.5.5.7.48.1.5 */
+    static final ASN1ObjectIdentifier id_pkix_ocsp_nocheck         = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.48.1.5");
+    /** OID: 1.3.6.1.5.5.7.48.1.6 */
+    static final ASN1ObjectIdentifier id_pkix_ocsp_archive_cutoff  = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.48.1.6");
+    /** OID: 1.3.6.1.5.5.7.48.1.7 */
+    static final ASN1ObjectIdentifier id_pkix_ocsp_service_locator = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.48.1.7");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/oiw/OIWObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/oiw/OIWObjectIdentifiers.java
@@ -2,30 +2,49 @@ package org.bouncycastle.asn1.oiw;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * OIW organization's OIDs:
+ * <p>
+ * id-SHA1 OBJECT IDENTIFIER ::=    
+ *   {iso(1) identified-organization(3) oiw(14) secsig(3) algorithms(2) 26 }
+ */
 public interface OIWObjectIdentifiers
 {
-    // id-SHA1 OBJECT IDENTIFIER ::=    
-    //   {iso(1) identified-organization(3) oiw(14) secsig(3) algorithms(2) 26 }    //
+    /** OID: 1.3.14.3.2.2 */
     static final ASN1ObjectIdentifier    md4WithRSA              = new ASN1ObjectIdentifier("1.3.14.3.2.2");
+    /** OID: 1.3.14.3.2.3 */
     static final ASN1ObjectIdentifier    md5WithRSA              = new ASN1ObjectIdentifier("1.3.14.3.2.3");
+    /** OID: 1.3.14.3.2.4 */
     static final ASN1ObjectIdentifier    md4WithRSAEncryption    = new ASN1ObjectIdentifier("1.3.14.3.2.4");
     
+    /** OID: 1.3.14.3.2.6 */
     static final ASN1ObjectIdentifier    desECB                  = new ASN1ObjectIdentifier("1.3.14.3.2.6");
+    /** OID: 1.3.14.3.2.7 */
     static final ASN1ObjectIdentifier    desCBC                  = new ASN1ObjectIdentifier("1.3.14.3.2.7");
+    /** OID: 1.3.14.3.2.8 */
     static final ASN1ObjectIdentifier    desOFB                  = new ASN1ObjectIdentifier("1.3.14.3.2.8");
+    /** OID: 1.3.14.3.2.9 */
     static final ASN1ObjectIdentifier    desCFB                  = new ASN1ObjectIdentifier("1.3.14.3.2.9");
 
+    /** OID: 1.3.14.3.2.17 */
     static final ASN1ObjectIdentifier    desEDE                  = new ASN1ObjectIdentifier("1.3.14.3.2.17");
     
+    /** OID: 1.3.14.3.2.26 */
     static final ASN1ObjectIdentifier    idSHA1                  = new ASN1ObjectIdentifier("1.3.14.3.2.26");
 
+    /** OID: 1.3.14.3.2.27 */
     static final ASN1ObjectIdentifier    dsaWithSHA1             = new ASN1ObjectIdentifier("1.3.14.3.2.27");
 
+    /** OID: 1.3.14.3.2.29 */
     static final ASN1ObjectIdentifier    sha1WithRSA             = new ASN1ObjectIdentifier("1.3.14.3.2.29");
     
-    // ElGamal Algorithm OBJECT IDENTIFIER ::=    
-    // {iso(1) identified-organization(3) oiw(14) dirservsig(7) algorithm(2) encryption(1) 1 }
-    //
+    /**
+     * <pre>
+     * ElGamal Algorithm OBJECT IDENTIFIER ::=    
+     *   {iso(1) identified-organization(3) oiw(14) dirservsig(7) algorithm(2) encryption(1) 1 }
+     * </pre>
+     * OID: 1.3.14.7.2.1.1
+     */
     static final ASN1ObjectIdentifier    elGamalAlgorithm        = new ASN1ObjectIdentifier("1.3.14.7.2.1.1");
 
 }

--- a/core/src/main/java/org/bouncycastle/asn1/pkcs/PKCSObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/pkcs/PKCSObjectIdentifiers.java
@@ -2,257 +2,389 @@ package org.bouncycastle.asn1.pkcs;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * pkcs-1 OBJECT IDENTIFIER ::=<p>
+ *   { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 1 }
+ *
+ */
 public interface PKCSObjectIdentifiers
 {
-    //
-    // pkcs-1 OBJECT IDENTIFIER ::= {
-    //       iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 1 }
-    //
+    /** PKCS#1: 1.2.840.113549.1.1 */
     static final ASN1ObjectIdentifier    pkcs_1                    = new ASN1ObjectIdentifier("1.2.840.113549.1.1");
+    /** PKCS#1: 1.2.840.113549.1.1.1 */
     static final ASN1ObjectIdentifier    rsaEncryption             = pkcs_1.branch("1");
+    /** PKCS#1: 1.2.840.113549.1.1.2 */
     static final ASN1ObjectIdentifier    md2WithRSAEncryption      = pkcs_1.branch("2");
+    /** PKCS#1: 1.2.840.113549.1.1.3 */
     static final ASN1ObjectIdentifier    md4WithRSAEncryption      = pkcs_1.branch("3");
+    /** PKCS#1: 1.2.840.113549.1.1.4 */
     static final ASN1ObjectIdentifier    md5WithRSAEncryption      = pkcs_1.branch("4");
+    /** PKCS#1: 1.2.840.113549.1.1.5 */
     static final ASN1ObjectIdentifier    sha1WithRSAEncryption     = pkcs_1.branch("5");
+    /** PKCS#1: 1.2.840.113549.1.1.6 */
     static final ASN1ObjectIdentifier    srsaOAEPEncryptionSET     = pkcs_1.branch("6");
+    /** PKCS#1: 1.2.840.113549.1.1.7 */
     static final ASN1ObjectIdentifier    id_RSAES_OAEP             = pkcs_1.branch("7");
+    /** PKCS#1: 1.2.840.113549.1.1.8 */
     static final ASN1ObjectIdentifier    id_mgf1                   = pkcs_1.branch("8");
+    /** PKCS#1: 1.2.840.113549.1.1.9 */
     static final ASN1ObjectIdentifier    id_pSpecified             = pkcs_1.branch("9");
+    /** PKCS#1: 1.2.840.113549.1.1.10 */
     static final ASN1ObjectIdentifier    id_RSASSA_PSS             = pkcs_1.branch("10");
+    /** PKCS#1: 1.2.840.113549.1.1.11 */
     static final ASN1ObjectIdentifier    sha256WithRSAEncryption   = pkcs_1.branch("11");
+    /** PKCS#1: 1.2.840.113549.1.1.12 */
     static final ASN1ObjectIdentifier    sha384WithRSAEncryption   = pkcs_1.branch("12");
+    /** PKCS#1: 1.2.840.113549.1.1.13 */
     static final ASN1ObjectIdentifier    sha512WithRSAEncryption   = pkcs_1.branch("13");
+    /** PKCS#1: 1.2.840.113549.1.1.14 */
     static final ASN1ObjectIdentifier    sha224WithRSAEncryption   = pkcs_1.branch("14");
 
     //
     // pkcs-3 OBJECT IDENTIFIER ::= {
     //       iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 3 }
     //
+    /** PKCS#3: 1.2.840.113549.1.3 */
     static final ASN1ObjectIdentifier    pkcs_3                  = new ASN1ObjectIdentifier("1.2.840.113549.1.3");
+    /** PKCS#3: 1.2.840.113549.1.3.1 */
     static final ASN1ObjectIdentifier    dhKeyAgreement          = pkcs_3.branch("1");
 
     //
     // pkcs-5 OBJECT IDENTIFIER ::= {
     //       iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 5 }
     //
+    /** PKCS#5: 1.2.840.113549.1.5 */
     static final ASN1ObjectIdentifier    pkcs_5                  = new ASN1ObjectIdentifier("1.2.840.113549.1.5");
 
+    /** PKCS#5: 1.2.840.113549.1.5.1 */
     static final ASN1ObjectIdentifier    pbeWithMD2AndDES_CBC    = pkcs_5.branch("1");
+    /** PKCS#5: 1.2.840.113549.1.5.4 */
     static final ASN1ObjectIdentifier    pbeWithMD2AndRC2_CBC    = pkcs_5.branch("4");
+    /** PKCS#5: 1.2.840.113549.1.5.3 */
     static final ASN1ObjectIdentifier    pbeWithMD5AndDES_CBC    = pkcs_5.branch("3");
+    /** PKCS#5: 1.2.840.113549.1.5.6 */
     static final ASN1ObjectIdentifier    pbeWithMD5AndRC2_CBC    = pkcs_5.branch("6");
+    /** PKCS#5: 1.2.840.113549.1.5.10 */
     static final ASN1ObjectIdentifier    pbeWithSHA1AndDES_CBC   = pkcs_5.branch("10");
+    /** PKCS#5: 1.2.840.113549.1.5.11 */
     static final ASN1ObjectIdentifier    pbeWithSHA1AndRC2_CBC   = pkcs_5.branch("11");
-
+    /** PKCS#5: 1.2.840.113549.1.5.13 */
     static final ASN1ObjectIdentifier    id_PBES2                = pkcs_5.branch("13");
-
+    /** PKCS#5: 1.2.840.113549.1.5.12 */
     static final ASN1ObjectIdentifier    id_PBKDF2               = pkcs_5.branch("12");
 
     //
     // encryptionAlgorithm OBJECT IDENTIFIER ::= {
     //       iso(1) member-body(2) us(840) rsadsi(113549) 3 }
     //
+    /**  1.2.840.113549.3 */
     static final ASN1ObjectIdentifier    encryptionAlgorithm     = new ASN1ObjectIdentifier("1.2.840.113549.3");
 
+    /**  1.2.840.113549.3.7 */
     static final ASN1ObjectIdentifier    des_EDE3_CBC            = encryptionAlgorithm.branch("7");
+    /**  1.2.840.113549.3.2 */
     static final ASN1ObjectIdentifier    RC2_CBC                 = encryptionAlgorithm.branch("2");
+    /**  1.2.840.113549.3.4 */
     static final ASN1ObjectIdentifier    rc4                     = encryptionAlgorithm.branch("4");
 
     //
     // object identifiers for digests
     //
+    /**  1.2.840.113549.2 */
     static final ASN1ObjectIdentifier    digestAlgorithm        = new ASN1ObjectIdentifier("1.2.840.113549.2");
     //
     // md2 OBJECT IDENTIFIER ::=
     //      {iso(1) member-body(2) US(840) rsadsi(113549) digestAlgorithm(2) 2}
     //
+    /**  1.2.840.113549.2.2 */
     static final ASN1ObjectIdentifier    md2                    = digestAlgorithm.branch("2");
 
     //
     // md4 OBJECT IDENTIFIER ::=
     //      {iso(1) member-body(2) US(840) rsadsi(113549) digestAlgorithm(2) 4}
     //
-    static final ASN1ObjectIdentifier    md4 = digestAlgorithm.branch("4");
+    /**  1.2.840.113549.2.4 */
+    static final ASN1ObjectIdentifier    md4                    = digestAlgorithm.branch("4");
 
     //
     // md5 OBJECT IDENTIFIER ::=
     //      {iso(1) member-body(2) US(840) rsadsi(113549) digestAlgorithm(2) 5}
     //
-    static final ASN1ObjectIdentifier    md5                     = digestAlgorithm.branch("5");
+    /**  1.2.840.113549.2.5 */
+    static final ASN1ObjectIdentifier    md5                    = digestAlgorithm.branch("5");
 
-    static final ASN1ObjectIdentifier    id_hmacWithSHA1         = digestAlgorithm.branch("7");
-    static final ASN1ObjectIdentifier    id_hmacWithSHA224       = digestAlgorithm.branch("8");
-    static final ASN1ObjectIdentifier    id_hmacWithSHA256       = digestAlgorithm.branch("9");
-    static final ASN1ObjectIdentifier    id_hmacWithSHA384       = digestAlgorithm.branch("10");
-    static final ASN1ObjectIdentifier    id_hmacWithSHA512       = digestAlgorithm.branch("11");
+    /**  1.2.840.113549.2.7 */
+    static final ASN1ObjectIdentifier    id_hmacWithSHA1        = digestAlgorithm.branch("7");
+    /**  1.2.840.113549.2.8 */
+    static final ASN1ObjectIdentifier    id_hmacWithSHA224      = digestAlgorithm.branch("8");
+    /**  1.2.840.113549.2.9 */
+    static final ASN1ObjectIdentifier    id_hmacWithSHA256      = digestAlgorithm.branch("9");
+    /**  1.2.840.113549.2.10 */
+    static final ASN1ObjectIdentifier    id_hmacWithSHA384      = digestAlgorithm.branch("10");
+    /**  1.2.840.113549.2.11 */
+    static final ASN1ObjectIdentifier    id_hmacWithSHA512      = digestAlgorithm.branch("11");
 
     //
     // pkcs-7 OBJECT IDENTIFIER ::= {
     //       iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 7 }
     //
-    static final String                 pkcs_7                  = "1.2.840.113549.1.7";
+    /** pkcs#7: 1.2.840.113549.1.7 */
+    static final String                 pkcs_7                   = "1.2.840.113549.1.7";
+    /** PKCS#7: 1.2.840.113549.1.7.1 */
     static final ASN1ObjectIdentifier    data                    = new ASN1ObjectIdentifier(pkcs_7 + ".1");
+    /** PKCS#7: 1.2.840.113549.1.7.2 */
     static final ASN1ObjectIdentifier    signedData              = new ASN1ObjectIdentifier(pkcs_7 + ".2");
+    /** PKCS#7: 1.2.840.113549.1.7.3 */
     static final ASN1ObjectIdentifier    envelopedData           = new ASN1ObjectIdentifier(pkcs_7 + ".3");
+    /** PKCS#7: 1.2.840.113549.1.7.4 */
     static final ASN1ObjectIdentifier    signedAndEnvelopedData  = new ASN1ObjectIdentifier(pkcs_7 + ".4");
+    /** PKCS#7: 1.2.840.113549.1.7.5 */
     static final ASN1ObjectIdentifier    digestedData            = new ASN1ObjectIdentifier(pkcs_7 + ".5");
+    /** PKCS#7: 1.2.840.113549.1.7.76 */
     static final ASN1ObjectIdentifier    encryptedData           = new ASN1ObjectIdentifier(pkcs_7 + ".6");
 
     //
     // pkcs-9 OBJECT IDENTIFIER ::= {
     //       iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 9 }
     //
+    /** PKCS#9: 1.2.840.113549.1.9 */
     static final ASN1ObjectIdentifier    pkcs_9                  = new ASN1ObjectIdentifier("1.2.840.113549.1.9");
 
-    static final ASN1ObjectIdentifier    pkcs_9_at_emailAddress  = pkcs_9.branch("1");
-    static final ASN1ObjectIdentifier    pkcs_9_at_unstructuredName = pkcs_9.branch("2");
-    static final ASN1ObjectIdentifier    pkcs_9_at_contentType = pkcs_9.branch("3");
-    static final ASN1ObjectIdentifier    pkcs_9_at_messageDigest = pkcs_9.branch("4");
-    static final ASN1ObjectIdentifier    pkcs_9_at_signingTime = pkcs_9.branch("5");
-    static final ASN1ObjectIdentifier    pkcs_9_at_counterSignature = pkcs_9.branch("6");
-    static final ASN1ObjectIdentifier    pkcs_9_at_challengePassword = pkcs_9.branch("7");
+    /** PKCS#9: 1.2.840.113549.1.9.1 */
+    static final ASN1ObjectIdentifier    pkcs_9_at_emailAddress        = pkcs_9.branch("1");
+    /** PKCS#9: 1.2.840.113549.1.9.2 */
+    static final ASN1ObjectIdentifier    pkcs_9_at_unstructuredName    = pkcs_9.branch("2");
+    /** PKCS#9: 1.2.840.113549.1.9.3 */
+    static final ASN1ObjectIdentifier    pkcs_9_at_contentType         = pkcs_9.branch("3");
+    /** PKCS#9: 1.2.840.113549.1.9.4 */
+    static final ASN1ObjectIdentifier    pkcs_9_at_messageDigest       = pkcs_9.branch("4");
+    /** PKCS#9: 1.2.840.113549.1.9.5 */
+    static final ASN1ObjectIdentifier    pkcs_9_at_signingTime         = pkcs_9.branch("5");
+    /** PKCS#9: 1.2.840.113549.1.9.6 */
+    static final ASN1ObjectIdentifier    pkcs_9_at_counterSignature    = pkcs_9.branch("6");
+    /** PKCS#9: 1.2.840.113549.1.9.7 */
+    static final ASN1ObjectIdentifier    pkcs_9_at_challengePassword   = pkcs_9.branch("7");
+    /** PKCS#9: 1.2.840.113549.1.9.8 */
     static final ASN1ObjectIdentifier    pkcs_9_at_unstructuredAddress = pkcs_9.branch("8");
+    /** PKCS#9: 1.2.840.113549.1.9.9 */
     static final ASN1ObjectIdentifier    pkcs_9_at_extendedCertificateAttributes = pkcs_9.branch("9");
 
+    /** PKCS#9: 1.2.840.113549.1.9.13 */
     static final ASN1ObjectIdentifier    pkcs_9_at_signingDescription = pkcs_9.branch("13");
-    static final ASN1ObjectIdentifier    pkcs_9_at_extensionRequest = pkcs_9.branch("14");
-    static final ASN1ObjectIdentifier    pkcs_9_at_smimeCapabilities = pkcs_9.branch("15");
+    /** PKCS#9: 1.2.840.113549.1.9.14 */
+    static final ASN1ObjectIdentifier    pkcs_9_at_extensionRequest   = pkcs_9.branch("14");
+    /** PKCS#9: 1.2.840.113549.1.9.15 */
+    static final ASN1ObjectIdentifier    pkcs_9_at_smimeCapabilities  = pkcs_9.branch("15");
+    /** PKCS#9: 1.2.840.113549.1.9.16 */
+    static final ASN1ObjectIdentifier    id_smime                     = pkcs_9.branch("16");
 
+    /** PKCS#9: 1.2.840.113549.1.9.20 */
     static final ASN1ObjectIdentifier    pkcs_9_at_friendlyName  = pkcs_9.branch("20");
+    /** PKCS#9: 1.2.840.113549.1.9.21 */
     static final ASN1ObjectIdentifier    pkcs_9_at_localKeyId    = pkcs_9.branch("21");
 
-    /** @deprecated use x509Certificate instead */
+    /** PKCS#9: 1.2.840.113549.1.9.22.1
+     * @deprecated use x509Certificate instead */
     static final ASN1ObjectIdentifier    x509certType            = pkcs_9.branch("22.1");
 
+    /** PKCS#9: 1.2.840.113549.1.9.22 */
     static final ASN1ObjectIdentifier    certTypes               = pkcs_9.branch("22");
+    /** PKCS#9: 1.2.840.113549.1.9.22.1 */
     static final ASN1ObjectIdentifier    x509Certificate         = certTypes.branch("1");
+    /** PKCS#9: 1.2.840.113549.1.9.22.2 */
     static final ASN1ObjectIdentifier    sdsiCertificate         = certTypes.branch("2");
 
+    /** PKCS#9: 1.2.840.113549.1.9.23 */
     static final ASN1ObjectIdentifier    crlTypes                = pkcs_9.branch("23");
+    /** PKCS#9: 1.2.840.113549.1.9.23.1 */
     static final ASN1ObjectIdentifier    x509Crl                 = crlTypes.branch("1");
-
-    static final ASN1ObjectIdentifier    id_alg_PWRI_KEK    = pkcs_9.branch("16.3.9");
 
     //
     // SMIME capability sub oids.
     //
+    /** PKCS#9: 1.2.840.113549.1.9.15.1 -- smime capability */
     static final ASN1ObjectIdentifier    preferSignedData        = pkcs_9.branch("15.1");
+    /** PKCS#9: 1.2.840.113549.1.9.15.2 -- smime capability  */
     static final ASN1ObjectIdentifier    canNotDecryptAny        = pkcs_9.branch("15.2");
+    /** PKCS#9: 1.2.840.113549.1.9.15.3 -- smime capability  */
     static final ASN1ObjectIdentifier    sMIMECapabilitiesVersions = pkcs_9.branch("15.3");
 
     //
     // id-ct OBJECT IDENTIFIER ::= {iso(1) member-body(2) usa(840)
     // rsadsi(113549) pkcs(1) pkcs-9(9) smime(16) ct(1)}
     //
+    /** PKCS#9: 1.2.840.113549.1.9.16.1 -- smime ct */
     static final ASN1ObjectIdentifier    id_ct = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16.1");
 
+    /** PKCS#9: 1.2.840.113549.1.9.16.1.2 -- smime ct authData */
     static final ASN1ObjectIdentifier    id_ct_authData          = id_ct.branch("2");
+    /** PKCS#9: 1.2.840.113549.1.9.16.1.4 -- smime ct TSTInfo*/
     static final ASN1ObjectIdentifier    id_ct_TSTInfo           = id_ct.branch("4");
+    /** PKCS#9: 1.2.840.113549.1.9.16.1.9 -- smime ct compressedData */
     static final ASN1ObjectIdentifier    id_ct_compressedData    = id_ct.branch("9");
+    /** PKCS#9: 1.2.840.113549.1.9.16.1.23 -- smime ct authEnvelopedData */
     static final ASN1ObjectIdentifier    id_ct_authEnvelopedData = id_ct.branch("23");
+    /** PKCS#9: 1.2.840.113549.1.9.16.1.31 -- smime ct timestampedData*/
     static final ASN1ObjectIdentifier    id_ct_timestampedData   = id_ct.branch("31");
+
+
+    /** S/MIME: Algorithm Identifiers ; 1.2.840.113549.1.9.16.3 */
+    static final ASN1ObjectIdentifier id_alg                  = id_smime.branch("3");
+    /** PKCS#9: 1.2.840.113549.1.9.16.3.9 */
+    static final ASN1ObjectIdentifier id_alg_PWRI_KEK         = id_alg.branch("9");
 
     //
     // id-cti OBJECT IDENTIFIER ::= {iso(1) member-body(2) usa(840)
     // rsadsi(113549) pkcs(1) pkcs-9(9) smime(16) cti(6)}
     //
+    /** PKCS#9: 1.2.840.113549.1.9.16.6 -- smime cti */
     static final ASN1ObjectIdentifier    id_cti = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16.6");
     
-    static final ASN1ObjectIdentifier    id_cti_ets_proofOfOrigin  = id_cti.branch("1");
-    static final ASN1ObjectIdentifier    id_cti_ets_proofOfReceipt = id_cti.branch("2");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.1 -- smime cti proofOfOrigin */
+    static final ASN1ObjectIdentifier    id_cti_ets_proofOfOrigin   = id_cti.branch("1");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2 -- smime cti proofOfReceipt*/
+    static final ASN1ObjectIdentifier    id_cti_ets_proofOfReceipt  = id_cti.branch("2");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.3 -- smime cti proofOfDelivery */
     static final ASN1ObjectIdentifier    id_cti_ets_proofOfDelivery = id_cti.branch("3");
-    static final ASN1ObjectIdentifier    id_cti_ets_proofOfSender = id_cti.branch("4");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.4 -- smime cti proofOfSender */
+    static final ASN1ObjectIdentifier    id_cti_ets_proofOfSender   = id_cti.branch("4");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.5 -- smime cti proofOfApproval */
     static final ASN1ObjectIdentifier    id_cti_ets_proofOfApproval = id_cti.branch("5");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.6 -- smime cti proofOfCreation */
     static final ASN1ObjectIdentifier    id_cti_ets_proofOfCreation = id_cti.branch("6");
     
     //
     // id-aa OBJECT IDENTIFIER ::= {iso(1) member-body(2) usa(840)
     // rsadsi(113549) pkcs(1) pkcs-9(9) smime(16) attributes(2)}
     //
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2 - smime attributes */
     static final ASN1ObjectIdentifier    id_aa = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16.2");
 
 
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.1 -- smime attribute receiptRequest */
     static final ASN1ObjectIdentifier id_aa_receiptRequest = id_aa.branch("1");
     
-    static final ASN1ObjectIdentifier id_aa_contentHint = id_aa.branch("4"); // See RFC 2634
-    static final ASN1ObjectIdentifier id_aa_msgSigDigest = id_aa.branch("5");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.4 - See <a href="http://tools.ietf.org/html/rfc2634">RFC 2634</a> */
+    static final ASN1ObjectIdentifier id_aa_contentHint      = id_aa.branch("4"); // See RFC 2634
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.5 */
+    static final ASN1ObjectIdentifier id_aa_msgSigDigest     = id_aa.branch("5");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.10 */
     static final ASN1ObjectIdentifier id_aa_contentReference = id_aa.branch("10");
     /*
      * id-aa-encrypKeyPref OBJECT IDENTIFIER ::= {id-aa 11}
      * 
      */
-    static final ASN1ObjectIdentifier id_aa_encrypKeyPref = id_aa.branch("11");
-    static final ASN1ObjectIdentifier id_aa_signingCertificate = id_aa.branch("12");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.11 */
+    static final ASN1ObjectIdentifier id_aa_encrypKeyPref        = id_aa.branch("11");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.12 */
+    static final ASN1ObjectIdentifier id_aa_signingCertificate   = id_aa.branch("12");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.47 */
     static final ASN1ObjectIdentifier id_aa_signingCertificateV2 = id_aa.branch("47");
 
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.7 - See <a href="http://tools.ietf.org/html/rfc2634">RFC 2634</a> */
     static final ASN1ObjectIdentifier id_aa_contentIdentifier = id_aa.branch("7"); // See RFC 2634
 
     /*
      * RFC 3126
      */
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.14 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_signatureTimeStampToken = id_aa.branch("14");
     
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.15 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_sigPolicyId = id_aa.branch("15");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.16 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_commitmentType = id_aa.branch("16");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.17 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_signerLocation = id_aa.branch("17");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.18 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_signerAttr = id_aa.branch("18");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.19 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_otherSigCert = id_aa.branch("19");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.20 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_contentTimestamp = id_aa.branch("20");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.21 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_certificateRefs = id_aa.branch("21");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.22 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_revocationRefs = id_aa.branch("22");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.23 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_certValues = id_aa.branch("23");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.24 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_revocationValues = id_aa.branch("24");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.25 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_escTimeStamp = id_aa.branch("25");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.26 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_certCRLTimestamp = id_aa.branch("26");
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.27 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     static final ASN1ObjectIdentifier id_aa_ets_archiveTimestamp = id_aa.branch("27");
 
     /** @deprecated use id_aa_ets_sigPolicyId instead */
-    static final ASN1ObjectIdentifier id_aa_sigPolicyId = id_aa_ets_sigPolicyId;
+    static final ASN1ObjectIdentifier id_aa_sigPolicyId    = id_aa_ets_sigPolicyId;
     /** @deprecated use id_aa_ets_commitmentType instead */
     static final ASN1ObjectIdentifier id_aa_commitmentType = id_aa_ets_commitmentType;
     /** @deprecated use id_aa_ets_signerLocation instead */
     static final ASN1ObjectIdentifier id_aa_signerLocation = id_aa_ets_signerLocation;
     /** @deprecated use id_aa_ets_otherSigCert instead */
-    static final ASN1ObjectIdentifier id_aa_otherSigCert = id_aa_ets_otherSigCert;
+    static final ASN1ObjectIdentifier id_aa_otherSigCert   = id_aa_ets_otherSigCert;
     
-    //
-    // id-spq OBJECT IDENTIFIER ::= {iso(1) member-body(2) usa(840)
-    // rsadsi(113549) pkcs(1) pkcs-9(9) smime(16) id-spq(5)}
-    //
+    /**
+     * id-spq OBJECT IDENTIFIER ::= {iso(1) member-body(2) usa(840)
+     * rsadsi(113549) pkcs(1) pkcs-9(9) smime(16) id-spq(5)}; <p>
+     * 1.2.840.113549.1.9.16.5
+     */
     final String id_spq = "1.2.840.113549.1.9.16.5";
 
-    static final ASN1ObjectIdentifier id_spq_ets_uri = new ASN1ObjectIdentifier(id_spq + ".1");
+    /** SMIME SPQ URI:     1.2.840.113549.1.9.16.5.1 */
+    static final ASN1ObjectIdentifier id_spq_ets_uri     = new ASN1ObjectIdentifier(id_spq + ".1");
+    /** SMIME SPQ UNOTICE: 1.2.840.113549.1.9.16.5.2 */
     static final ASN1ObjectIdentifier id_spq_ets_unotice = new ASN1ObjectIdentifier(id_spq + ".2");
 
     //
     // pkcs-12 OBJECT IDENTIFIER ::= {
     //       iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 12 }
     //
+    /** PKCS#12: 1.2.840.113549.1.12 */
     static final ASN1ObjectIdentifier   pkcs_12                  = new ASN1ObjectIdentifier("1.2.840.113549.1.12");
+    /** PKCS#12: 1.2.840.113549.1.12.10.1 */
     static final ASN1ObjectIdentifier   bagtypes                 = pkcs_12.branch("10.1");
 
+    /** PKCS#12: 1.2.840.113549.1.12.10.1.1 */
     static final ASN1ObjectIdentifier    keyBag                  = bagtypes.branch("1");
+    /** PKCS#12: 1.2.840.113549.1.12.10.1.2 */
     static final ASN1ObjectIdentifier    pkcs8ShroudedKeyBag     = bagtypes.branch("2");
+    /** PKCS#12: 1.2.840.113549.1.12.10.1.3 */
     static final ASN1ObjectIdentifier    certBag                 = bagtypes.branch("3");
+    /** PKCS#12: 1.2.840.113549.1.12.10.1.4 */
     static final ASN1ObjectIdentifier    crlBag                  = bagtypes.branch("4");
+    /** PKCS#12: 1.2.840.113549.1.12.10.1.5 */
     static final ASN1ObjectIdentifier    secretBag               = bagtypes.branch("5");
+    /** PKCS#12: 1.2.840.113549.1.12.10.1.6 */
     static final ASN1ObjectIdentifier    safeContentsBag         = bagtypes.branch("6");
 
-    static final ASN1ObjectIdentifier    pkcs_12PbeIds  = pkcs_12.branch("1");
+    /** PKCS#12: 1.2.840.113549.1.12.1 */
+    static final ASN1ObjectIdentifier    pkcs_12PbeIds           = pkcs_12.branch("1");
 
-    static final ASN1ObjectIdentifier    pbeWithSHAAnd128BitRC4 = pkcs_12PbeIds.branch("1");
-    static final ASN1ObjectIdentifier    pbeWithSHAAnd40BitRC4  = pkcs_12PbeIds.branch("2");
+    /** PKCS#12: 1.2.840.113549.1.12.1.1 */
+    static final ASN1ObjectIdentifier    pbeWithSHAAnd128BitRC4          = pkcs_12PbeIds.branch("1");
+    /** PKCS#12: 1.2.840.113549.1.12.1.2 */
+    static final ASN1ObjectIdentifier    pbeWithSHAAnd40BitRC4           = pkcs_12PbeIds.branch("2");
+    /** PKCS#12: 1.2.840.113549.1.12.1.3 */
     static final ASN1ObjectIdentifier    pbeWithSHAAnd3_KeyTripleDES_CBC = pkcs_12PbeIds.branch("3");
+    /** PKCS#12: 1.2.840.113549.1.12.1.4 */
     static final ASN1ObjectIdentifier    pbeWithSHAAnd2_KeyTripleDES_CBC = pkcs_12PbeIds.branch("4");
-    static final ASN1ObjectIdentifier    pbeWithSHAAnd128BitRC2_CBC = pkcs_12PbeIds.branch("5");
-    static final ASN1ObjectIdentifier    pbeWithSHAAnd40BitRC2_CBC = pkcs_12PbeIds.branch("6");
+    /** PKCS#12: 1.2.840.113549.1.12.1.5 */
+    static final ASN1ObjectIdentifier    pbeWithSHAAnd128BitRC2_CBC      = pkcs_12PbeIds.branch("5");
+    /** PKCS#12: 1.2.840.113549.1.12.1.6 */
+    static final ASN1ObjectIdentifier    pbeWithSHAAnd40BitRC2_CBC       = pkcs_12PbeIds.branch("6");
 
     /**
+     * PKCS#12: 1.2.840.113549.1.12.1.6
      * @deprecated use pbeWithSHAAnd40BitRC2_CBC
      */
     static final ASN1ObjectIdentifier    pbewithSHAAnd40BitRC2_CBC = pkcs_12PbeIds.branch("6");
 
+    /** PKCS#9: 1.2.840.113549.1.9.16.3.6 */
     static final ASN1ObjectIdentifier    id_alg_CMS3DESwrap = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16.3.6");
-    static final ASN1ObjectIdentifier    id_alg_CMSRC2wrap = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16.3.7");
+    /** PKCS#9: 1.2.840.113549.1.9.16.3.7 */
+    static final ASN1ObjectIdentifier    id_alg_CMSRC2wrap  = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16.3.7");
 }
 

--- a/core/src/main/java/org/bouncycastle/asn1/sec/SECObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/sec/SECObjectIdentifiers.java
@@ -3,48 +3,85 @@ package org.bouncycastle.asn1.sec;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 
+/**
+ * Certicom object identifiers
+ * <pre>
+ *  ellipticCurve OBJECT IDENTIFIER ::= {
+ *        iso(1) identified-organization(3) certicom(132) curve(0)
+ *  }
+ * </pre>
+ */
 public interface SECObjectIdentifiers
 {
-    /**
-     *  ellipticCurve OBJECT IDENTIFIER ::= {
-     *        iso(1) identified-organization(3) certicom(132) curve(0)
-     *  }
-     */
+    /** Base OID: 1.3.132.0 */
     static final ASN1ObjectIdentifier ellipticCurve = new ASN1ObjectIdentifier("1.3.132.0");
 
+    /**  sect163k1 OID: 1.3.132.0.1 */
     static final ASN1ObjectIdentifier sect163k1 = ellipticCurve.branch("1");
+    /**  sect163r1 OID: 1.3.132.0.2 */
     static final ASN1ObjectIdentifier sect163r1 = ellipticCurve.branch("2");
+    /**  sect239k1 OID: 1.3.132.0.3 */
     static final ASN1ObjectIdentifier sect239k1 = ellipticCurve.branch("3");
+    /**  sect113r1 OID: 1.3.132.0.4 */
     static final ASN1ObjectIdentifier sect113r1 = ellipticCurve.branch("4");
+    /**  sect113r2 OID: 1.3.132.0.5 */
     static final ASN1ObjectIdentifier sect113r2 = ellipticCurve.branch("5");
+    /**  secp112r1 OID: 1.3.132.0.6 */
     static final ASN1ObjectIdentifier secp112r1 = ellipticCurve.branch("6");
+    /**  secp112r2 OID: 1.3.132.0.7 */
     static final ASN1ObjectIdentifier secp112r2 = ellipticCurve.branch("7");
+    /**  secp160r1 OID: 1.3.132.0.8 */
     static final ASN1ObjectIdentifier secp160r1 = ellipticCurve.branch("8");
+    /**  secp160k1 OID: 1.3.132.0.9 */
     static final ASN1ObjectIdentifier secp160k1 = ellipticCurve.branch("9");
+    /**  secp256k1 OID: 1.3.132.0.10 */
     static final ASN1ObjectIdentifier secp256k1 = ellipticCurve.branch("10");
+    /**  sect163r2 OID: 1.3.132.0.15 */
     static final ASN1ObjectIdentifier sect163r2 = ellipticCurve.branch("15");
+    /**  sect283k1 OID: 1.3.132.0.16 */
     static final ASN1ObjectIdentifier sect283k1 = ellipticCurve.branch("16");
+    /**  sect283r1 OID: 1.3.132.0.17 */
     static final ASN1ObjectIdentifier sect283r1 = ellipticCurve.branch("17");
+    /**  sect131r1 OID: 1.3.132.0.22 */
     static final ASN1ObjectIdentifier sect131r1 = ellipticCurve.branch("22");
+    /**  sect131r2 OID: 1.3.132.0.23 */
     static final ASN1ObjectIdentifier sect131r2 = ellipticCurve.branch("23");
+    /**  sect193r1 OID: 1.3.132.0.24 */
     static final ASN1ObjectIdentifier sect193r1 = ellipticCurve.branch("24");
+    /**  sect193r2 OID: 1.3.132.0.25 */
     static final ASN1ObjectIdentifier sect193r2 = ellipticCurve.branch("25");
+    /**  sect233k1 OID: 1.3.132.0.26 */
     static final ASN1ObjectIdentifier sect233k1 = ellipticCurve.branch("26");
+    /**  sect233r1 OID: 1.3.132.0.27 */
     static final ASN1ObjectIdentifier sect233r1 = ellipticCurve.branch("27");
+    /**  secp128r1 OID: 1.3.132.0.28 */
     static final ASN1ObjectIdentifier secp128r1 = ellipticCurve.branch("28");
+    /**  secp128r2 OID: 1.3.132.0.29 */
     static final ASN1ObjectIdentifier secp128r2 = ellipticCurve.branch("29");
+    /**  secp160r2 OID: 1.3.132.0.30 */
     static final ASN1ObjectIdentifier secp160r2 = ellipticCurve.branch("30");
+    /**  secp192k1 OID: 1.3.132.0.31 */
     static final ASN1ObjectIdentifier secp192k1 = ellipticCurve.branch("31");
+    /**  secp224k1 OID: 1.3.132.0.32 */
     static final ASN1ObjectIdentifier secp224k1 = ellipticCurve.branch("32");
+    /**  secp224r1 OID: 1.3.132.0.33 */
     static final ASN1ObjectIdentifier secp224r1 = ellipticCurve.branch("33");
+    /**  secp384r1 OID: 1.3.132.0.34 */
     static final ASN1ObjectIdentifier secp384r1 = ellipticCurve.branch("34");
+    /**  secp521r1 OID: 1.3.132.0.35 */
     static final ASN1ObjectIdentifier secp521r1 = ellipticCurve.branch("35");
+    /**  sect409k1 OID: 1.3.132.0.36 */
     static final ASN1ObjectIdentifier sect409k1 = ellipticCurve.branch("36");
+    /**  sect409r1 OID: 1.3.132.0.37 */
     static final ASN1ObjectIdentifier sect409r1 = ellipticCurve.branch("37");
+    /**  sect571k1 OID: 1.3.132.0.38 */
     static final ASN1ObjectIdentifier sect571k1 = ellipticCurve.branch("38");
+    /**  sect571r1 OID: 1.3.132.0.39 */
     static final ASN1ObjectIdentifier sect571r1 = ellipticCurve.branch("39");
 
+    /**  secp192r1 OID: 1.3.132.0.prime192v1 */
     static final ASN1ObjectIdentifier secp192r1 = X9ObjectIdentifiers.prime192v1;
+    /**  secp256r1 OID: 1.3.132.0.prime256v1 */
     static final ASN1ObjectIdentifier secp256r1 = X9ObjectIdentifiers.prime256v1;
 
 }

--- a/core/src/main/java/org/bouncycastle/asn1/teletrust/TeleTrusTObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/teletrust/TeleTrusTObjectIdentifiers.java
@@ -2,41 +2,74 @@ package org.bouncycastle.asn1.teletrust;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * TeleTrusT:
+ *   { iso(1) identifier-organization(3) teleTrust(36) algorithm(3)
+ *
+ */
 public interface TeleTrusTObjectIdentifiers
 {
+    /** 1.3.36.3 */
     static final ASN1ObjectIdentifier teleTrusTAlgorithm = new ASN1ObjectIdentifier("1.3.36.3");
 
+    /** 1.3.36.3.2.1 */
     static final ASN1ObjectIdentifier    ripemd160           = teleTrusTAlgorithm.branch("2.1");
+    /** 1.3.36.3.2.2 */
     static final ASN1ObjectIdentifier    ripemd128           = teleTrusTAlgorithm.branch("2.2");
+    /** 1.3.36.3.2.3 */
     static final ASN1ObjectIdentifier    ripemd256           = teleTrusTAlgorithm.branch("2.3");
 
+    /** 1.3.36.3.3.1 */
     static final ASN1ObjectIdentifier teleTrusTRSAsignatureAlgorithm = teleTrusTAlgorithm.branch("3.1");
 
-    static final ASN1ObjectIdentifier    rsaSignatureWithripemd160           = teleTrusTRSAsignatureAlgorithm.branch("2");
-    static final ASN1ObjectIdentifier    rsaSignatureWithripemd128           = teleTrusTRSAsignatureAlgorithm.branch("3");
-    static final ASN1ObjectIdentifier    rsaSignatureWithripemd256           = teleTrusTRSAsignatureAlgorithm.branch("4");
+    /** 1.3.36.3.3.1.2 */
+    static final ASN1ObjectIdentifier rsaSignatureWithripemd160      = teleTrusTRSAsignatureAlgorithm.branch("2");
+    /** 1.3.36.3.3.1.3 */
+    static final ASN1ObjectIdentifier rsaSignatureWithripemd128      = teleTrusTRSAsignatureAlgorithm.branch("3");
+    /** 1.3.36.3.3.1.4 */
+    static final ASN1ObjectIdentifier rsaSignatureWithripemd256      = teleTrusTRSAsignatureAlgorithm.branch("4");
 
-    static final ASN1ObjectIdentifier    ecSign = teleTrusTAlgorithm.branch("3.2");
+    /** 1.3.36.3.3.2 */
+    static final ASN1ObjectIdentifier    ecSign               = teleTrusTAlgorithm.branch("3.2");
 
-    static final ASN1ObjectIdentifier    ecSignWithSha1  = ecSign.branch("1");
+    /** 1.3.36.3.3.2,1 */
+    static final ASN1ObjectIdentifier    ecSignWithSha1       = ecSign.branch("1");
+    /** 1.3.36.3.3.2.2 */
     static final ASN1ObjectIdentifier    ecSignWithRipemd160  = ecSign.branch("2");
 
+    /** 1.3.36.3.3.2.8 */
     static final ASN1ObjectIdentifier ecc_brainpool = teleTrusTAlgorithm.branch("3.2.8");
+    /** 1.3.36.3.3.2.8.1 */
     static final ASN1ObjectIdentifier ellipticCurve = ecc_brainpool.branch("1");
+    /** 1.3.36.3.3.2.8.1 */
     static final ASN1ObjectIdentifier versionOne = ellipticCurve.branch("1");
 
+    /** 1.3.36.3.3.2.8.1.1 */
     static final ASN1ObjectIdentifier brainpoolP160r1 = versionOne.branch("1");
+    /** 1.3.36.3.3.2.8.1.2 */
     static final ASN1ObjectIdentifier brainpoolP160t1 = versionOne.branch("2");
+    /** 1.3.36.3.3.2.8.1.3 */
     static final ASN1ObjectIdentifier brainpoolP192r1 = versionOne.branch("3");
+    /** 1.3.36.3.3.2.8.1.4 */
     static final ASN1ObjectIdentifier brainpoolP192t1 = versionOne.branch("4");
+    /** 1.3.36.3.3.2.8.1.5 */
     static final ASN1ObjectIdentifier brainpoolP224r1 = versionOne.branch("5");
+    /** 1.3.36.3.3.2.8.1.6 */
     static final ASN1ObjectIdentifier brainpoolP224t1 = versionOne.branch("6");
+    /** 1.3.36.3.3.2.8.1.7 */
     static final ASN1ObjectIdentifier brainpoolP256r1 = versionOne.branch("7");
+    /** 1.3.36.3.3.2.8.1.8 */
     static final ASN1ObjectIdentifier brainpoolP256t1 = versionOne.branch("8");
+    /** 1.3.36.3.3.2.8.1.9 */
     static final ASN1ObjectIdentifier brainpoolP320r1 = versionOne.branch("9");
+    /** 1.3.36.3.3.2.8.1.10 */
     static final ASN1ObjectIdentifier brainpoolP320t1 = versionOne.branch("10");
+    /** 1.3.36.3.3.2.8.1.11 */
     static final ASN1ObjectIdentifier brainpoolP384r1 = versionOne.branch("11");
+    /** 1.3.36.3.3.2.8.1.12 */
     static final ASN1ObjectIdentifier brainpoolP384t1 = versionOne.branch("12");
+    /** 1.3.36.3.3.2.8.1.13 */
     static final ASN1ObjectIdentifier brainpoolP512r1 = versionOne.branch("13");
+    /** 1.3.36.3.3.2.8.1.14 */
     static final ASN1ObjectIdentifier brainpoolP512t1 = versionOne.branch("14");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/ua/UAObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ua/UAObjectIdentifiers.java
@@ -2,15 +2,22 @@ package org.bouncycastle.asn1.ua;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * Ukrainian object identifiers
+ * <p>
+ * {iso(1) member-body(2) Ukraine(804) root(2) security(1) cryptography(1) pki(1)}
+ * <p>
+ * { ...  pki-alg(1) pki-alg-sym(3) Dstu4145WithGost34311(1) PB(1)}
+ * <p>
+ * DSTU4145 in polynomial basis has 2 oids, one for little-endian representation and one for big-endian
+ */
 public interface UAObjectIdentifiers
 {
-    // Ukrainian object identifiers
-    // {iso(1) member-body(2) Ukraine(804 ) root(2) security(1) cryptography(1) pki(1)}
-
+    /** Base OID: 1.2.804.2.1.1.1 */
     static final ASN1ObjectIdentifier UaOid = new ASN1ObjectIdentifier("1.2.804.2.1.1.1");
 
-    // {pki-alg(1) pki-alg-�sym(3) Dstu4145WithGost34311(1) PB(1)}
-    // DSTU4145 in polynomial basis has 2 oids, one for little-endian representation and one for big-endian
+    /** DSTU4145 Little Endian presentation.  OID: 1.2.804.2.1.1.1.1.3.1.1 */
     static final ASN1ObjectIdentifier dstu4145le = UaOid.branch("1.3.1.1");
+    /** DSTU4145 Big Endian presentation.  OID: 1.2.804.2.1.1.1.1.3.1.1.1 */
     static final ASN1ObjectIdentifier dstu4145be = UaOid.branch("1.3.1.1.1.1");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/x509/X509ObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/X509ObjectIdentifiers.java
@@ -4,64 +4,78 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
 public interface X509ObjectIdentifiers
 {
-    //
-    // base id
-    //
-    static final String                 id                      = "2.5.4";
+    
+    /** Subject RDN components: commonName = 2.5.4.3 */
+    static final ASN1ObjectIdentifier    commonName              = new ASN1ObjectIdentifier("2.5.4.3");
+    /** Subject RDN components: countryName = 2.5.4.6 */
+    static final ASN1ObjectIdentifier    countryName             = new ASN1ObjectIdentifier("2.5.4.6");
+    /** Subject RDN components: localityName = 2.5.4.7 */
+    static final ASN1ObjectIdentifier    localityName            = new ASN1ObjectIdentifier("2.5.4.7");
+    /** Subject RDN components: stateOrProvinceName = 2.5.4.8 */
+    static final ASN1ObjectIdentifier    stateOrProvinceName     = new ASN1ObjectIdentifier("2.5.4.8");
+    /** Subject RDN components: organization = 2.5.4.10 */
+    static final ASN1ObjectIdentifier    organization            = new ASN1ObjectIdentifier("2.5.4.10");
+    /** Subject RDN components: organizationalUnitName = 2.5.4.11 */
+    static final ASN1ObjectIdentifier    organizationalUnitName  = new ASN1ObjectIdentifier("2.5.4.11");
 
-    static final ASN1ObjectIdentifier    commonName              = new ASN1ObjectIdentifier(id + ".3");
-    static final ASN1ObjectIdentifier    countryName             = new ASN1ObjectIdentifier(id + ".6");
-    static final ASN1ObjectIdentifier    localityName            = new ASN1ObjectIdentifier(id + ".7");
-    static final ASN1ObjectIdentifier    stateOrProvinceName     = new ASN1ObjectIdentifier(id + ".8");
-    static final ASN1ObjectIdentifier    organization            = new ASN1ObjectIdentifier(id + ".10");
-    static final ASN1ObjectIdentifier    organizationalUnitName  = new ASN1ObjectIdentifier(id + ".11");
-
+    /** Subject RDN components: telephone_number = 2.5.4.20 */
     static final ASN1ObjectIdentifier    id_at_telephoneNumber   = new ASN1ObjectIdentifier("2.5.4.20");
-    static final ASN1ObjectIdentifier    id_at_name              = new ASN1ObjectIdentifier(id + ".41");
+    /** Subject RDN components: name = 2.5.4.41 */
+    static final ASN1ObjectIdentifier    id_at_name              = new ASN1ObjectIdentifier("2.5.4.41");
 
-    // id-SHA1 OBJECT IDENTIFIER ::=    
-    //   {iso(1) identified-organization(3) oiw(14) secsig(3) algorithms(2) 26 }    //
+    /**
+     * id-SHA1 OBJECT IDENTIFIER ::=    
+     *   {iso(1) identified-organization(3) oiw(14) secsig(3) algorithms(2) 26 }
+     * <p>
+     * OID: 1.3.14.3.2.27
+     */
     static final ASN1ObjectIdentifier    id_SHA1                 = new ASN1ObjectIdentifier("1.3.14.3.2.26");
 
-    //
-    // ripemd160 OBJECT IDENTIFIER ::=
-    //      {iso(1) identified-organization(3) TeleTrust(36) algorithm(3) hashAlgorithm(2) RIPEMD-160(1)}
-    //
+    /**
+     * ripemd160 OBJECT IDENTIFIER ::=
+     *      {iso(1) identified-organization(3) TeleTrust(36) algorithm(3) hashAlgorithm(2) RIPEMD-160(1)}
+     * <p>
+     * OID: 1.3.36.3.2.1
+     */
     static final ASN1ObjectIdentifier    ripemd160               = new ASN1ObjectIdentifier("1.3.36.3.2.1");
 
-    //
-    // ripemd160WithRSAEncryption OBJECT IDENTIFIER ::=
-    //      {iso(1) identified-organization(3) TeleTrust(36) algorithm(3) signatureAlgorithm(3) rsaSignature(1) rsaSignatureWithripemd160(2) }
-    //
+    /**
+     * ripemd160WithRSAEncryption OBJECT IDENTIFIER ::=
+     *      {iso(1) identified-organization(3) TeleTrust(36) algorithm(3) signatureAlgorithm(3) rsaSignature(1) rsaSignatureWithripemd160(2) }
+     * <p>
+     * OID: 1.3.36.3.3.1.2
+     */
     static final ASN1ObjectIdentifier    ripemd160WithRSAEncryption = new ASN1ObjectIdentifier("1.3.36.3.3.1.2");
 
 
+    /** OID: 2.5.8.1.1  */
     static final ASN1ObjectIdentifier    id_ea_rsa = new ASN1ObjectIdentifier("2.5.8.1.1");
     
-    // id-pkix
-    static final ASN1ObjectIdentifier id_pkix = new ASN1ObjectIdentifier("1.3.6.1.5.5.7");
+    /** id-pkix OID: 1.3.6.1.5.5.7
+     */
+    static final ASN1ObjectIdentifier  id_pkix = new ASN1ObjectIdentifier("1.3.6.1.5.5.7");
 
-    //
-    // private internet extensions
-    //
-    static final ASN1ObjectIdentifier  id_pe = new ASN1ObjectIdentifier(id_pkix + ".1");
+    /**
+     * private internet extensions; OID = 1.3.6.1.5.5.7.1
+     */
+    static final ASN1ObjectIdentifier  id_pe   = id_pkix.branch("1");
 
-    //
-    // ISO ARC for standard certificate and CRL extensions
-    //
+    /**
+     * ISO ARC for standard certificate and CRL extensions
+     * <p>
+     * OID: 2.5.29
+     */
     static final ASN1ObjectIdentifier id_ce = new ASN1ObjectIdentifier("2.5.29");
 
-    //
-    // authority information access
-    //
-    static final ASN1ObjectIdentifier  id_ad = new ASN1ObjectIdentifier(id_pkix + ".48");
-    static final ASN1ObjectIdentifier  id_ad_caIssuers = new ASN1ObjectIdentifier(id_ad + ".2");
-    static final ASN1ObjectIdentifier  id_ad_ocsp = new ASN1ObjectIdentifier(id_ad + ".1");
+    /** id-pkix OID:         1.3.6.1.5.5.7.48  */
+    static final ASN1ObjectIdentifier  id_ad           = id_pkix.branch("48");
+    /** id-ad-caIssuers OID: 1.3.6.1.5.5.7.48.2  */
+    static final ASN1ObjectIdentifier  id_ad_caIssuers = id_ad.branch("2");
+    /** id-ad-ocsp OID:      1.3.6.1.5.5.7.48.1  */
+    static final ASN1ObjectIdentifier  id_ad_ocsp      = id_ad.branch("1");
 
-    //
-    //    OID for ocsp and crl uri in AuthorityInformationAccess extension
-    //
+    /** OID for ocsp uri in AuthorityInformationAccess extension */
     static final ASN1ObjectIdentifier ocspAccessMethod = id_ad_ocsp;
-    static final ASN1ObjectIdentifier crlAccessMethod = id_ad_caIssuers;
+    /** OID for crl uri in AuthorityInformationAccess extension */
+    static final ASN1ObjectIdentifier crlAccessMethod  = id_ad_caIssuers;
 }
-

--- a/core/src/main/java/org/bouncycastle/asn1/x509/qualified/ETSIQCObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/qualified/ETSIQCObjectIdentifiers.java
@@ -4,13 +4,8 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
 public interface ETSIQCObjectIdentifiers
 {
-    //
-    // base id
-    //
-    static final ASN1ObjectIdentifier    id_etsi_qcs                  = new ASN1ObjectIdentifier("0.4.0.1862.1");
-
-    static final ASN1ObjectIdentifier    id_etsi_qcs_QcCompliance     = id_etsi_qcs.branch("1");
-    static final ASN1ObjectIdentifier    id_etsi_qcs_LimiteValue      = id_etsi_qcs.branch("2");
-    static final ASN1ObjectIdentifier    id_etsi_qcs_RetentionPeriod  = id_etsi_qcs.branch("3");
-    static final ASN1ObjectIdentifier    id_etsi_qcs_QcSSCD           = id_etsi_qcs.branch("4");
+    static final ASN1ObjectIdentifier    id_etsi_qcs_QcCompliance     = new ASN1ObjectIdentifier("0.4.0.1862.1.1");
+    static final ASN1ObjectIdentifier    id_etsi_qcs_LimiteValue      = new ASN1ObjectIdentifier("0.4.0.1862.1.2");
+    static final ASN1ObjectIdentifier    id_etsi_qcs_RetentionPeriod  = new ASN1ObjectIdentifier("0.4.0.1862.1.3");
+    static final ASN1ObjectIdentifier    id_etsi_qcs_QcSSCD           = new ASN1ObjectIdentifier("0.4.0.1862.1.4");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/x509/qualified/RFC3739QCObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/qualified/RFC3739QCObjectIdentifiers.java
@@ -4,11 +4,8 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
 public interface RFC3739QCObjectIdentifiers
 {
-    //
-    // base id
-    //
-    static final ASN1ObjectIdentifier   id_qcs             = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.11");
-
-    static final ASN1ObjectIdentifier   id_qcs_pkixQCSyntax_v1  = id_qcs.branch("1");
-    static final ASN1ObjectIdentifier   id_qcs_pkixQCSyntax_v2  = id_qcs.branch("2");
+    /** OID: 1.3.6.1.5.5.7.11.1 */
+    static final ASN1ObjectIdentifier   id_qcs_pkixQCSyntax_v1  = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.11.1");
+    /** OID: 1.3.6.1.5.5.7.11.2 */
+    static final ASN1ObjectIdentifier   id_qcs_pkixQCSyntax_v2  = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.11.2");
 }

--- a/core/src/main/java/org/bouncycastle/asn1/x509/sigi/SigIObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/sigi/SigIObjectIdentifiers.java
@@ -8,38 +8,53 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
  */
 public interface SigIObjectIdentifiers
 {
+    /**
+     * OID: 1.3.36.8
+     */
     public final static ASN1ObjectIdentifier id_sigi = new ASN1ObjectIdentifier("1.3.36.8");
 
     /**
      * Key purpose IDs for German SigI (Signature Interoperability
      * Specification)
+     * <p>
+     * OID: 1.3.36.8.2
      */
-    public final static ASN1ObjectIdentifier id_sigi_kp = new ASN1ObjectIdentifier(id_sigi + ".2");
+    public final static ASN1ObjectIdentifier id_sigi_kp = new ASN1ObjectIdentifier("1.3.36.8.2");
 
     /**
      * Certificate policy IDs for German SigI (Signature Interoperability
      * Specification)
+     * <p>
+     * OID: 1.3.36.8.1
      */
-    public final static ASN1ObjectIdentifier id_sigi_cp = new ASN1ObjectIdentifier(id_sigi + ".1");
+    public final static ASN1ObjectIdentifier id_sigi_cp = new ASN1ObjectIdentifier("1.3.36.8.1");
 
     /**
      * Other Name IDs for German SigI (Signature Interoperability Specification)
+     * <p>
+     * OID: 1.3.36.8.4
      */
-    public final static ASN1ObjectIdentifier id_sigi_on = new ASN1ObjectIdentifier(id_sigi + ".4");
+    public final static ASN1ObjectIdentifier id_sigi_on = new ASN1ObjectIdentifier("1.3.36.8.4");
 
     /**
      * To be used for for the generation of directory service certificates.
+     * <p>
+     * OID: 1.3.36.8.2.1
      */
-    public static final ASN1ObjectIdentifier id_sigi_kp_directoryService = new ASN1ObjectIdentifier(id_sigi_kp + ".1");
+    public static final ASN1ObjectIdentifier id_sigi_kp_directoryService = new ASN1ObjectIdentifier("1.3.36.8.2.1");
 
     /**
      * ID for PersonalData
+     * <p>
+     * OID: 1.3.36.8.4.1
      */
-    public static final ASN1ObjectIdentifier id_sigi_on_personalData = new ASN1ObjectIdentifier(id_sigi_on + ".1");
+    public static final ASN1ObjectIdentifier id_sigi_on_personalData = new ASN1ObjectIdentifier("1.3.36.8.4.1");
 
     /**
-     * Certificate is conform to german signature law.
+     * Certificate is conformant to german signature law.
+     * <p>
+     * OID: 1.3.36.8.1.1
      */
-    public static final ASN1ObjectIdentifier id_sigi_cp_sigconform = new ASN1ObjectIdentifier(id_sigi_cp + ".1");
+    public static final ASN1ObjectIdentifier id_sigi_cp_sigconform = new ASN1ObjectIdentifier("1.3.36.8.1.1");
 
 }

--- a/core/src/main/java/org/bouncycastle/asn1/x9/X9ObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x9/X9ObjectIdentifiers.java
@@ -2,109 +2,172 @@ package org.bouncycastle.asn1.x9;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ *
+ * X9.62
+ * <pre>
+ * ansi-X9-62 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+ *                                    us(840) ansi-x962(10045) }
+ * </pre>
+ */
 public interface X9ObjectIdentifiers
 {
-    //
-    // X9.62
-    //
-    // ansi-X9-62 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
-    //            us(840) ansi-x962(10045) }
-    //
+    /** Base OID: 1.2.840.10045 */
     static final ASN1ObjectIdentifier ansi_X9_62 = new ASN1ObjectIdentifier("1.2.840.10045");
+
+    /** OID: 1.2.840.10045.1 */
     static final ASN1ObjectIdentifier id_fieldType = ansi_X9_62.branch("1");
 
+    /** OID: 1.2.840.10045.1.1 */
     static final ASN1ObjectIdentifier prime_field = id_fieldType.branch("1");
 
+    /** OID: 1.2.840.10045.1.2 */
     static final ASN1ObjectIdentifier characteristic_two_field = id_fieldType.branch("2");
 
+    /** OID: 1.2.840.10045.1.2.3.1 */
     static final ASN1ObjectIdentifier gnBasis = characteristic_two_field.branch("3.1");
 
+    /** OID: 1.2.840.10045.1.2.3.2 */
     static final ASN1ObjectIdentifier tpBasis = characteristic_two_field.branch("3.2");
 
+    /** OID: 1.2.840.10045.1.2.3.3 */
     static final ASN1ObjectIdentifier ppBasis = characteristic_two_field.branch("3.3");
 
+    /** OID: 1.2.840.10045.4 */
     static final ASN1ObjectIdentifier id_ecSigType = ansi_X9_62.branch("4");
 
-    static final ASN1ObjectIdentifier ecdsa_with_SHA1 = new ASN1ObjectIdentifier(id_ecSigType + ".1");
+    /** OID: 1.2.840.10045.4.1 */
+    static final ASN1ObjectIdentifier ecdsa_with_SHA1 = id_ecSigType.branch("1");
 
+    /** OID: 1.2.840.10045.2 */
     static final ASN1ObjectIdentifier id_publicKeyType = ansi_X9_62.branch("2");
 
+    /** OID: 1.2.840.10045.2.1 */
     static final ASN1ObjectIdentifier id_ecPublicKey = id_publicKeyType.branch("1");
 
+    /** OID: 1.2.840.10045.4.3 */
     static final ASN1ObjectIdentifier ecdsa_with_SHA2 = id_ecSigType.branch("3");
 
+    /** OID: 1.2.840.10045.4.3.1 */
     static final ASN1ObjectIdentifier ecdsa_with_SHA224 = ecdsa_with_SHA2.branch("1");
 
+    /** OID: 1.2.840.10045.4.3.2 */
     static final ASN1ObjectIdentifier ecdsa_with_SHA256 = ecdsa_with_SHA2.branch("2");
 
+    /** OID: 1.2.840.10045.4.3.3 */
     static final ASN1ObjectIdentifier ecdsa_with_SHA384 = ecdsa_with_SHA2.branch("3");
 
+    /** OID: 1.2.840.10045.4.3.4 */
     static final ASN1ObjectIdentifier ecdsa_with_SHA512 = ecdsa_with_SHA2.branch("4");
 
-    //
-    // named curves
-    //
+    /**
+     * Named curves base
+     * <p>
+     * OID: 1.2.840.10045.1
+     */
     static final ASN1ObjectIdentifier ellipticCurve = ansi_X9_62.branch("3");
 
-    //
-    // Two Curves
-    //
+    /**
+     * Two Curves
+     * <p>
+     * OID: 1.2.840.10045.1.0
+     */
     static final ASN1ObjectIdentifier  cTwoCurve = ellipticCurve.branch("0");
 
+    /** Two Curve c2pnb163v1, OID: 1.2.840.10045.1.0.1 */
     static final ASN1ObjectIdentifier c2pnb163v1 = cTwoCurve.branch("1");
+    /** Two Curve c2pnb163v2, OID: 1.2.840.10045.1.0.2 */
     static final ASN1ObjectIdentifier c2pnb163v2 = cTwoCurve.branch("2");
+    /** Two Curve c2pnb163v3, OID: 1.2.840.10045.1.0.3 */
     static final ASN1ObjectIdentifier c2pnb163v3 = cTwoCurve.branch("3");
+    /** Two Curve c2pnb176w1, OID: 1.2.840.10045.1.0.4 */
     static final ASN1ObjectIdentifier c2pnb176w1 = cTwoCurve.branch("4");
+    /** Two Curve c2tnb191v1, OID: 1.2.840.10045.1.0.5 */
     static final ASN1ObjectIdentifier c2tnb191v1 = cTwoCurve.branch("5");
+    /** Two Curve c2tnb191v2, OID: 1.2.840.10045.1.0.6 */
     static final ASN1ObjectIdentifier c2tnb191v2 = cTwoCurve.branch("6");
+    /** Two Curve c2tnb191v3, OID: 1.2.840.10045.1.0.7 */
     static final ASN1ObjectIdentifier c2tnb191v3 = cTwoCurve.branch("7");
+    /** Two Curve c2onb191v4, OID: 1.2.840.10045.1.0.8 */
     static final ASN1ObjectIdentifier c2onb191v4 = cTwoCurve.branch("8");
+    /** Two Curve c2onb191v5, OID: 1.2.840.10045.1.0.9 */
     static final ASN1ObjectIdentifier c2onb191v5 = cTwoCurve.branch("9");
+    /** Two Curve c2pnb208w1, OID: 1.2.840.10045.1.0.10 */
     static final ASN1ObjectIdentifier c2pnb208w1 = cTwoCurve.branch("10");
+    /** Two Curve c2tnb239v1, OID: 1.2.840.10045.1.0.11 */
     static final ASN1ObjectIdentifier c2tnb239v1 = cTwoCurve.branch("11");
+    /** Two Curve c2tnb239v2, OID: 1.2.840.10045.1.0.12 */
     static final ASN1ObjectIdentifier c2tnb239v2 = cTwoCurve.branch("12");
+    /** Two Curve c2tnb239v3, OID: 1.2.840.10045.1.0.13 */
     static final ASN1ObjectIdentifier c2tnb239v3 = cTwoCurve.branch("13");
+    /** Two Curve c2onb239v4, OID: 1.2.840.10045.1.0.14 */
     static final ASN1ObjectIdentifier c2onb239v4 = cTwoCurve.branch("14");
+    /** Two Curve c2onb239v5, OID: 1.2.840.10045.1.0.15 */
     static final ASN1ObjectIdentifier c2onb239v5 = cTwoCurve.branch("15");
+    /** Two Curve c2pnb272w1, OID: 1.2.840.10045.1.0.16 */
     static final ASN1ObjectIdentifier c2pnb272w1 = cTwoCurve.branch("16");
+    /** Two Curve c2pnb304w1, OID: 1.2.840.10045.1.0.17 */
     static final ASN1ObjectIdentifier c2pnb304w1 = cTwoCurve.branch("17");
+    /** Two Curve c2tnb359v1, OID: 1.2.840.10045.1.0.18 */
     static final ASN1ObjectIdentifier c2tnb359v1 = cTwoCurve.branch("18");
+    /** Two Curve c2pnb368w1, OID: 1.2.840.10045.1.0.19 */
     static final ASN1ObjectIdentifier c2pnb368w1 = cTwoCurve.branch("19");
+    /** Two Curve c2tnb431r1, OID: 1.2.840.10045.1.0.20 */
     static final ASN1ObjectIdentifier c2tnb431r1 = cTwoCurve.branch("20");
 
-    //
-    // Prime
-    //
+    /**
+     * Prime Curves
+     * <p>
+     * OID: 1.2.840.10045.1.1
+     */
     static final ASN1ObjectIdentifier primeCurve = ellipticCurve.branch("1");
 
+    /** Prime Curve prime192v1, OID: 1.2.840.10045.1.1.1 */
     static final ASN1ObjectIdentifier prime192v1 = primeCurve.branch("1");
+    /** Prime Curve prime192v2, OID: 1.2.840.10045.1.1.2 */
     static final ASN1ObjectIdentifier prime192v2 = primeCurve.branch("2");
+    /** Prime Curve prime192v3, OID: 1.2.840.10045.1.1.3 */
     static final ASN1ObjectIdentifier prime192v3 = primeCurve.branch("3");
+    /** Prime Curve prime239v1, OID: 1.2.840.10045.1.1.4 */
     static final ASN1ObjectIdentifier prime239v1 = primeCurve.branch("4");
+    /** Prime Curve prime239v2, OID: 1.2.840.10045.1.1.5 */
     static final ASN1ObjectIdentifier prime239v2 = primeCurve.branch("5");
+    /** Prime Curve prime239v3, OID: 1.2.840.10045.1.1.6 */
     static final ASN1ObjectIdentifier prime239v3 = primeCurve.branch("6");
+    /** Prime Curve prime256v1, OID: 1.2.840.10045.1.1.7 */
     static final ASN1ObjectIdentifier prime256v1 = primeCurve.branch("7");
 
-    //
-    // DSA
-    //
-    // dsapublicnumber OBJECT IDENTIFIER ::= { iso(1) member-body(2)
-    //            us(840) ansi-x957(10040) number-type(4) 1 }
+    /**
+     * DSA
+     * <pre>
+     * dsapublicnumber OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+     *                                         us(840) ansi-x957(10040) number-type(4) 1 }
+     * </pre>
+     * Base OID: 1.2.840.10040.4.1
+     */
     static final ASN1ObjectIdentifier id_dsa = new ASN1ObjectIdentifier("1.2.840.10040.4.1");
 
     /**
-     * id-dsa-with-sha1 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) x9-57
-     * (10040) x9cm(4) 3 }
+     * <pre>
+     * id-dsa-with-sha1 OBJECT IDENTIFIER ::= {
+     *     iso(1) member-body(2) us(840) x9-57(10040) x9cm(4) 3 }
+     * </pre>
+     * OID: 1.2.840.10040.4.3
      */
-    public static final ASN1ObjectIdentifier id_dsa_with_sha1 = new ASN1ObjectIdentifier("1.2.840.10040.4.3");
+    static final ASN1ObjectIdentifier id_dsa_with_sha1 = new ASN1ObjectIdentifier("1.2.840.10040.4.3");
 
     /**
-     * X9.63
+     * X9.63 - Signature Specification
+     * <p>
+     * Base OID: 1.3.133.16.840.63.0
      */
-    public static final ASN1ObjectIdentifier x9_63_scheme = new ASN1ObjectIdentifier("1.3.133.16.840.63.0");
-    public static final ASN1ObjectIdentifier dhSinglePass_stdDH_sha1kdf_scheme = x9_63_scheme.branch("2");
-    public static final ASN1ObjectIdentifier dhSinglePass_cofactorDH_sha1kdf_scheme = x9_63_scheme.branch("3");
-    public static final ASN1ObjectIdentifier mqvSinglePass_sha1kdf_scheme = x9_63_scheme.branch("16");
+    static final ASN1ObjectIdentifier x9_63_scheme = new ASN1ObjectIdentifier("1.3.133.16.840.63.0");
+    /** OID: 1.3.133.16.840.63.0.2 */
+    static final ASN1ObjectIdentifier dhSinglePass_stdDH_sha1kdf_scheme      = x9_63_scheme.branch("2");
+    /** OID: 1.3.133.16.840.63.0.3 */
+    static final ASN1ObjectIdentifier dhSinglePass_cofactorDH_sha1kdf_scheme = x9_63_scheme.branch("3");
+    /** OID: 1.3.133.16.840.63.0.16 */
+    static final ASN1ObjectIdentifier mqvSinglePass_sha1kdf_scheme           = x9_63_scheme.branch("16");
 
     /**
      * X9.42
@@ -112,21 +175,33 @@ public interface X9ObjectIdentifiers
 
     static final ASN1ObjectIdentifier ansi_X9_42 = new ASN1ObjectIdentifier("1.2.840.10046");
 
-    //
-    // Diffie-Hellman
-    //
-    // dhpublicnumber OBJECT IDENTIFIER ::= { iso(1) member-body(2)
-    //            us(840) ansi-x942(10046) number-type(2) 1 }
-    //
-    public static final ASN1ObjectIdentifier dhpublicnumber = ansi_X9_42.branch("2.1");
+    /**
+     * Diffie-Hellman
+     * <pre>
+     * dhpublicnumber OBJECT IDENTIFIER ::= {
+     *    iso(1) member-body(2)  us(840) ansi-x942(10046) number-type(2) 1
+     * }
+     * </pre>
+     * OID: 1.2.840.10046.2.1
+     */
+    static final ASN1ObjectIdentifier dhpublicnumber = ansi_X9_42.branch("2.1");
 
-    public static final ASN1ObjectIdentifier x9_42_schemes = ansi_X9_42.branch("3");
-    public static final ASN1ObjectIdentifier dhStatic = x9_42_schemes.branch("1");
-    public static final ASN1ObjectIdentifier dhEphem = x9_42_schemes.branch("2");
-    public static final ASN1ObjectIdentifier dhOneFlow = x9_42_schemes.branch("3");
-    public static final ASN1ObjectIdentifier dhHybrid1 = x9_42_schemes.branch("4");
-    public static final ASN1ObjectIdentifier dhHybrid2 = x9_42_schemes.branch("5");
-    public static final ASN1ObjectIdentifier dhHybridOneFlow = x9_42_schemes.branch("6");
-    public static final ASN1ObjectIdentifier mqv2 = x9_42_schemes.branch("7");
-    public static final ASN1ObjectIdentifier mqv1 = x9_42_schemes.branch("8");
+    /** X9.42 schemas base OID: 1.2.840.10046.3 */
+    static final ASN1ObjectIdentifier x9_42_schemes = ansi_X9_42.branch("3");
+    /** X9.42 dhStatic OID: 1.2.840.10046.3.1 */
+    static final ASN1ObjectIdentifier dhStatic        = x9_42_schemes.branch("1");
+    /** X9.42 dhEphem OID: 1.2.840.10046.3.2 */
+    static final ASN1ObjectIdentifier dhEphem         = x9_42_schemes.branch("2");
+    /** X9.42 dhOneFlow OID: 1.2.840.10046.3.3 */
+    static final ASN1ObjectIdentifier dhOneFlow       = x9_42_schemes.branch("3");
+    /** X9.42 dhHybrid1 OID: 1.2.840.10046.3.4 */
+    static final ASN1ObjectIdentifier dhHybrid1       = x9_42_schemes.branch("4");
+    /** X9.42 dhHybrid2 OID: 1.2.840.10046.3.5 */
+    static final ASN1ObjectIdentifier dhHybrid2       = x9_42_schemes.branch("5");
+    /** X9.42 dhHybridOneFlow OID: 1.2.840.10046.3.6 */
+    static final ASN1ObjectIdentifier dhHybridOneFlow = x9_42_schemes.branch("6");
+    /** X9.42 MQV2 OID: 1.2.840.10046.3.7 */
+    static final ASN1ObjectIdentifier mqv2            = x9_42_schemes.branch("7");
+    /** X9.42 MQV1 OID: 1.2.840.10046.3.8 */
+    static final ASN1ObjectIdentifier mqv1            = x9_42_schemes.branch("8");
 }

--- a/core/src/main/java/org/bouncycastle/pqc/asn1/PQCObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/pqc/asn1/PQCObjectIdentifiers.java
@@ -2,26 +2,45 @@ package org.bouncycastle.pqc.asn1;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
+/**
+ * PQC:
+ * <p>
+ * { iso(1) identifier-organization(3) dod(6) internet(1) private(4) 1 8301 3 1 3 5 3 ... }
+ */
 public interface PQCObjectIdentifiers
 {
+    /** 1.3.6.1.4.1.8301.3.1.3.5.3.2 */
     public static final ASN1ObjectIdentifier rainbow = new ASN1ObjectIdentifier("1.3.6.1.4.1.8301.3.1.3.5.3.2");
 
-    public static final ASN1ObjectIdentifier rainbowWithSha1 = rainbow.branch("1");
+    /** 1.3.6.1.4.1.8301.3.1.3.5.3.2.1 */
+    public static final ASN1ObjectIdentifier rainbowWithSha1   = rainbow.branch("1");
+    /** 1.3.6.1.4.1.8301.3.1.3.5.3.2.2 */
     public static final ASN1ObjectIdentifier rainbowWithSha224 = rainbow.branch("2");
+    /** 1.3.6.1.4.1.8301.3.1.3.5.3.2.3 */
     public static final ASN1ObjectIdentifier rainbowWithSha256 = rainbow.branch("3");
+    /** 1.3.6.1.4.1.8301.3.1.3.5.3.2.4 */
     public static final ASN1ObjectIdentifier rainbowWithSha384 = rainbow.branch("4");
+    /** 1.3.6.1.4.1.8301.3.1.3.5.3.2.5 */
     public static final ASN1ObjectIdentifier rainbowWithSha512 = rainbow.branch("5");
 
+    /** 1.3.6.1.4.1.8301.3.1.3.3 */
     public static final ASN1ObjectIdentifier gmss = new ASN1ObjectIdentifier("1.3.6.1.4.1.8301.3.1.3.3");
 
-    public static final ASN1ObjectIdentifier gmssWithSha1 = gmss.branch("1");
+    /** 1.3.6.1.4.1.8301.3.1.3.3.1 */
+    public static final ASN1ObjectIdentifier gmssWithSha1   = gmss.branch("1");
+    /** 1.3.6.1.4.1.8301.3.1.3.3.2 */
     public static final ASN1ObjectIdentifier gmssWithSha224 = gmss.branch("2");
+    /** 1.3.6.1.4.1.8301.3.1.3.3.3 */
     public static final ASN1ObjectIdentifier gmssWithSha256 = gmss.branch("3");
+    /** 1.3.6.1.4.1.8301.3.1.3.3.4 */
     public static final ASN1ObjectIdentifier gmssWithSha384 = gmss.branch("4");
+    /** 1.3.6.1.4.1.8301.3.1.3.3.5 */
     public static final ASN1ObjectIdentifier gmssWithSha512 = gmss.branch("5");
 
-    public static final ASN1ObjectIdentifier mcEliece = new ASN1ObjectIdentifier("1.3.6.1.4.1.8301.3.1.3.4.1");
+    /** 1.3.6.1.4.1.8301.3.1.3.4.1 */
+    public static final ASN1ObjectIdentifier mcEliece       = new ASN1ObjectIdentifier("1.3.6.1.4.1.8301.3.1.3.4.1");
 
-    public static final ASN1ObjectIdentifier mcElieceCca2 = new ASN1ObjectIdentifier("1.3.6.1.4.1.8301.3.1.3.4.2");
+    /** 1.3.6.1.4.1.8301.3.1.3.4.2 */
+    public static final ASN1ObjectIdentifier mcElieceCca2   = new ASN1ObjectIdentifier("1.3.6.1.4.1.8301.3.1.3.4.2");
 
 }


### PR DESCRIPTION
These classes are defining complex constants, which on JavaDoc are usually completely lacking documentation.
This set creates those documents.

At least have full form of the numeric OID listed on particular definition.

I did clean some of superfluous 'public' definitions on values inside the 'interface'.  Apparently more could be cleaned.
