### PR TITLE
Support 32-bit and 64-bit tags in GCM.

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/modes/GCMBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/GCMBlockCipher.java
@@ -98,7 +98,8 @@ public class GCMBlockCipher
             initialAssociatedText = param.getAssociatedText();
 
             int macSizeBits = param.getMacSize();
-            if (macSizeBits < 96 || macSizeBits > 128 || macSizeBits % 8 != 0)
+            if ((macSizeBits < 96 || macSizeBits > 128 || macSizeBits % 8 != 0)
+                && macSizeBits != 32 && macSizeBits != 64)
             {
                 throw new IllegalArgumentException("Invalid value for MAC size: " + macSizeBits);
             }


### PR DESCRIPTION
NIST SP 800-38D supports 32-bit and 64-bit tags in GCM for "certain applications" where the developer understands the limitations of using such a small tag size.

See: http://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf

I ran into this issue while implementing a protocol that [uses a 32-bit GCM tag for a certain encrypted field](https://github.com/telehash/telehash.org/blob/master/cs/2a.md).
