### PR TITLE
Support IDEA as a PGP block cipher and update IDEA patent verbiage.

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/engines/IDEAEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/IDEAEngine.java
@@ -10,22 +10,12 @@ import org.bouncycastle.crypto.params.KeyParameter;
  * A class that provides a basic International Data Encryption Algorithm (IDEA) engine.
  * <p>
  * This implementation is based on the "HOWTO: INTERNATIONAL DATA ENCRYPTION ALGORITHM"
- * implementation summary by Fauzan Mirza (F.U.Mirza@sheffield.ac.uk). (baring 1 typo at the
+ * implementation summary by Fauzan Mirza (F.U.Mirza@sheffield.ac.uk). (barring 1 typo at the
  * end of the mulinv function!).
  * <p>
  * It can be found at ftp://ftp.funet.fi/pub/crypt/cryptography/symmetric/idea/
  * <p>
- * Note 1: This algorithm is patented in the USA, Japan, and Europe including
- * at least Austria, France, Germany, Italy, Netherlands, Spain, Sweden, Switzerland
- * and the United Kingdom. Non-commercial use is free, however any commercial
- * products are liable for royalties. Please see
- * <a href="http://www.mediacrypt.com">www.mediacrypt.com</a> for
- * further details. This announcement has been included at the request of
- * the patent holders.
- * <p>
- * Note 2: Due to the requests concerning the above, this algorithm is now only
- * included in the extended Bouncy Castle provider and JCE signed jars. It is
- * not included in the default distributions.
+ * Note: This algorithm was patented in the USA, Japan and Europe. These patents expired in 2011/2012. 
  */
 public class IDEAEngine
     implements BlockCipher

--- a/docs/specifications.html
+++ b/docs/specifications.html
@@ -53,17 +53,13 @@ appropriate classpath:
 Some of the algorithms in the Bouncy Castle APIs are patented in some
 places. It is upon the user of the library to be aware of what the
 legal situation is in their own situation, however we have been asked
-to specifically mention the patent below, in the following terms, at
+to specifically mention the patents below, in the following terms, at
 the request of the patent holder. Algorithms that appear here are only
 distributed in the -ext- versions of the provider.
 <p>
-The IDEA encryption algorithm is patented in the USA, Japan, and Europe
-including at least Austria, France, Germany, Italy, Netherlands, Spain, Sweden,
-Switzerland and the United Kingdom. Non-commercial use is free, however
-any commercial products that make use of IDEA are liable for royalties.
-Please see
-<a href="http://www.mediacrypt.com">www.mediacrypt.com</a> for
-further details.
+The IDEA Encryption algorithm was patented in the USA, Japan and Europe.
+These patents expired in 2011/2012, and IDEA is now provided in the standard
+Bouncy Castle provider.
 
 <h2>3.0 Specifications</h2>
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcImplProvider.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcImplProvider.java
@@ -24,6 +24,7 @@ import org.bouncycastle.crypto.engines.CamelliaEngine;
 import org.bouncycastle.crypto.engines.DESEngine;
 import org.bouncycastle.crypto.engines.DESedeEngine;
 import org.bouncycastle.crypto.engines.ElGamalEngine;
+import org.bouncycastle.crypto.engines.IDEAEngine;
 import org.bouncycastle.crypto.engines.RSABlindedEngine;
 import org.bouncycastle.crypto.engines.TwofishEngine;
 import org.bouncycastle.crypto.signers.DSADigestSigner;
@@ -102,6 +103,9 @@ class BcImplProvider
             break;
         case SymmetricKeyAlgorithmTags.DES:
             engine = new DESEngine();
+            break;
+        case SymmetricKeyAlgorithmTags.IDEA:
+            engine = new IDEAEngine();
             break;
         case SymmetricKeyAlgorithmTags.TWOFISH:
             engine = new TwofishEngine();


### PR DESCRIPTION
Fixes #46, and updates the now out of data IDEA patent text.
