### PR TITLE
Format cert-revocation date in GMT to avoid timezone-dependent tests

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jce/provider/RFC3280CertPathUtilities.java
+++ b/prov/src/main/java/org/bouncycastle/jce/provider/RFC3280CertPathUtilities.java
@@ -14,6 +14,7 @@ import java.security.cert.PKIXCertPathChecker;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.security.cert.X509Extension;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -24,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.Vector;
 
 import javax.security.auth.x500.X500Principal;
@@ -2004,7 +2006,9 @@ public class RFC3280CertPathUtilities
         }
         if (certStatus.getCertStatus() != CertStatus.UNREVOKED)
         {
-            String message = "Certificate revocation after " + certStatus.getRevocationDate();
+            SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            String message = "Certificate revocation after " + df.format(certStatus.getRevocationDate());
             message += ", reason: " + crlReasons[certStatus.getCertStatus()];
             throw new AnnotatedException(message);
         }

--- a/prov/src/main/jdk1.1/org/bouncycastle/jce/provider/PKIXCertPathValidatorSpi.java
+++ b/prov/src/main/jdk1.1/org/bouncycastle/jce/provider/PKIXCertPathValidatorSpi.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import org.bouncycastle.jce.X509Principal;
 import org.bouncycastle.jce.PrincipalUtil;
@@ -1898,8 +1899,10 @@ public class PKIXCertPathValidatorSpi extends CertPathValidatorSpi
                             reason = crlReasons[reasonCode.getValue().intValue()];
                         }
                     }
-                    
-                    String message = "Certificate revocation after " + crl_entry.getRevocationDate();
+
+                    SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
+                    df.setTimeZone(TimeZone.getTimeZone("UTC"));
+                    String message = "Certificate revocation after " + df.format(crl_entry.getRevocationDate());
                     
                     if (reason != null)
                     {

--- a/prov/src/main/jdk1.3/org/bouncycastle/jce/provider/RFC3280CertPathUtilities.java
+++ b/prov/src/main/jdk1.3/org/bouncycastle/jce/provider/RFC3280CertPathUtilities.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.Vector;
 
 import org.bouncycastle.asn1.ASN1Encodable;
@@ -2017,7 +2018,9 @@ public class RFC3280CertPathUtilities
         }
         if (certStatus.getCertStatus() != CertStatus.UNREVOKED)
         {
-            String message = "Certificate revocation after " + certStatus.getRevocationDate();
+            SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            String message = "Certificate revocation after " + df.format(certStatus.getRevocationDate());
             message += ", reason: " + crlReasons[certStatus.getCertStatus()];
             throw new AnnotatedException(message);
         }

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/nist/NistCertPathTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/nist/NistCertPathTest.java
@@ -206,7 +206,7 @@ public class NistCertPathTest
                 new String[] { "NegativeSerialNumberCACert", "InvalidNegativeSerialNumberTest15EE" }, 
                 new String[] { TRUST_ANCHOR_ROOT_CRL, "NegativeSerialNumberCACRL" },
                 0,
-                "Certificate revocation after Fri Apr 20 00:57:20", "reason: keyCompromise");
+                "Certificate revocation after 2001-04-19 14:57:20 +0000", "reason: keyCompromise");
     }
     
     //

--- a/prov/src/test/jdk1.3/org/bouncycastle/jce/provider/test/nist/NistCertPathTest.java
+++ b/prov/src/test/jdk1.3/org/bouncycastle/jce/provider/test/nist/NistCertPathTest.java
@@ -206,7 +206,7 @@ public class NistCertPathTest
                 new String[] { "NegativeSerialNumberCACert", "InvalidNegativeSerialNumberTest15EE" }, 
                 new String[] { TRUST_ANCHOR_ROOT_CRL, "NegativeSerialNumberCACRL" },
                 0,
-                "Certificate revocation after Fri Apr 20 00:57:20", "reason: keyCompromise");
+                "Certificate revocation after 2001-04-19 14:57:20 +0000", "reason: keyCompromise");
     }
     
     //


### PR DESCRIPTION
In my London-based JVM, the date was actually Apr 19th, and the
asserted string in NistCertPathTest did not match.

This is an alternative to this prior pull-request, which just relaxed
the test condition to ignore the date:

https://github.com/bcgit/bc-java/pull/45#issuecomment-31311148
