### PR TITLE
Gradle: Specify version of JUnit to avoid unreproducible builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ subprojects {
     }
 
     dependencies {
-        testCompile group: 'junit', name: 'junit', version: '4.+'
+        testCompile group: 'junit', name: 'junit', version: '4.11'
     }
 
     sourceCompatibility = 1.5


### PR DESCRIPTION
Another reason for this change is that it stops Gradle from making unnecessary trips to the network to verify if it has the latest version of JUnit.

ie, on my laptop, even after many successful builds, it was still possible to get this error if disconnected from the internet:

```
$ gradle test

FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all dependencies for configuration ':core:testCompile'.
> Could not resolve junit:junit:4.+.
  Required by:
      spongycastle:core:1.50-b01
   > Failed to list versions for junit:junit:4.+.
      > Could not list versions using M2 pattern 'http://repo1.maven.org/maven2/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]'.
         > Could not GET 'http://repo1.maven.org/maven2/junit/junit/'.
            > repo1.maven.org
```
