### PR TITLE
small typo in comment in BouncyCastleProvider.java

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jce/provider/BouncyCastleProvider.java
+++ b/prov/src/main/java/org/bouncycastle/jce/provider/BouncyCastleProvider.java
@@ -100,7 +100,7 @@ public final class BouncyCastleProvider extends Provider
     };
 
     /*
-     * Configurable digests
+     * Configurable keystores
      */
     private static final String KEYSTORE_PACKAGE = "org.bouncycastle.jcajce.provider.keystore.";
     private static final String[] KEYSTORES =


### PR DESCRIPTION
The items following this comment are keystores, not digests.
