### PR TITLE
Relax certificate test - was dependent on build-machine timezone

### DIFF
--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/nist/NistCertPathTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/nist/NistCertPathTest.java
@@ -206,7 +206,7 @@ public class NistCertPathTest
                 new String[] { "NegativeSerialNumberCACert", "InvalidNegativeSerialNumberTest15EE" }, 
                 new String[] { TRUST_ANCHOR_ROOT_CRL, "NegativeSerialNumberCACRL" },
                 0,
-                "Certificate revocation after Fri Apr 20 00:57:20", "reason: keyCompromise");
+                "Certificate revocation after ", "reason: keyCompromise");
     }
     
     //

--- a/prov/src/test/jdk1.3/org/bouncycastle/jce/provider/test/nist/NistCertPathTest.java
+++ b/prov/src/test/jdk1.3/org/bouncycastle/jce/provider/test/nist/NistCertPathTest.java
@@ -206,7 +206,7 @@ public class NistCertPathTest
                 new String[] { "NegativeSerialNumberCACert", "InvalidNegativeSerialNumberTest15EE" }, 
                 new String[] { TRUST_ANCHOR_ROOT_CRL, "NegativeSerialNumberCACRL" },
                 0,
-                "Certificate revocation after Fri Apr 20 00:57:20", "reason: keyCompromise");
+                "Certificate revocation after ", "reason: keyCompromise");
     }
     
     //


### PR DESCRIPTION
In my London-based JVM, the date was actually Apr 19th, and the asserted string did not match.
