### PR TITLE
BCrypt implementation

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/generators/BCrypt.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/BCrypt.java
@@ -26,6 +26,7 @@ public class BCrypt
 
         public EksBlowfishEngine(byte[] salt, int cost)
         {
+            super(false);   // Don't restrict min/max key lengths
             this.salt = Arrays.copyOf(salt, salt.length);
             this.cost = cost;
         }

--- a/core/src/main/java/org/bouncycastle/crypto/generators/BCrypt.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/BCrypt.java
@@ -1,0 +1,133 @@
+package org.bouncycastle.crypto.generators;
+
+import org.bouncycastle.crypto.engines.BlowfishEngine;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.util.Arrays;
+
+/**
+ * Implementation of the <b>bcrypt</b> password hash function from <a
+ * href="http://www.openbsd.org/papers/bcrypt-paper.pdf">A Future Adaptable Password Scheme</a> by
+ * Niels Provos and David Mazieres.
+ * <p>
+ * This implementation implements the raw bcrypt hash function. To produce/consume crypt style
+ * formatted strings use {@link OpenBSDBcrypt}.
+ */
+public class BCrypt
+{
+
+    /**
+     * EksBlowfish - Blowfish encryption with an Expensive Key Schedule.
+     */
+    private static class EksBlowfishEngine
+        extends BlowfishEngine
+    {
+        private final byte[] salt;
+        private final int cost;
+
+        public EksBlowfishEngine(byte[] salt, int cost)
+        {
+            this.salt = Arrays.copyOf(salt, salt.length);
+            this.cost = cost;
+        }
+
+        public String getAlgorithmName()
+        {
+            return "EksBlowfish";
+        }
+
+        /**
+         * Expensive key schedule for bcrypt.
+         */
+        protected void setKey(byte[] key)
+        {
+            // Blowfish is not defined for a zero byte key, so treat empty key as a sequence of zero
+            // valued bytes, which produces the same key setup (as do all zero byte sequences).
+            if (key.length == 0)
+            {
+                key = new byte[4];
+            }
+
+            // Extended key setup, substituting salt words for zeros in original Blowfish
+            setKey(key, new ByteCycle(salt));
+
+            // Repeat standard Blowfish key setup for 2^cost iterations
+            // alternating salt and key as the 'key' input
+            long setupRounds = 1L << cost;
+            // NOTE: long to avoid integer overflow on 1 << 31
+            for (int i = 0; i < setupRounds; i++)
+            {
+                // NOTE: original bcrypt paper has salt/key iteration.
+                // Most implementations (including OpenBSD) do key/salt
+                super.setKey(key);
+                super.setKey(salt);
+            }
+        }
+    }
+
+    /** Base plaintext vector encrypted with Blowfish in the bcrypt algorithm */
+    // OrpheanBeholderScryDoubt
+    private static final byte[] HASH_BASE = {
+        0x4f,0x72,0x70,0x68,0x65,0x61,0x6e,0x42,0x65,0x68,0x6f,0x6c,
+        0x64,0x65,0x72,0x53,0x63,0x72,0x79,0x44,0x6f,0x75,0x62,0x74
+        };
+
+    /** Size of the salt parameter in bytes */
+    static final int SALT_SIZE_BYTES = 16;
+
+    /** Minimum value of cost parameter, equal to log2(bytes of salt) */
+    static final int MIN_COST = 4;
+
+    /** Maximum value of cost parameter (31 == 2,147,483,648) */
+    static final int MAX_COST = 31;
+
+    /** Maximum size of password == max (unrestricted) size of Blowfish key */
+    // Blowfish spec limits keys to 448bit/56 bytes to ensure all bits of key affect all ciphertext
+    // bits, but technically algorithm handles 72 byte keys and most implementations support this.
+    static final int MAX_PASSWORD_BYTES = 72;
+
+    /**
+     * Calculates the <b>bcrypt</b> hash of a password.
+     * <p>
+     * This implements the raw <b>bcrypt</b> function as defined in the bcrypt specification, not
+     * the crypt encoded version implemented in OpenBSD.
+     *
+     * @param password the password bytes (up to 72 bytes) to use for this invocation.
+     * @param salt the 128 bit salt to use for this invocation.
+     * @param cost the bcrypt cost parameter. The cost of the bcrypt function grows as
+     *            <code>2^cost</code>. Legal values are 4..31 inclusive.
+     * @return the output of the raw bcrypt operation: a 192 bit (24 byte) hash.
+     */
+    public static byte[] generate(byte[] password, byte[] salt, int cost)
+    {
+        if (password == null || salt == null)
+        {
+            throw new IllegalArgumentException("Password and salt are required");
+        }
+        if (salt.length != SALT_SIZE_BYTES)
+        {
+            throw new IllegalArgumentException("BCrypt salt must be 128 bits");
+        }
+        if (password.length > MAX_PASSWORD_BYTES)
+        {
+            throw new IllegalArgumentException("BCrypt password must be <= 72 bytes");
+        }
+        if (cost < MIN_COST || cost > MAX_COST)
+        {
+            throw new IllegalArgumentException("BCrypt cost must be from 4..31");
+        }
+
+        EksBlowfishEngine bf = new EksBlowfishEngine(salt, cost);
+        bf.init(true, new KeyParameter(password));
+
+        byte[] ctext = Arrays.copyOf(HASH_BASE, HASH_BASE.length);
+        for (int i = 0; i < 64; i++)
+        {
+            bf.processBlock(ctext, 0, ctext, 0);
+            bf.processBlock(ctext, 8, ctext, 8);
+            bf.processBlock(ctext, 16, ctext, 16);
+        }
+
+        return ctext;
+    }
+
+}

