### PR TITLE
Adopts sun.misc.Unsafe as the default bit packing mechanism.  Dalvik has...

### DIFF
--- a/core/src/main/java/org/bouncycastle/util/Pack.java
+++ b/core/src/main/java/org/bouncycastle/util/Pack.java
@@ -1,201 +1,225 @@
 package org.bouncycastle.util;
 
-public abstract class Pack
-{
-    public static int bigEndianToInt(byte[] bs, int off)
-    {
-        int n = bs[  off] << 24;
-        n |= (bs[++off] & 0xff) << 16;
-        n |= (bs[++off] & 0xff) << 8;
-        n |= (bs[++off] & 0xff);
-        return n;
+import java.nio.ByteOrder;
+
+import static org.bouncycastle.util.UnsafeUtil.*;
+
+public abstract class Pack {
+
+
+    public static int bigEndianToInt(byte[] bs, int off) {
+
+        int anInt = UNSAFE.getInt(bs, BYTE_ARRAY_OFFSET + off);
+
+        if (NATIVE_BYTE_ORDER != ByteOrder.BIG_ENDIAN) {
+            anInt = Integer.reverseBytes(anInt);
+        }
+
+        return anInt;
     }
 
-    public static void bigEndianToInt(byte[] bs, int off, int[] ns)
-    {
-        for (int i = 0; i < ns.length; ++i)
-        {
+    public static void bigEndianToInt(byte[] bs, int off, int[] ns) {
+        for (int i = 0; i < ns.length; ++i) {
             ns[i] = bigEndianToInt(bs, off);
             off += 4;
         }
     }
 
-    public static byte[] intToBigEndian(int n)
-    {
+    public static byte[] intToBigEndian(int n) {
+
+
         byte[] bs = new byte[4];
+
         intToBigEndian(n, bs, 0);
+
         return bs;
     }
 
-    public static void intToBigEndian(int n, byte[] bs, int off)
-    {
-        bs[  off] = (byte)(n >>> 24);
-        bs[++off] = (byte)(n >>> 16);
-        bs[++off] = (byte)(n >>>  8);
-        bs[++off] = (byte)(n       );
+    public static void intToBigEndian(int n, byte[] bs, int off) {
+
+        if (NATIVE_BYTE_ORDER != ByteOrder.BIG_ENDIAN) {
+            n = Integer.reverseBytes(n);
+        }
+
+        UNSAFE.putInt(bs, BYTE_ARRAY_OFFSET + off, n);
+
     }
 
-    public static byte[] intToBigEndian(int[] ns)
-    {
+    public static byte[] intToBigEndian(int[] ns) {
         byte[] bs = new byte[4 * ns.length];
         intToBigEndian(ns, bs, 0);
         return bs;
     }
 
-    public static void intToBigEndian(int[] ns, byte[] bs, int off)
-    {
-        for (int i = 0; i < ns.length; ++i)
-        {
+    public static void intToBigEndian(int[] ns, byte[] bs, int off) {
+        for (int i = 0; i < ns.length; ++i) {
             intToBigEndian(ns[i], bs, off);
             off += 4;
         }
     }
 
-    public static long bigEndianToLong(byte[] bs, int off)
-    {
-        int hi = bigEndianToInt(bs, off);
-        int lo = bigEndianToInt(bs, off + 4);
-        return ((long)(hi & 0xffffffffL) << 32) | (long)(lo & 0xffffffffL);
+    public static long bigEndianToLong(byte[] bs, int off) {
+
+
+        long anLong = UNSAFE.getLong(bs, BYTE_ARRAY_OFFSET + off);
+
+        if (NATIVE_BYTE_ORDER != ByteOrder.BIG_ENDIAN) {
+            anLong = Long.reverseBytes(anLong);
+        }
+
+        return anLong;
+
+
     }
 
-    public static void bigEndianToLong(byte[] bs, int off, long[] ns)
-    {
-        for (int i = 0; i < ns.length; ++i)
-        {
+    public static void bigEndianToLong(byte[] bs, int off, long[] ns) {
+        for (int i = 0; i < ns.length; ++i) {
             ns[i] = bigEndianToLong(bs, off);
             off += 8;
         }
     }
 
-    public static byte[] longToBigEndian(long n)
-    {
+    public static byte[] longToBigEndian(long n) {
         byte[] bs = new byte[8];
         longToBigEndian(n, bs, 0);
         return bs;
     }
 
-    public static void longToBigEndian(long n, byte[] bs, int off)
-    {
-        intToBigEndian((int)(n >>> 32), bs, off);
-        intToBigEndian((int)(n & 0xffffffffL), bs, off + 4);
+    public static void longToBigEndian(long n, byte[] bs, int off) {
+
+
+        if (NATIVE_BYTE_ORDER != ByteOrder.BIG_ENDIAN) {
+            n = Long.reverseBytes(n);
+        }
+
+        UNSAFE.putLong(bs, BYTE_ARRAY_OFFSET + off, n);
+
+
     }
 
-    public static byte[] longToBigEndian(long[] ns)
-    {
+    public static byte[] longToBigEndian(long[] ns) {
         byte[] bs = new byte[8 * ns.length];
         longToBigEndian(ns, bs, 0);
         return bs;
     }
 
-    public static void longToBigEndian(long[] ns, byte[] bs, int off)
-    {
-        for (int i = 0; i < ns.length; ++i)
-        {
+    public static void longToBigEndian(long[] ns, byte[] bs, int off) {
+        for (int i = 0; i < ns.length; ++i) {
             longToBigEndian(ns[i], bs, off);
             off += 8;
         }
     }
 
-    public static int littleEndianToInt(byte[] bs, int off)
-    {
-        int n = bs[  off] & 0xff;
-        n |= (bs[++off] & 0xff) << 8;
-        n |= (bs[++off] & 0xff) << 16;
-        n |= bs[++off] << 24;
-        return n;
+    public static int littleEndianToInt(byte[] bs, int off) {
+
+
+        int anInt = UNSAFE.getInt(bs, BYTE_ARRAY_OFFSET + off);
+
+        if (NATIVE_BYTE_ORDER != ByteOrder.LITTLE_ENDIAN) {
+            anInt = Integer.reverseBytes(anInt);
+        }
+
+        return anInt;
+
+
     }
 
-    public static void littleEndianToInt(byte[] bs, int off, int[] ns)
-    {
-        for (int i = 0; i < ns.length; ++i)
-        {
+    public static void littleEndianToInt(byte[] bs, int off, int[] ns) {
+        for (int i = 0; i < ns.length; ++i) {
             ns[i] = littleEndianToInt(bs, off);
             off += 4;
         }
     }
 
-    public static void littleEndianToInt(byte[] bs, int bOff, int[] ns, int nOff, int count)
-    {
-        for (int i = 0; i < count; ++i)
-        {
+    public static void littleEndianToInt(byte[] bs, int bOff, int[] ns, int nOff, int count) {
+        for (int i = 0; i < count; ++i) {
             ns[nOff + i] = littleEndianToInt(bs, bOff);
             bOff += 4;
         }
     }
 
-    public static byte[] intToLittleEndian(int n)
-    {
+    public static byte[] intToLittleEndian(int n) {
         byte[] bs = new byte[4];
         intToLittleEndian(n, bs, 0);
         return bs;
     }
 
-    public static void intToLittleEndian(int n, byte[] bs, int off)
-    {
-        bs[  off] = (byte)(n       );
-        bs[++off] = (byte)(n >>>  8);
-        bs[++off] = (byte)(n >>> 16);
-        bs[++off] = (byte)(n >>> 24);
+    public static void intToLittleEndian(int n, byte[] bs, int off) {
+        if (NATIVE_BYTE_ORDER != ByteOrder.LITTLE_ENDIAN) {
+            n =   Integer.reverseBytes(n);
+        }
+
+        UNSAFE.putInt(bs, BYTE_ARRAY_OFFSET + off, n);
+
     }
 
-    public static byte[] intToLittleEndian(int[] ns)
-    {
+    public static byte[] intToLittleEndian(int[] ns) {
         byte[] bs = new byte[4 * ns.length];
         intToLittleEndian(ns, bs, 0);
         return bs;
     }
 
-    public static void intToLittleEndian(int[] ns, byte[] bs, int off)
-    {
-        for (int i = 0; i < ns.length; ++i)
-        {
+    public static void intToLittleEndian(int[] ns, byte[] bs, int off) {
+        for (int i = 0; i < ns.length; ++i) {
             intToLittleEndian(ns[i], bs, off);
             off += 4;
         }
     }
 
-    public static long littleEndianToLong(byte[] bs, int off)
-    {
-        int lo = littleEndianToInt(bs, off);
-        int hi = littleEndianToInt(bs, off + 4);
-        return ((long)(hi & 0xffffffffL) << 32) | (long)(lo & 0xffffffffL);
+    public static long littleEndianToLong(byte[] bs, int off) {
+        long anLong = UNSAFE.getLong(bs, BYTE_ARRAY_OFFSET + off);
+
+        if (NATIVE_BYTE_ORDER != ByteOrder.LITTLE_ENDIAN) {
+            anLong =  Long.reverseBytes(anLong);
+        }
+
+        return anLong;
     }
 
-    public static void littleEndianToLong(byte[] bs, int off, long[] ns)
-    {
-        for (int i = 0; i < ns.length; ++i)
-        {
+    public static void littleEndianToLong(byte[] bs, int off, long[] ns) {
+        for (int i = 0; i < ns.length; ++i) {
             ns[i] = littleEndianToLong(bs, off);
             off += 8;
         }
     }
 
-    public static byte[] longToLittleEndian(long n)
-    {
+    public static byte[] longToLittleEndian(long n) {
         byte[] bs = new byte[8];
         longToLittleEndian(n, bs, 0);
         return bs;
     }
 
-    public static void longToLittleEndian(long n, byte[] bs, int off)
-    {
-        intToLittleEndian((int)(n & 0xffffffffL), bs, off);
-        intToLittleEndian((int)(n >>> 32), bs, off + 4);
+    public static void longToLittleEndian(long n, byte[] bs, int off) {
+        if (NATIVE_BYTE_ORDER != ByteOrder.LITTLE_ENDIAN) {
+            n =   Long.reverseBytes(n);
+        }
+
+        UNSAFE.putLong(bs, BYTE_ARRAY_OFFSET + off, n);
     }
 
-    public static byte[] longToLittleEndian(long[] ns)
-    {
+    public static byte[] longToLittleEndian(long[] ns) {
         byte[] bs = new byte[8 * ns.length];
         longToLittleEndian(ns, bs, 0);
         return bs;
     }
 
-    public static void longToLittleEndian(long[] ns, byte[] bs, int off)
-    {
-        for (int i = 0; i < ns.length; ++i)
-        {
+    public static void longToLittleEndian(long[] ns, byte[] bs, int off) {
+        for (int i = 0; i < ns.length; ++i) {
             longToLittleEndian(ns[i], bs, off);
             off += 8;
         }
+    }
+
+    public static void main(String[] args) {
+
+        byte[] a = new byte[16];
+
+        longToBigEndian(3123123, a, 3);
+
+        System.out.println(java.util.Arrays.toString(a));
+
+        System.out.println(bigEndianToLong(a, 3));
+
+
     }
 }

--- a/core/src/main/java/org/bouncycastle/util/UnsafeUtil.java
+++ b/core/src/main/java/org/bouncycastle/util/UnsafeUtil.java
@@ -1,0 +1,49 @@
+package org.bouncycastle.util;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.nio.ByteOrder;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+
+/**
+ * Created by Borislav Ivanov
+ * Date: 7/7/14
+ * Time: 12:32 PM
+ */
+public class UnsafeUtil {
+
+
+    public static Unsafe UNSAFE;
+
+    static
+    {
+        try
+        {
+            final PrivilegedExceptionAction<Unsafe> action = new PrivilegedExceptionAction<Unsafe>()
+            {
+                public Unsafe run() throws Exception
+                {
+                    final Field field = Unsafe.class.getDeclaredField("theUnsafe");
+                    field.setAccessible(true);
+                    return (Unsafe)field.get(null);
+                }
+            };
+
+            UNSAFE = AccessController.doPrivileged(action);
+        }
+        catch (final Exception ex)
+        {
+            throw new RuntimeException(ex);
+        }
+    }
+
+
+    public static final ByteOrder NATIVE_BYTE_ORDER = ByteOrder.nativeOrder();
+
+    public static final long BYTE_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+
+
+
+}


### PR DESCRIPTION

implementation of org.bouncycastle.crypto.util.Pack using sun.misc.Unsafe for the bit packing

c.b.b.BitpackBenchmark.int_big_endian_BC thrpt 50 420776590.853 5220912.983 ops/s c.b.b.BitpackBenchmark.int_big_endian_UNSAFE thrpt 50 584328042.702 6204675.094 ops/s c.b.b.BitpackBenchmark.int_little_endian_BC thrpt 50 414145920.999 2039601.760 ops/s c.b.b.BitpackBenchmark.int_little_endian_UNSAFE thrpt 50 566896814.581 9367267.811 ops/s c.b.b.BitpackBenchmark.long_big_endian_BC thrpt 50 221806956.179 2572464.388 ops/s c.b.b.BitpackBenchmark.long_big_endian_UNSAFE thrpt 50 513907043.514 2208120.558 ops/s c.b.b.BitpackBenchmark.long_little_endian_BC thrpt 50 222062509.695 2979629.774 ops/s c.b.b.BitpackBenchmark.long_little_endian_UNSAFE thrpt 50 569441920.581 11614150.590 ops/s

Microbenchmark:

package com.bobymicroby.bitpacktest;

import org.openjdk.jmh.annotations.*;

import java.util.Arrays; import java.util.Random; import java.util.concurrent.TimeUnit;

/**

Created by Borislav Ivanov
Date: 7/7/14
Time: 2:17 PM */
@State(Scope.Thread) @BenchmarkMode(Mode.Throughput) @OutputTimeUnit(TimeUnit.SECONDS) @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS) @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)

public class BitpackBenchmark {

@State(Scope.Thread)
public static class ThreadState {


    private static final int n = 10000;

    private static int[] ints = new int[n];

    private static long[] longs = new long[n];

    private static final Random r = new Random();

    static {
        Arrays.fill(ints, 0, n, r.nextInt()
        );

        Arrays.fill(longs, 0, n, r.nextLong()
        );

    }

    int iCounter = 0;

    public int nextInt() {
        if (iCounter == n) {
            iCounter = 0;
        }
        return ints[iCounter++];
    }


    int lCounter = 0;

    public long nextLong() {
        if (lCounter == n) {
            lCounter = 0;
        }
        return longs[lCounter++];
    }


}

@Benchmark
public int int_big_endian_BC(ThreadState state) {


    return PackBouncyCastle.bigEndianToInt(PackBouncyCastle.intToBigEndian(state.nextInt()), 0);


}

@Benchmark
public int int_big_endian_UNSAFE(ThreadState state) {

    return PackUnsafe.littleEndianToInt(PackUnsafe.intToLittleEndian(state.nextInt()), 0);
}

@Benchmark
public int int_little_endian_UNSAFE(ThreadState state) {

    return PackUnsafe.littleEndianToInt(PackUnsafe.intToLittleEndian(state.nextInt()), 0);
}


@Benchmark
public int int_little_endian_BC(ThreadState state) {

    return PackBouncyCastle.bigEndianToInt(PackBouncyCastle.intToBigEndian(state.nextInt()), 0);
}


@Benchmark
public long long_big_endian_UNSAFE(ThreadState state) {

    return PackUnsafe.bigEndianToLong(PackUnsafe.longToBigEndian(state.nextLong()), 0);
}

@Benchmark
public long long_big_endian_BC(ThreadState state) {

    return PackBouncyCastle.bigEndianToLong(PackBouncyCastle.longToBigEndian(state.nextLong()), 0);
}


@Benchmark
public long long_little_endian_UNSAFE(ThreadState state) {

    return PackUnsafe.littleEndianToLong(PackUnsafe.longToLittleEndian(state.nextLong()), 0);
}

@Benchmark
public long long_little_endian_BC(ThreadState state) {

    return PackBouncyCastle.littleEndianToLong(PackBouncyCastle.longToLittleEndian(state.nextLong()), 0);
}
}
Status API Training Shop Blog About © 2014 GitHub, Inc. Terms Privacy Security Contact 