### PR TITLE
PGP: Add constants for GNU protection modes in PGP S2K class

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/S2K.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/S2K.java
@@ -27,6 +27,9 @@ public class S2K
 
     public static final int GNU_DUMMY_S2K = 101;
 
+    public static final int GNU_PROTECTION_MODE_NO_PRIVATE_KEY = 1;
+    public static final int GNU_PROTECTION_MODE_DIVERT_TO_CARD = 2;
+
     int       type;
     int       algorithm;
     byte[]    iv;


### PR DESCRIPTION
These are the two actually used protection modes in GnuPG. I found them by reading the gpg sourcecode.