### PR TITLE
SipHash KeyGenerator regs in JCE and spec docs.

### DIFF
--- a/docs/specifications.html
+++ b/docs/specifications.html
@@ -719,6 +719,8 @@ change as the draft is finalised.
 <tr><td>HMAC-Skein-256-*</td><td>128, 160, 224, 256</td><td>e.g. HMAC-Skein-256-160</td></tr>
 <tr><td>HMAC-Skein-512-*</td><td>128, 160, 224, 256, 384, 512</td><td>e.g. HMAC-Skein-512-256</td></tr>
 <tr><td>HMAC-Skein-1024-*</td><td>384, 512, 1024</td><td>e.g. HMAC-Skein-1024-1024</td></tr>
+<tr><td>Siphash-2-4 (SipHash)</td><td>64</td><td></td></tr>
+<tr><td>Siphash-4-8</td><td>64</td><td></td></tr>
 <tr><td>Skein-MAC-256-*</td><td>128, 160, 224, 256</td><td>e.g. Skein-MAC-256-160</td></tr>
 <tr><td>Skein-MAC-512-*</td><td>128, 160, 224, 256, 384, 512</td><td>e.g. Skein-MAC-512-256</td></tr>
 <tr><td>Skein-MAC-1024-*</td><td>384, 512, 1024</td><td>e.g. Skein-MAC-1024-1024</td></tr>

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/SipHash.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/SipHash.java
@@ -1,6 +1,8 @@
 package org.bouncycastle.jcajce.provider.symmetric;
 
+import org.bouncycastle.crypto.CipherKeyGenerator;
 import org.bouncycastle.jcajce.provider.config.ConfigurableProvider;
+import org.bouncycastle.jcajce.provider.symmetric.util.BaseKeyGenerator;
 import org.bouncycastle.jcajce.provider.symmetric.util.BaseMac;
 import org.bouncycastle.jcajce.provider.util.AlgorithmProvider;
 
@@ -9,11 +11,11 @@ public final class SipHash
     private SipHash()
     {
     }
-    
-    public static class Mac
+
+    public static class Mac24
         extends BaseMac
     {
-        public Mac()
+        public Mac24()
         {
             super(new org.bouncycastle.crypto.macs.SipHash());
         }
@@ -28,6 +30,15 @@ public final class SipHash
         }
     }
 
+    public static class KeyGen
+        extends BaseKeyGenerator
+    {
+        public KeyGen()
+        {
+            super("SipHash", 128, new CipherKeyGenerator());
+        }
+    }
+
     public static class Mappings
         extends AlgorithmProvider
     {
@@ -39,9 +50,13 @@ public final class SipHash
 
         public void configure(ConfigurableProvider provider)
         {
-            provider.addAlgorithm("Mac.SIPHASH", PREFIX + "$Mac");
-            provider.addAlgorithm("Alg.Alias.Mac.SIPHASH-2-4", "SIPHASH");
+            provider.addAlgorithm("Mac.SIPHASH-2-4", PREFIX + "$Mac24");
+            provider.addAlgorithm("Alg.Alias.Mac.SIPHASH", "SIPHASH-2-4");
             provider.addAlgorithm("Mac.SIPHASH-4-8", PREFIX + "$Mac48");
+
+            provider.addAlgorithm("KeyGenerator.SIPHASH", PREFIX + "$KeyGen");
+            provider.addAlgorithm("Alg.Alias.KeyGenerator.SIPHASH-2-4", "SIPHASH");
+            provider.addAlgorithm("Alg.Alias.KeyGenerator.SIPHASH-4-8", "SIPHASH");
         }
     }
 }

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/SipHashTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/SipHashTest.java
@@ -1,8 +1,13 @@
 package org.bouncycastle.jce.provider.test;
 
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.Security;
 
+import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
+import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -15,6 +20,42 @@ public class SipHashTest
 {
     public void performTest()
         throws Exception
+    {
+        testMac();
+        testKeyGenerator();
+    }
+
+    private void testKeyGenerator()
+        throws NoSuchAlgorithmException,
+        NoSuchProviderException
+    {
+        testKeyGen("SipHash");
+        testKeyGen("SipHash-2-4");
+        testKeyGen("SipHash-4-8");
+    }
+
+    private void testKeyGen(String algorithm)
+        throws NoSuchAlgorithmException,
+        NoSuchProviderException
+    {
+        KeyGenerator kg = KeyGenerator.getInstance(algorithm, "BC");
+
+        SecretKey key = kg.generateKey();
+
+        if (!key.getAlgorithm().equalsIgnoreCase("SipHash"))
+        {
+            fail("Unexpected algorithm name in key", "SipHash", key.getAlgorithm());
+        }
+        if (key.getEncoded().length != 16)
+        {
+            fail("Expected 128 bit key");
+        }
+    }
+
+    private void testMac()
+        throws NoSuchAlgorithmException,
+        NoSuchProviderException,
+        InvalidKeyException
     {
         byte[] key = Hex.decode("000102030405060708090a0b0c0d0e0f");
         byte[] input = Hex.decode("000102030405060708090a0b0c0d0e");


### PR DESCRIPTION
Add KeyGenerator registrations for SipHash in JCE API and add JCE SipHash algorithms to specs.

Also made Mac.SipHash-2-4 the primary algorithm with Mac.SipHash as an alias, as per usage in "SipHash: a fast short-input PRF" where SipHash is the family name.
