### PR TITLE
Fix some "no such provider" initialisation errors in tests

### DIFF
--- a/pkix/src/test/java/org/bouncycastle/cms/test/MiscDataStreamTest.java
+++ b/pkix/src/test/java/org/bouncycastle/cms/test/MiscDataStreamTest.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.security.KeyPair;
 import java.security.MessageDigest;
+import java.security.Security;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -106,6 +107,7 @@ public class MiscDataStreamTest
         if (!_initialised)
         {
             _initialised = true;
+            Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 
             _signDN   = "O=Bouncy Castle, C=AU";
             _signKP   = CMSTestUtil.makeKeyPair();

--- a/pkix/src/test/java/org/bouncycastle/cms/test/NewAuthenticatedDataStreamTest.java
+++ b/pkix/src/test/java/org/bouncycastle/cms/test/NewAuthenticatedDataStreamTest.java
@@ -3,6 +3,7 @@ package org.bouncycastle.cms.test;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.security.KeyPair;
+import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
@@ -60,6 +61,7 @@ public class NewAuthenticatedDataStreamTest
         if (!_initialised)
         {
             _initialised = true;
+            Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 
             _signDN   = "O=Bouncy Castle, C=AU";
             _signKP   = CMSTestUtil.makeKeyPair();

--- a/pkix/src/test/java/org/bouncycastle/cms/test/NewAuthenticatedDataTest.java
+++ b/pkix/src/test/java/org/bouncycastle/cms/test/NewAuthenticatedDataTest.java
@@ -3,6 +3,7 @@ package org.bouncycastle.cms.test;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
@@ -75,6 +76,7 @@ public class NewAuthenticatedDataTest
         if (!_initialised)
         {
             _initialised = true;
+            Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 
             _signDN   = "O=Bouncy Castle, C=AU";
             _signKP   = CMSTestUtil.makeKeyPair();

--- a/pkix/src/test/java/org/bouncycastle/cms/test/NewEnvelopedDataTest.java
+++ b/pkix/src/test/java/org/bouncycastle/cms/test/NewEnvelopedDataTest.java
@@ -1,13 +1,7 @@
 package org.bouncycastle.cms.test;
 
 import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.security.Key;
-import java.security.KeyFactory;
-import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.PrivateKey;
+import java.security.*;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.security.spec.MGF1ParameterSpec;
@@ -228,6 +222,7 @@ public class NewEnvelopedDataTest
         if (!_initialised)
         {
             _initialised = true;
+            Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 
             _signDN   = "O=Bouncy Castle, C=AU";
             _signKP   = CMSTestUtil.makeKeyPair();

--- a/pkix/src/test/java/org/bouncycastle/pkcs/test/PfxPduTest.java
+++ b/pkix/src/test/java/org/bouncycastle/pkcs/test/PfxPduTest.java
@@ -3,11 +3,7 @@ package org.bouncycastle.pkcs.test;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.security.KeyFactory;
-import java.security.KeyStore;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
+import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.security.spec.RSAPrivateCrtKeySpec;
@@ -677,6 +673,11 @@ public class PfxPduTest
         X509CertificateHolder cert = v3CertBuilder.build(new JcaContentSignerBuilder("SHA1withRSA").setProvider(BC).build(caPrivKey));
 
         return new JcaX509CertificateConverter().setProvider(BC).getCertificate(cert);
+    }
+
+    public void setUp()
+    {
+        Security.addProvider(new BouncyCastleProvider());
     }
 
     public void testPfxPdu()

--- a/pkix/src/test/java/org/bouncycastle/tsp/test/NewTSPTest.java
+++ b/pkix/src/test/java/org/bouncycastle/tsp/test/NewTSPTest.java
@@ -4,6 +4,7 @@ import java.io.OutputStream;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -56,6 +57,11 @@ public class NewTSPTest
     extends TestCase
 {
     private static final String BC = BouncyCastleProvider.PROVIDER_NAME;
+
+    public void setUp()
+    {
+        Security.addProvider(new BouncyCastleProvider());
+    }
 
     public void testGeneral()
         throws Exception

--- a/pkix/src/test/java/org/bouncycastle/tsp/test/ParseTest.java
+++ b/pkix/src/test/java/org/bouncycastle/tsp/test/ParseTest.java
@@ -2,6 +2,7 @@ package org.bouncycastle.tsp.test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.Security;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
@@ -11,6 +12,7 @@ import org.bouncycastle.asn1.cmp.PKIFailureInfo;
 import org.bouncycastle.asn1.cmp.PKIStatus;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.tsp.TSPAlgorithms;
 import org.bouncycastle.tsp.TimeStampRequest;
 import org.bouncycastle.tsp.TimeStampResponse;
@@ -357,6 +359,11 @@ public class ParseTest
         {
             fail("request not rejected.");
         }
+    }
+
+    public void setUp()
+    {
+        Security.addProvider(new BouncyCastleProvider());
     }
     
     public void testParsing()


### PR DESCRIPTION
When running the Gradle build, these tests fail because the Bouncy Castle provider has not been registered.