--- a/core/src/main/java/org/bouncycastle/crypto/generators/OpenBSDBcrypt.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/OpenBSDBcrypt.java
@@ -1,0 +1,458 @@
+package org.bouncycastle.crypto.generators;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.security.SecureRandom;
+
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.encoders.Base64Encoder;
+
+/**
+ * Implements the <b>bcrypt</b> password hash function from <a
+ * href="http://www.openbsd.org/papers/bcrypt-paper.pdf">A Future Adaptable Password Scheme</a> as
+ * implemented by OpenBSD (and implementations derived from that).
+ * <p>
+ * This implementation produces/consumes the crypt style formatted string salt/hash strings. To use
+ * the raw BCrypt hash function directly, use the {@link BCrypt} class.
+ * <p>
+ * <b>NOTE:</b> This implementation follows the OpenBSD (and derived implementations by):
+ * <ul>
+ * <li>Supporting passwords up to 72 bytes in length (after conversion from strings where
+ * applicable).</li>
+ * <li>Truncating the last byte of the raw bcrypt hash (returning only 184 bits of hash).</li>
+ * <li>Using the <code>2a</code> variant, where a null byte is added to the end of the passcode. The
+ * <code>2</code>, <code>2a</code>, <code>2b</code> and <code>2y</code> variants are supported for
+ * existing salt/hash values, but are all (except for the original <code>2</code>) treated as
+ * equivalent by this implementation. The <code>2x</code> variant, and the <code>2a</code> 'with
+ * safety' implemented in some crypt libraries are not supported.</li>
+ * <li>Using a custom Base64 encoding alphabet, without padding.</li>
+ * </ul>
+ */
+public class OpenBSDBcrypt
+{
+    /*
+     * Ref: OpenBSD impl http://ftp.usa.openbsd.org/pub/OpenBSD/src/lib/libc/crypt/bcrypt.c (2a/2b
+     * variants)
+     *
+     * Ref: Crypt_Blowfish http://www.openwall.com/crypt/ (2x/2y variants)
+     */
+
+    private static final SecureRandom DEFAULT_RANDOM = new SecureRandom();
+
+    /**
+     * BCrypt parameters, encodable in a hash string.
+     */
+    private static class BCryptParameters
+    {
+        // Original '2' variant is not supported by OpenBSD or crypt_blowfish
+        public static final char VARIANT_NONE = 0;
+        // 'a' signals null termination of key (not in original spec)
+        // NOTE: Openwall crypt_blowfish implements magic collision checking for buggy 'a' impls
+        // This implementation does not have those bugs (see 'y' variant).
+        public static final char VARIANT_A = 'a';
+        // 'b' signals a fix for cost param integer overflow in OpenBSD impl
+        public static final char VARIANT_B = 'b';
+        // 'y' signals a fix for improper sign extension during key bytes -> words in crypt_blowfish
+        public static final char VARIANT_Y = 'y';
+        // 'x' (not implemented) signals explicit harmful sign extension buggy behaviour in
+        // crypt_blowfish - not easy to implement without borking BlowfishEngine
+
+        private char variant;
+        private byte[] salt;
+        private int cost;
+
+        public BCryptParameters(char variant, byte[] salt, int cost)
+        {
+            this.variant = variant;
+            this.salt = salt;
+            this.cost = cost;
+        }
+    }
+
+    /**
+     * Custom Base64 encoder as used in OpenBSD bcrypt implementation.
+     */
+    private static class BCryptBase64Encoder
+        extends Base64Encoder
+    {
+        private static final byte[] ENCODER_TABLE;
+
+        static
+        {
+            // Custom Base64 encoder alphabet
+            final String encodeAlphabet = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+            ENCODER_TABLE = new byte[encodeAlphabet.length()];
+            for (int i = 0; i < encodeAlphabet.length(); i++)
+            {
+                ENCODER_TABLE[i] = (byte)encodeAlphabet.charAt(i);
+            }
+        }
+
+        protected void initialiseDecodingTable()
+        {
+            System.arraycopy(ENCODER_TABLE, 0, encodingTable, 0, ENCODER_TABLE.length);
+            super.initialiseDecodingTable();
+        }
+
+        /**
+         * Base64 encode data, stripping padding bytes.
+         */
+        public int encode(byte[] data, int off, int length, OutputStream out)
+            throws IOException
+        {
+            return super.encode(data, off, length, new Base64PaddingStripper(out));
+        }
+
+        /**
+         * Decode unpadded base64 data, restoring padding if required.
+         */
+        public int decode(byte[] data, int off, int length, OutputStream out)
+            throws IOException
+        {
+            int padding = 4 - (data.length % 4);
+            if (padding != 0)
+            {
+                data = Arrays.copyOf(data, data.length + padding);
+                for (int i = data.length - 1; i >= data.length - padding; i--)
+                {
+                    data[i] = '=';
+                }
+            }
+            return super.decode(data, off, length, out);
+        }
+
+        /**
+         * Decode unpadded base64 data, restoring padding if required.
+         */
+        public int decode(String data, OutputStream out)
+            throws IOException
+        {
+            int padding = 4 - (data.length() % 4);
+            for (int i = 0; i < padding; i++)
+            {
+                data = data + "=";
+            }
+            return super.decode(data, out);
+        }
+    }
+
+    /**
+     * Output stream that drops Base64 padding bytes ('=')
+     */
+    private static class Base64PaddingStripper
+        extends OutputStream
+    {
+        private OutputStream out;
+
+        public Base64PaddingStripper(OutputStream out)
+        {
+            this.out = out;
+        }
+
+        public void write(int b)
+            throws IOException
+        {
+            if (b == '=')
+            {
+                return;
+            }
+            out.write(b);
+        }
+
+    }
+
+    /**
+     * Output stream to Writer adapter that writes ASCII bytes as ASCII chars.
+     */
+    private static class ASCIIWriter
+        extends OutputStream
+    {
+        private Writer writer;
+
+        public ASCIIWriter(Writer writer)
+        {
+            this.writer = writer;
+        }
+
+        public void write(int b)
+            throws IOException
+        {
+            writer.write(b);
+        }
+    }
+
+    /**
+     * String writer with BCrypt style Base64 encoding for data.
+     */
+    private static class BCryptWriter
+        extends StringWriter
+    {
+        private Base64Encoder enc = new BCryptBase64Encoder();
+        private OutputStream b64Out = new ASCIIWriter(this);
+
+        public BCryptWriter()
+        {
+        }
+
+        public void encode(byte[] data, int length)
+            throws IOException
+        {
+            enc.encode(data, 0, length, b64Out);
+        }
+
+    }
+
+    /**
+     * Generate a salt for use with the {@link #hash(String, String)} method. <br/>
+     * A random 128 bit salt will be generated with a platform default {@link SecureRandom}.
+     *
+     * @param cost the bcrypt cost parameter. The cost of the bcrypt function grows as
+     *            <code>2^cost</code>. Legal values are 4..31 inclusive.
+     * @return a string encoding the algorithm identifier, cost and salt.
+     */
+    public static String generateSalt(int cost)
+    {
+        return generateSalt(cost, DEFAULT_RANDOM);
+    }
+
+    /**
+     * Generate a salt for use with the {@link #hash(String, String)} method.
+     *
+     * @param cost the bcrypt cost parameter. The cost of the bcrypt function grows as
+     *            <code>2^cost</code>. Legal values are 4..31 inclusive.
+     * @param rand a source of randomness to generate the 128 bit salt with.
+     * @return a string encoding the algorithm identifier, cost and salt.
+     */
+    public static String generateSalt(int cost, SecureRandom rand)
+    {
+        byte[] salt = new byte[BCrypt.SALT_SIZE_BYTES];
+        rand.nextBytes(salt);
+
+        return encodeSalt(salt, cost);
+    }
+
+    /**
+     * Encodes a pre-generated 128 bit salt and cost for use with the {@link #hash(String, String)}
+     * method.
+     *
+     * @param salt a 128 bit (16 byte) salt.
+     * @param cost the bcrypt cost parameter. The cost of the bcrypt function grows as
+     *            <code>2^cost</code>. Legal values are 4..31 inclusive.
+     * @return a string encoding the algorithm identifier, cost and salt.
+     */
+    public static String encodeSalt(byte[] salt, int cost)
+    {
+        if (salt == null)
+        {
+            throw new IllegalArgumentException("Salt is required");
+        }
+        if (salt.length != BCrypt.SALT_SIZE_BYTES)
+        {
+            throw new IllegalArgumentException("BCrypt salt must be 128 bits");
+        }
+        try
+        {
+            final BCryptWriter encoded = new BCryptWriter();
+            encodeSalt(new BCryptParameters(BCryptParameters.VARIANT_A, salt, cost), encoded);
+            return encoded.toString();
+        }
+        catch (IOException e)
+        {
+            throw new IllegalStateException("Unexpected error.");
+        }
+    }
+
+    private static void encodeSalt(BCryptParameters params, BCryptWriter encoded)
+        throws IOException
+    {
+        encoded.write("$2");
+        if (params.variant != BCryptParameters.VARIANT_NONE)
+        {
+            encoded.write(params.variant);
+        }
+        encoded.write("$");
+        if (params.cost < 10)
+        {
+            encoded.write('0');
+        }
+        encoded.write(Integer.toString(params.cost));
+        encoded.write("$");
+
+        encoded.encode(params.salt, params.salt.length);
+    }
+
+    private static BCryptParameters decodeSalt(String salt)
+    {
+        if (salt.charAt(0) != '$')
+        {
+            throw new IllegalArgumentException("Expected $ at start of salt.");
+        }
+        if (salt.charAt(1) != '2')
+        {
+            throw new IllegalArgumentException("Expected bcrypt identifier (2) in salt.");
+        }
+        char variant = salt.charAt(2);
+        if (variant == '$')
+        {
+            variant = BCryptParameters.VARIANT_NONE;
+            salt = salt.substring(3);
+        }
+        else if (variant == BCryptParameters.VARIANT_A || variant == BCryptParameters.VARIANT_B
+            || variant == BCryptParameters.VARIANT_Y)
+        {
+            salt = salt.substring(4);
+        }
+        else
+        {
+            throw new IllegalArgumentException("Only $2$, $2a$, $2b$ and $2y$ version identifiers are supported.");
+        }
+        if (salt.charAt(2) != '$')
+        {
+            throw new IllegalArgumentException("Missing cost factor.");
+        }
+
+        try
+        {
+            int cost = Integer.parseInt(salt.substring(0, 2));
+            if (cost < BCrypt.MIN_COST || cost > BCrypt.MAX_COST)
+            {
+                throw new IllegalArgumentException("Cost outside legal range.");
+            }
+            salt = salt.substring(3);
+
+            if (salt.length() < 22)
+            {
+                throw new IllegalArgumentException("Encoded salt must be 22 characters");
+            }
+            salt = salt.substring(0, 22);
+
+            BCryptBase64Encoder b64 = new BCryptBase64Encoder();
+            ByteArrayOutputStream saltBytes = new ByteArrayOutputStream();
+            b64.decode(salt, saltBytes);
+            return new BCryptParameters(variant, saltBytes.toByteArray(), cost);
+        }
+        catch (NumberFormatException e)
+        {
+            throw new IllegalArgumentException("Cost is not a valid integer");
+        }
+        catch (IOException e)
+        {
+            throw new IllegalStateException("Unexpected error: " + e);
+        }
+    }
+
+    /**
+     * Calculates the <b>bcrypt</b> hash of a password, converting the password to a UTF-8 encoded
+     * byte sequence prior to {@link #hash(byte[], String) hashing}.
+     *
+     * @param password the password text, which may contain non ASCII characters.
+     * @param salt a {@link #generateSalt(int) bcrypt formatted salt string}, including encoded
+     *            cost.
+     * @return the bcrypt encoded hash, including the algorithm identifier, cost, 128 bit salt and
+     *         184 bit hash value.
+     * @see OpenBSDBcrypt
+     */
+    public static String hash(String password, String salt)
+    {
+        if (password == null)
+        {
+            throw new IllegalArgumentException("Password is required");
+        }
+        try
+        {
+            return hash(password.getBytes("UTF-8"), salt);
+        }
+        catch (UnsupportedEncodingException e)
+        {
+            throw new IllegalStateException("UTF-8 not supported");
+        }
+    }
+
+    /**
+     * Calculates the <b>bcrypt</b> hash of a password and encodes it in a string compatible with
+     * the original OpenBSD bcrypt implementation (e.g <code>$2a$cost$salt+hash</code>).
+     *
+     * @param password the password bytes to use for this invocation, <b>without</b> a trailing null
+     *            byte if that is specified by the algorithm identifier in the salt.
+     * @param salt the 128 bit salt to use for this invocation.
+     * @param cost the bcrypt cost parameter. The cost of the bcrypt function grows as
+     *            <code>2^cost</code>. Legal values are 4..31 inclusive.
+     * @return the bcrypt encoded hash, including the algorithm identifier, cost, 128 bit salt and
+     *         184 bit hash value.
+     * @see OpenBSDBcrypt
+     */
+    public static String hash(byte[] password, String salt)
+    {
+        if (password == null)
+        {
+            throw new IllegalArgumentException("Password is required");
+        }
+        if (salt == null)
+        {
+            throw new IllegalArgumentException("Salt is required");
+        }
+        return hash(password, decodeSalt(salt));
+    }
+
+    private static String hash(byte[] password, BCryptParameters params)
+    {
+        // Follow OpenBSD implementation of $2a mode by including zero terminator of password in key
+        if ((params.variant != BCryptParameters.VARIANT_NONE) && (password.length < BCrypt.MAX_PASSWORD_BYTES))
+        {
+            // Terminate with zero if room: for 72 byte password, zero terminator would be ignored
+            // by Blowfish key schedule anyway
+            password = Arrays.copyOf(password, password.length + 1);
+        }
+
+        byte[] bc = BCrypt.generate(password, params.salt, params.cost);
+
+        final BCryptWriter encoded = new BCryptWriter();
+        try
+        {
+            encodeSalt(params, encoded);
+            // OpenBSD bcrypt and others that follow it faithfully throw away last byte of hash
+            encoded.encode(bc, bc.length - 1);
+            return encoded.toString();
+        }
+        catch (IOException e)
+        {
+            throw new IllegalStateException("Hash encoding failed: " + e);
+        }
+    }
+
+    /**
+     * Verifies a password against a previously generated hash value, converting the password to a
+     * UTF-8 encoded byte sequence prior to hashing.
+     * @param password the password text to hash and verify, which may contain non ASCII characters.
+     * @param hash a {@link #hash(String, String) hashed} password, which also encodes the algorithm
+     *            identifier, cost and salt.
+     *
+     * @return <code>true</code> iff the provided password hashes to the same value as that in the
+     *         provided hash.
+     */
+    public static boolean verify(String password, String hash)
+    {
+        String check = hash(password, hash);
+        return Arrays.constantTimeAreEqual(check.toCharArray(), hash.toCharArray());
+    }
+
+    /**
+     * Verifies a password against a previously generated hash value.
+     * @param password the bytes of the password to hash and verify.
+     * @param hash a {@link #hash(byte[], String) hashed} password, which also encodes the algorithm
+     *            identifier, cost and salt.
+     *
+     * @return <code>true</code> iff the provided password hashes to the same value as that in the
+     *         provided hash.
+     */
+    public static boolean verify(byte[] password, String hash)
+    {
+        String check = hash(password, hash);
+        return Arrays.constantTimeAreEqual(check.toCharArray(), hash.toCharArray());
+    }
+
+}

