### PR TITLE
Exception testing for CTS mode

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/modes/CTSBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/CTSBlockCipher.java
@@ -22,8 +22,9 @@ public class CTSBlockCipher
     public CTSBlockCipher(
         BlockCipher     cipher)
     {
-        if ((cipher instanceof OFBBlockCipher) || (cipher instanceof CFBBlockCipher))
+        if ((cipher instanceof OFBBlockCipher) || (cipher instanceof CFBBlockCipher) || (cipher instanceof SICBlockCipher))
         {
+            // TODO: This is broken - need to introduce marker interface to differentiate block cipher primitive from mode?
             throw new IllegalArgumentException("CTSBlockCipher can only accept ECB, or CBC ciphers");
         }
 
@@ -239,6 +240,11 @@ public class CTSBlockCipher
         }
         else
         {
+            if (bufOff < blockSize)
+            {
+                throw new DataLengthException("need at least one block of input for CTS");
+            }
+
             byte[]  lastBlock = new byte[blockSize];
 
             if (cipher instanceof CBCBlockCipher)

--- a/core/src/test/java/org/bouncycastle/crypto/test/CTSTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/CTSTest.java
@@ -3,12 +3,15 @@ package org.bouncycastle.crypto.test;
 import org.bouncycastle.crypto.BlockCipher;
 import org.bouncycastle.crypto.BufferedBlockCipher;
 import org.bouncycastle.crypto.CipherParameters;
+import org.bouncycastle.crypto.DataLengthException;
+import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.engines.DESEngine;
 import org.bouncycastle.crypto.engines.SkipjackEngine;
 import org.bouncycastle.crypto.modes.CBCBlockCipher;
 import org.bouncycastle.crypto.modes.CTSBlockCipher;
 import org.bouncycastle.crypto.modes.OldCTSBlockCipher;
+import org.bouncycastle.crypto.modes.SICBlockCipher;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.crypto.params.ParametersWithIV;
 import org.bouncycastle.util.encoders.Hex;
@@ -94,6 +97,66 @@ public class CTSTest
         }
     }
 
+    private void testExceptions() throws InvalidCipherTextException
+    {
+        BufferedBlockCipher engine = new CTSBlockCipher(new DESEngine());
+        CipherParameters params = new KeyParameter(new byte[engine.getBlockSize()]);
+        engine.init(true, params);
+
+        byte[] out = new byte[engine.getOutputSize(engine.getBlockSize())];
+        
+        engine.processBytes(new byte[engine.getBlockSize() - 1], 0, engine.getBlockSize() - 1, out, 0);
+        try 
+        {
+            engine.doFinal(out, 0);
+            fail("Expected CTS encrypt error on < 1 block input");
+        } catch(DataLengthException e)
+        {
+            // Expected
+        }
+
+        engine.init(true, params);
+        engine.processBytes(new byte[engine.getBlockSize()], 0, engine.getBlockSize(), out, 0);
+        try 
+        {
+            engine.doFinal(out, 0);
+        } catch(DataLengthException e)
+        {
+            fail("Unexpected CTS encrypt error on == 1 block input");
+        }
+
+        engine.init(false, params);
+        engine.processBytes(new byte[engine.getBlockSize() - 1], 0, engine.getBlockSize() - 1, out, 0);
+        try 
+        {
+            engine.doFinal(out, 0);
+            fail("Expected CTS decrypt error on < 1 block input");
+        } catch(DataLengthException e)
+        {
+            // Expected
+        }
+
+        engine.init(false, params);
+        engine.processBytes(new byte[engine.getBlockSize()], 0, engine.getBlockSize(), out, 0);
+        try 
+        {
+            engine.doFinal(out, 0);
+        } catch(DataLengthException e)
+        {
+            fail("Unexpected CTS decrypt error on == 1 block input");
+        }
+
+        try 
+        {
+            new CTSBlockCipher(new SICBlockCipher(new AESEngine()));
+            fail("Expected CTS construction error - only ECB/CBC supported.");
+        } catch(IllegalArgumentException e)
+        {
+            // Expected
+        }
+
+    }
+
     public String getName()
     {
         return "CTS";
@@ -135,6 +198,8 @@ public class CTSTest
 
         testCTS(7, new CBCBlockCipher(new AESEngine()), new ParametersWithIV(new KeyParameter(aes128), new byte[16]), aes1Block, pstErrata);
         testOldCTS(7, new CBCBlockCipher(new AESEngine()), new ParametersWithIV(new KeyParameter(aes128), new byte[16]), aes1Block, preErrata);
+
+        testExceptions();
     }
 
     public static void main(


### PR DESCRIPTION
Add exception testing (as already exist for other modes) for CTS mode.
Fix a couple of minor issues arising from those tests.

Added TODO to fix hacky checking of cipher compatibility when there is a stable mechanism to differentiate primitive block ciphers from block cipher modes - BC isn't very clean about the block cipher/block cipher mode separation.
