### PR TITLE
Reduce data copying in CCM mode

### DIFF
--- a/core/src/main/java/org/bouncycastle/util/io/AccessibleByteArrayOutputStream.java
+++ b/core/src/main/java/org/bouncycastle/util/io/AccessibleByteArrayOutputStream.java
@@ -1,0 +1,25 @@
+package org.bouncycastle.util.io;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * {@link ByteArrayOutputStream} that allows access to the internal byte buffer.
+ */
+public class AccessibleByteArrayOutputStream extends ByteArrayOutputStream
+{
+
+    public AccessibleByteArrayOutputStream()
+    {
+    }
+
+    public AccessibleByteArrayOutputStream(int size)
+    {
+        super(size);
+    }
+
+    public byte[] getBuffer()
+    {
+        return this.buf;
+    }
+
+}

--- a/core/src/test/java/org/bouncycastle/crypto/test/CCMTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/CCMTest.java
@@ -88,7 +88,7 @@ public class CCMTest
         {
             ccm.init(false, new AEADParameters(new KeyParameter(K1), 32, N2, A2));
             
-            ccm.processPacket(C2, 0, C2.length);
+            ccm.processPacket(C2, 0, C2.length, new byte[100], 0);
             
             fail("invalid cipher text not picked up");
         }


### PR DESCRIPTION
Remove unnecessary data copying in the CCM mode implementation:
- ByteArrayOutputStream buffers for AD and data are accessed directly to avoid extra allocate+copy of each
- The output buffer is used directly by processPacket output without allocate+copy of a temporary buffer