--- a/core/src/main/java/org/bouncycastle/util/Arrays.java
+++ b/core/src/main/java/org/bouncycastle/util/Arrays.java
@@ -139,6 +139,41 @@ public final class Arrays
         return nonEqual == 0;
     }
 
+    /**
+     * A constant time equals comparison - does not terminate early if test will fail.
+     * 
+     * @param a first array
+     * @param b second array
+     * @return true if arrays equal, false otherwise.
+     */
+    public static boolean constantTimeAreEqual(
+        char[] a,
+        char[] b)
+    {
+        if (a == b)
+        {
+            return true;
+        }
+
+        if (a == null || b == null)
+        {
+            return false;
+        }
+
+        if (a.length != b.length)
+        {
+            return false;
+        }
+
+        int nonEqual = 0;
+
+        for (int i = 0; i != a.length; i++)
+        {
+            nonEqual |= (a[i] ^ b[i]);
+        }
+
+        return nonEqual == 0;
+    }
     public static boolean areEqual(
         int[]  a,
         int[]  b)

--- a/core/src/test/java/org/bouncycastle/crypto/test/BCryptTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/BCryptTest.java
@@ -1,0 +1,150 @@
+package org.bouncycastle.crypto.test;
+
+import org.bouncycastle.crypto.generators.BCrypt;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.encoders.Hex;
+import org.bouncycastle.util.test.SimpleTest;
+
+/*
+ * bcrypt test vectors
+ */
+public class BCryptTest
+    extends SimpleTest
+{
+    // Raw test vectors based on crypt style test vectors
+    // Cross checked with JBCrypt
+    private static final Object[][] testVectors = {
+        {"","144b3d691a7b4ecf39cf735c7fa7a79c",6,"557e94f34bf286e8719a26be94ac1e16d95ef9f819dee092"},
+        {"00","144b3d691a7b4ecf39cf735c7fa7a79c",6,"557e94f34bf286e8719a26be94ac1e16d95ef9f819dee092"},
+        {"00","26c63033c04f8bcba2fe24b574db6274",8,"56701b26164d8f1bc15225f46234ac8ac79bf5bc16bf48ba"},
+        {"00","9b7c9d2ada0fd07091c915d1517701d6",10,"7b2e03106a43c9753821db688b5cc7590b18fdf9ba544632"},
+        {"6100","a3612d8c9a37dac2f99d94da03bd4521",6,"e6d53831f82060dc08a2e8489ce850ce48fbf976978738f3"},
+        {"6100","7a17b15dfe1c4be10ec6a3ab47818386",8,"a9f3469a61cbff0a0f1a1445dfe023587f38b2c9c40570e1"},
+        {"6100","9bef4d04e1f8f92f3de57323f8179190",10,"5169fd39606d630524285147734b4c981def0ee512c3ace1"},
+        {"61626300","2a1f1dc70a3d147956a46febe3016017",6,"d9a275b493bcbe1024b0ff80d330253cfdca34687d8f69e5"},
+        {"61626300","4ead845a142c9bc79918c8797f470ef5",8,"8d4131a723bfbbac8a67f2e035cae08cc33b69f37331ea91"},
+        {"61626300","631c554493327c32f9c26d9be7d18e4c",10,"8cd0b863c3ff0860e31a2b42427974e0283b3af7142969a6"},
+        {"6162636465666768696a6b6c6d6e6f707172737475767778797a00","02d1176d74158ee29cffdac6150cf123",6,"4d38b523ce9dc6f2f6ff9fb3c2cd71dfe7f96eb4a3baf19f"},
+        {"6162636465666768696a6b6c6d6e6f707172737475767778797a00","715b96caed2ac92c354ed16c1e19e38a",8,"98bf9ffc1f5be485f959e8b1d526392fbd4ed2d5719f506b"},
+        {"6162636465666768696a6b6c6d6e6f707172737475767778797a00","85727e838f9049397fbec90566ede0df",10,"cebba53f67bd28af5a44c6707383c231ac4ef244a6f5fb2b"},
+        {"7e21402324255e262a28292020202020207e21402324255e262a2829504e4246524400","8512ae0d0fac4ec9a5978f79b6171028",6,"26f517fe5345ad575ba7dfb8144f01bfdb15f3d47c1e146a"},
+        {"7e21402324255e262a28292020202020207e21402324255e262a2829504e4246524400","1ace2de8807df18c79fced54678f388f",8,"d51d7cdf839b91a25758b80141e42c9f896ae80fd6cd561f"},
+        {"7e21402324255e262a28292020202020207e21402324255e262a2829504e4246524400","36285a6267751b14ba2dc989f6d43126",10,"db4fab24c1ff41c1e2c966f8b3d6381c76e86f52da9e15a9"},
+        {"c2a300","144b3d691a7b4ecf39cf735c7fa7a79c",6,"5a6c4fedb23980a7da9217e0442565ac6145b687c7313339"},
+    };
+
+    public String getName()
+    {
+        return "BCrypt";
+    }
+
+    public void performTest()
+        throws Exception
+    {
+        testParameters();
+        testShortKeys();
+        testVectors();
+    }
+
+    private void testShortKeys()
+    {
+        byte[] salt = new byte[16];
+
+        // Check BCrypt with empty key pads to zero byte key
+        byte[] hashEmpty = BCrypt.generate(new byte[0], salt, 4);
+        byte[] hashZero1 = BCrypt.generate(new byte[1], salt, 4);
+
+        if (!Arrays.areEqual(hashEmpty, hashZero1))
+        {
+            fail("Hash for empty password should equal zeroed key", new String(Hex.encode(hashEmpty)),
+                    new String(Hex.encode(hashZero1)));
+        }
+
+        // Check zeroed byte key of min Blowfish length is equivalent
+        byte[] hashZero4 = BCrypt.generate(new byte[4], salt, 4);
+        if (!Arrays.areEqual(hashEmpty, hashZero4))
+        {
+            fail("Hash for empty password should equal zeroed key[4]", new String(Hex.encode(hashEmpty)), new String(
+                    Hex.encode(hashZero4)));
+        }
+
+        // Check BCrypt isn't padding too small (32 bit) keys
+        byte[] hashA = BCrypt.generate(new byte[]{'a'}, salt, 4);
+        byte[] hashA0 = BCrypt.generate(new byte[]{'a', 0}, salt, 4);
+        if (Arrays.areEqual(hashA, hashA0))
+        {
+            fail("Small keys should not be 0 padded.");
+        }
+    }
+
+    public void testParameters()
+    {
+        checkOK("Empty key", new byte[0], new byte[16], 4);
+        checkOK("Minimal values", new byte[1], new byte[16], 4);
+        // checkOK("Max cost", new byte[1], new byte[16], 31);
+        checkOK("Max passcode", new byte[72], new byte[16], 4);
+        checkIllegal("Null password", null, new byte[16], 4);
+        checkIllegal("Null salt", new byte[1], null, 4);
+        checkIllegal("Salt too small", new byte[1], new byte[15], 4);
+        checkIllegal("Salt too big", new byte[1], new byte[17], 4);
+        checkIllegal("Cost too low", new byte[16], new byte[16], 3);
+        checkIllegal("Cost too high", new byte[16], new byte[16], 32);
+        checkIllegal("Passcode too long", new byte[73], new byte[16], 32);
+    }
+
+    private void checkOK(String msg, byte[] pass, byte[] salt, int cost)
+    {
+        try
+        {
+            BCrypt.generate(pass, salt, cost);
+        }
+        catch (IllegalArgumentException e)
+        {
+            e.printStackTrace();
+            fail(msg);
+        }
+    }
+
+    private void checkIllegal(String msg, byte[] pass, byte[] salt, int cost)
+    {
+        try
+        {
+            BCrypt.generate(pass, salt, cost);
+            fail(msg);
+        }
+        catch (IllegalArgumentException e)
+        {
+            // e.printStackTrace();
+        }
+    }
+
+    public void testVectors()
+        throws Exception
+    {
+        for (int i = 0; i < testVectors.length; i++)
+        {
+            byte[] password = Hex.decode((String)testVectors[i][0]);
+            byte[] salt = Hex.decode((String)testVectors[i][1]);
+            int cost = ((Integer)testVectors[i][2]).intValue();
+            byte[] expected = Hex.decode((String)testVectors[i][3]);
+
+            test(password, salt, cost, expected);
+        }
+
+    }
+
+    private void test(byte[] password, byte[] salt, int cost, byte[] expected)
+    {
+        byte[] hash = BCrypt.generate(password, salt, cost);
+        if (!Arrays.areEqual(hash, expected))
+        {
+            fail("Hash for " + new String(Hex.encode(password)), new String(Hex.encode(expected)),
+                    new String(Hex.encode(hash)));
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new BCryptTest());
+    }
+}

