### PR TITLE
Fix BcCertTest to use PEMData class that is within the pkix project

### DIFF
--- a/pkix/src/test/java/org/bouncycastle/cert/test/BcCertTest.java
+++ b/pkix/src/test/java/org/bouncycastle/cert/test/BcCertTest.java
@@ -62,7 +62,7 @@ import org.bouncycastle.crypto.params.RSAKeyGenerationParameters;
 import org.bouncycastle.crypto.params.RSAKeyParameters;
 import org.bouncycastle.crypto.params.RSAPrivateCrtKeyParameters;
 import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
-import org.bouncycastle.jce.provider.test.PEMData;
+import org.bouncycastle.cert.test.PEMData;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.ContentVerifierProvider;
 import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;


### PR DESCRIPTION
There are at least two identical PEMData classes, this test failed to
compile because it was using the one defined by the 'prov' tests, rather
than 'pkix'.
