### PR TITLE
Add Travis-CI configuration to ensure the Gradle-based build doesn't break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+
+jdk:
+  - openjdk7
+
+install:
+  - TERM=dumb gradle assemble
+
+script:
+  - TERM=dumb gradle check --info
+


### PR DESCRIPTION
Although the Gradle-based build works pretty well, and is very useful in the repackaging of Bouncy Castle into Spongy Castle, it's not necessarily used by all Bouncy Castle developers, and consequently it gets broken from time to time, as new tests are added that don't work out-of-the-box. Continuous Integration testing (as provided for free by Travis) will help avoid this gradual corruption of the build, by letting devs know when problems arise.

Bouncy Castle has some quite difficult-to-support build profiles (J2ME, Java 1.1, 1.2, 1.3, etc) but this configuration just runs `gradle check` against OpenJDK 1.7 - as a bare minimum, the test suite should pass on that platform :)

Testing against OpenJDK also means we're not attempting to get the JCE signed-provider stuff working, which is actually for the best, as uploading the keystore that holds the signing key to the public repo is _not_ on the list of things you're allowed to do.

Note that after this configuration is merged, there is still a short set-up process to perform through the Travis admin interface - see these links:

http://docs.travis-ci.com/user/getting-started/
http://docs.travis-ci.com/user/github-oauth-scopes/