--- a/core/src/test/java/org/bouncycastle/crypto/test/BlowfishTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/BlowfishTest.java
@@ -49,6 +49,65 @@ public class BlowfishTest
         return "Blowfish";
     }
 
+    public void performTest()
+        throws Exception
+    {
+        super.performTest();
+
+        testPasswordLengths();
+    }
+
+    private void testPasswordLengths()
+    {
+        BlowfishEngine engine = new BlowfishEngine();
+
+        // 4 byte (32 bit) key is OK
+        engine.init(true, new KeyParameter(new byte[4]));
+
+        // < 4 bytes not OK
+        try
+        {
+            engine.init(true, new KeyParameter(new byte[3]));
+            fail("< 32 bit key should be disallowed");
+        }
+        catch (IllegalArgumentException e)
+        {
+        }
+
+        // 56 byte (448 bit) OK
+        engine.init(true, new KeyParameter(new byte[56]));
+
+        // > 56 bytes not OK
+        try
+        {
+            engine.init(true, new KeyParameter(new byte[57]));
+            fail("> 448");
+        }
+        catch (IllegalArgumentException e)
+        {
+        }
+
+        // Check unrestricted key size version doesn't care
+        engine = BlowfishEngine.uncheckedKeySize();
+
+        // < 4 byte is OK
+        engine.init(true, new KeyParameter(new byte[4]));
+
+        // 0 byte key is never OK
+        try
+        {
+            engine.init(true, new KeyParameter(new byte[0]));
+            fail("0 bit key should be disallowed");
+        }
+        catch (IllegalArgumentException e)
+        {
+        }
+
+        // > 56 bytes is OK
+        engine.init(true, new KeyParameter(new byte[57]));
+
+    }
+
     public static void main(
         String[]    args)
     {

--- a/core/src/test/java/org/bouncycastle/crypto/test/OpenBSDBCryptTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/OpenBSDBCryptTest.java
@@ -1,0 +1,247 @@
+package org.bouncycastle.crypto.test;
+
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.generators.OpenBSDBcrypt;
+import org.bouncycastle.util.encoders.Hex;
+import org.bouncycastle.util.test.SimpleTest;
+
+/*
+ * OpenBSD style bcrypt test vectors
+ */
+public class OpenBSDBCryptTest
+    extends SimpleTest
+{
+    // Test vectors from JBCrypt, cross-checked with crypt_blowfish
+    private static String[][] testVectors = {
+            { "",                                   "$2a$06$DCq7YPn5Rq63x1Lad4cll.",    "$2a$06$DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s." },
+            { "",                                   "$2a$08$HqWuK6/Ng6sg9gQzbLrgb.",    "$2a$08$HqWuK6/Ng6sg9gQzbLrgb.Tl.ZHfXLhvt/SgVyWhQqgqcZ7ZuUtye" },
+            { "",                                   "$2a$10$k1wbIrmNyFAPwPVPSVa/ze",    "$2a$10$k1wbIrmNyFAPwPVPSVa/zecw2BCEnBwVS2GbrmgzxFUOqW9dk4TCW" },
+//            { "",                                   "$2a$12$k42ZFHFWqBp3vWli.nIn8u",    "$2a$12$k42ZFHFWqBp3vWli.nIn8uYyIkbvYRvodzbfbK18SSsY.CsIQPlxO" },
+            { "a",                                  "$2a$06$m0CrhHm10qJ3lXRY.5zDGO",    "$2a$06$m0CrhHm10qJ3lXRY.5zDGO3rS2KdeeWLuGmsfGlMfOxih58VYVfxe" },
+            { "a",                                  "$2a$08$cfcvVd2aQ8CMvoMpP2EBfe",    "$2a$08$cfcvVd2aQ8CMvoMpP2EBfeodLEkkFJ9umNEfPD18.hUF62qqlC/V." },
+            { "a",                                  "$2a$10$k87L/MF28Q673VKh8/cPi.",    "$2a$10$k87L/MF28Q673VKh8/cPi.SUl7MU/rWuSiIDDFayrKk/1tBsSQu4u" },
+//            { "a",                                  "$2a$12$8NJH3LsPrANStV6XtBakCe",    "$2a$12$8NJH3LsPrANStV6XtBakCez0cKHXVxmvxIlcz785vxAIZrihHZpeS" },
+            { "abc",                                "$2a$06$If6bvum7DFjUnE9p2uDeDu",    "$2a$06$If6bvum7DFjUnE9p2uDeDu0YHzrHM6tf.iqN8.yx.jNN1ILEf7h0i" },
+            { "abc",                                "$2a$08$Ro0CUfOqk6cXEKf3dyaM7O",    "$2a$08$Ro0CUfOqk6cXEKf3dyaM7OhSCvnwM9s4wIX9JeLapehKK5YdLxKcm" },
+            { "abc",                                "$2a$10$WvvTPHKwdBJ3uk0Z37EMR.",    "$2a$10$WvvTPHKwdBJ3uk0Z37EMR.hLA2W6N9AEBhEgrAOljy2Ae5MtaSIUi" },
+//            { "abc",                                "$2a$12$EXRkfkdmXn2gzds2SSitu.",    "$2a$12$EXRkfkdmXn2gzds2SSitu.MW9.gAVqa9eLS1//RYtYCmB1eLHg.9q" },
+            { "abcdefghijklmnopqrstuvwxyz",         "$2a$06$.rCVZVOThsIa97pEDOxvGu",    "$2a$06$.rCVZVOThsIa97pEDOxvGuRRgzG64bvtJ0938xuqzv18d3ZpQhstC" },
+            { "abcdefghijklmnopqrstuvwxyz",         "$2a$08$aTsUwsyowQuzRrDqFflhge",    "$2a$08$aTsUwsyowQuzRrDqFflhgekJ8d9/7Z3GV3UcgvzQW3J5zMyrTvlz." },
+            { "abcdefghijklmnopqrstuvwxyz",         "$2a$10$fVH8e28OQRj9tqiDXs1e1u",    "$2a$10$fVH8e28OQRj9tqiDXs1e1uxpsjN0c7II7YPKXua2NAKYvM6iQk7dq" },
+//            { "abcdefghijklmnopqrstuvwxyz",         "$2a$12$D4G5f18o7aMMfwasBL7Gpu",    "$2a$12$D4G5f18o7aMMfwasBL7GpuQWuP3pkrZrOAnqP.bmezbMng.QwJ/pG" },
+            { "~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$06$fPIsBO8qRqkjj273rfaOI.",    "$2a$06$fPIsBO8qRqkjj273rfaOI.HtSV9jLDpTbZn782DC6/t7qT67P6FfO" },
+            { "~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$08$Eq2r4G/76Wv39MzSX262hu",    "$2a$08$Eq2r4G/76Wv39MzSX262huzPz612MZiYHVUJe/OcOql2jo4.9UxTW" },
+            { "~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$10$LgfYWkbzEvQ4JakH7rOvHe",    "$2a$10$LgfYWkbzEvQ4JakH7rOvHe0y8pHKF9OaFgwUZ2q7W2FFZmZzJYlfS" },
+//            { "~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$12$WApznUOJfkEGSmYRfnkrPO",    "$2a$12$WApznUOJfkEGSmYRfnkrPOr466oFDCaj4b6HY3EXGvfxm43seyhgC" },
+            { "\u00a3"                            , "$2a$06$DCq7YPn5Rq63x1Lad4cll.",    "$2a$06$DCq7YPn5Rq63x1Lad4cll.UkvN5ZG3eIdYifdePATjpEDDrmdFKRK" },
+        };
+
+    // Test vectors from crypt_blowfish, not including tests for 2x mode and 'safe' 2a mode.
+    // http://cvsweb.openwall.com/cgi/cvsweb.cgi/Owl/packages/glibc/crypt_blowfish/wrapper.c
+    private static Object[][] crypt_blowfishVectors = {
+            {"U*U","$2a$05$CCCCCCCCCCCCCCCCCCCCC.E5YPO9kmyuRGyh0XouQYb4YMJKvyOeW"},
+            {"U*U*","$2a$05$CCCCCCCCCCCCCCCCCCCCC.VGOzA784oUp/Z0DY336zx7pLYAy0lwK"},
+            {"U*U*U","$2a$05$XXXXXXXXXXXXXXXXXXXXXOAcXxm9kjPGEMsLznoKqmqw7tc8WCx4a"},
+            {"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789","$2a$05$abcdefghijklmnopqrstuu5s2v8.iXieOjg/.AySBTTZIIVFJeBui"},
+            {Hex.decode("ffffa3"),"$2y$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e"},
+            {Hex.decode("a3"),"$2y$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq"},
+            {Hex.decode("a3"),"$2a$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq"},
+            {Hex.decode("ffa33334ffffffa3333435"),"$2y$05$/OK.fbVrR/bpIqNJ5ianF.o./n25XVfn6oAPaUvHe.Csk4zRfsYPi"},
+            {Hex.decode("ffa3333435"),"$2y$05$/OK.fbVrR/bpIqNJ5ianF.nRht2l/HRhr6zmCp9vYUvvsqynflf9e"},
+            {Hex.decode("ffa3333435"),"$2a$05$/OK.fbVrR/bpIqNJ5ianF.nRht2l/HRhr6zmCp9vYUvvsqynflf9e"},
+            {Hex.decode("a36162"),"$2a$05$/OK.fbVrR/bpIqNJ5ianF.6IflQkJytoRVc1yuaNtHfiuq.FRlSIS"},
+            {Hex.decode("a36162"),"$2y$05$/OK.fbVrR/bpIqNJ5ianF.6IflQkJytoRVc1yuaNtHfiuq.FRlSIS"},
+            {Hex.decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                "$2a$05$/OK.fbVrR/bpIqNJ5ianF.swQOIzjOiJ9GHEPuhEkvqrUyvWhEMx6"},
+            {Hex.decode("aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55a"
+                + "a55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55aa55"),
+                "$2a$05$/OK.fbVrR/bpIqNJ5ianF.R9xrDjiycxMbQE2bp.vgqlYpW5wx2yy"},
+            {Hex.decode("55aaff55aaff55aaff55aaff55aaff55aaff55aaff55aaff55aaff55aaff55aaff55a"
+                + "aff55aaff55aaff55aaff55aaff55aaff55aaff55aaff55aaff55aaff55aaff55aaff55aaff"),
+                "$2a$05$/OK.fbVrR/bpIqNJ5ianF.9tQZzcJfm3uj2NvJ/n5xkhpqLrMpWCe"},
+            {"","$2a$05$CCCCCCCCCCCCCCCCCCCCC.7uG0VCzI2bS7j6ymqJi9CdcdxiRTWNy"},
+        };
+
+    public String getName()
+    {
+        return "OpenBSDBCrypt";
+    }
+
+    public void performTest()
+        throws Exception
+    {
+        testParameters();
+        testSaltGeneration();
+        testVectors();
+        testCryptBlowfishVectors();
+    }
+
+    public void testSaltGeneration()
+    {
+        try
+        {
+            OpenBSDBcrypt.encodeSalt(new byte[15], 4);
+            fail("Salt size for encode");
+        }
+        catch (IllegalArgumentException e)
+        {
+        }
+
+        final byte[] salt = Hex.decode("000102030405060708090a0b0c0d0e0f");
+        String encodedSalt = OpenBSDBcrypt.encodeSalt(salt, 4);
+        if (!encodedSalt.equals("$2a$04$..CA.uOD/eaGAOmJB.yMBu"))
+        {
+            fail("Salt encoding : ", "$2a$04$..CA.uOD/eaGAOmJB.yMBu", encodedSalt);
+        }
+
+        SecureRandom r = new SecureRandom() {
+            @Override
+            public synchronized void nextBytes(byte[] bytes)
+            {
+                System.arraycopy(salt, 0, bytes, 0, bytes.length);
+            }
+        };
+
+        String generatedSalt = OpenBSDBcrypt.generateSalt(4, r);
+        if (!generatedSalt.equals("$2a$04$..CA.uOD/eaGAOmJB.yMBu"))
+        {
+            fail("Salt generation : ", "$2a$04$..CA.uOD/eaGAOmJB.yMBu", generatedSalt);
+        }
+
+        String generatedSalt2 = OpenBSDBcrypt.generateSalt(10);
+        if (!generatedSalt2.startsWith("$2a$10") || generatedSalt2.length() == 28)
+        {
+            fail("Generated salt format: " + generatedSalt2);
+        }
+
+    }
+
+    public void testParameters()
+    {
+        checkOK("Empty key", new byte[0], new byte[16], 4);
+        checkOK("Minimal values", new byte[1], new byte[16], 4);
+        // checkOK("Max cost", new byte[1], new byte[16], 31);
+        checkOK("Max passcode", new byte[72], new byte[16], 4);
+        checkIllegal("Null password", null, new byte[16], 4);
+        checkIllegal("Null salt", new byte[1], null, 4);
+        checkIllegal("Null salt", new byte[1], null);
+        checkIllegal("Salt too small", new byte[1], new byte[15], 4);
+        checkIllegal("Salt too big", new byte[1], new byte[17], 4);
+        checkIllegal("Cost too low", new byte[16], new byte[16], 3);
+        checkIllegal("Cost too high", new byte[16], new byte[16], 32);
+        checkIllegal("Passcode too long", new byte[73], new byte[16], 32);
+    }
+
+    private void checkOK(String msg, byte[] pass, byte[] salt, int cost)
+    {
+        String encodedSalt = (salt == null) ? null : OpenBSDBcrypt.encodeSalt(salt, cost);
+        checkOK(msg, pass, encodedSalt);
+    }
+
+    private void checkOK(String msg, byte[] pass, String encodedSalt)
+    {
+        try
+        {
+            OpenBSDBcrypt.hash(pass, encodedSalt);
+        }
+        catch (IllegalArgumentException e)
+        {
+            e.printStackTrace();
+            fail(msg);
+        }
+    }
+
+    private void checkIllegal(String msg, byte[] pass, byte[] salt, int cost)
+    {
+        try
+        {
+            String encodedSalt = OpenBSDBcrypt.encodeSalt(salt, cost);
+            OpenBSDBcrypt.hash(pass, encodedSalt);
+            fail(msg);
+        }
+        catch (IllegalArgumentException e)
+        {
+            // e.printStackTrace();
+        }
+    }
+
+    private void checkIllegal(String msg, byte[] pass, String encodedSalt)
+    {
+        try
+        {
+            OpenBSDBcrypt.hash(pass, encodedSalt);
+            fail(msg);
+        }
+        catch (IllegalArgumentException e)
+        {
+            // e.printStackTrace();
+        }
+    }
+
+    public void testVectors()
+        throws Exception
+    {
+        for (int i = 0; i < testVectors.length; i++)
+        {
+            String plain = testVectors[i][0];
+            String salt = testVectors[i][1];
+            String expected = testVectors[i][2];
+
+            test(plain, salt, expected);
+
+            // Check salt as prefix of hash works the same
+            test(plain, expected, expected);
+        }
+    }
+
+    public void testCryptBlowfishVectors()
+    {
+        for (int i = 0; i < crypt_blowfishVectors.length; i++)
+        {
+            Object plain = crypt_blowfishVectors[i][0];
+            String expected = (String)crypt_blowfishVectors[i][1];
+
+            if (plain instanceof String)
+            {
+                test((String)plain, expected, expected);
+            }
+            else
+            {
+                test((byte[])plain, expected);
+            }
+        }
+    }
+
+    private void test(byte[] password, String expected)
+    {
+        String hash = OpenBSDBcrypt.hash(password, expected);
+        if (!hash.equals(expected))
+        {
+            fail("Hash mismatch: " + new String(Hex.encode(password)), expected, hash);
+        }
+        if (!OpenBSDBcrypt.verify(password, expected))
+        {
+            fail("Hash verify failed: " + new String(Hex.encode(password)), expected, hash);
+        }
+    }
+
+    private void test(String password, String salt, String expected)
+    {
+        String hash = OpenBSDBcrypt.hash(password, salt);
+        if (!hash.equals(expected))
+        {
+            fail("Hash mismatch: " + password, expected, hash);
+        }
+        if (!OpenBSDBcrypt.verify(password, expected))
+        {
+            fail("Hash verify failed: " + password, expected, hash);
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new OpenBSDBCryptTest());
+    }
+}


### PR DESCRIPTION
Implementation of raw and OpenBSD/crypt style bcrypt password hash functions.

Raw and OpenBSD style are separated.
The OpenBSD/crypt style is most useful for compatibility with existing uses or clients wanting a simple hash+params encoding.
The raw style could be plugged into a future password hash API quite easily (i.e. based on the PHC API).

To reuse the existing Blowfish implementation (having an unverified copy is the cause of at least one major bug in crypt_blowfish) BlowfishEngine is extended slightly with hooks to allow the key schedule to be overridden and for salt to be mixed in during table processing in key setup. Performance impact should be negligible given the existing cost of the Blowfish key setup.

In the OpenBSD implementation the 2 (original), 2a, 2b and 2y formats are supported (a/b/y are algorithmically equivalent, but represent bug fixes in various crypt implementations). The crypt_blowfish 2x and 'safe 2a' modes are not implemented since they require borking the BlowfishEngine (where the bug was identified).

Cross tested with JBCrypt and OpenWall crypt_blowfish test vectors (links in unit tests).

Also added checking for defined key sizes in BlowfishEngine, with a constructor/factory for uses needing unrestricted key lengths (bcrypt being one of them). That's in a separate commit, so feel free to drop/amend.