### PR TITLE
PGP: Dont write version header by default to armored messages

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
@@ -93,8 +93,6 @@ public class ArmoredOutputStream
     String          footerStart = "-----END PGP ";
     String          footerTail = "-----";
 
-    String          version = "BCPG v@RELEASE_NAME@";
-
     Hashtable       headers = new Hashtable();
 
     /**
@@ -157,7 +155,6 @@ public class ArmoredOutputStream
     public void resetHeaders()
     {
         headers.clear();
-        headers.put("Version", version);
     }
 
     /**

--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
@@ -318,7 +318,10 @@ public class ArmoredOutputStream
                 out.write(nl.charAt(i));
             }
 
-            writeHeaderEntry("Version", (String)headers.get("Version"));
+            // write version header first if existing
+            if (headers.containsKey("Version")) {
+                writeHeaderEntry("Version", (String) headers.get("Version"));
+            }
 
             Enumeration e = headers.keys();
             while (e.hasMoreElements())


### PR DESCRIPTION
By telling which version of Bouncy Castle has been used in armored outputs, it is much easier to find exported keys on the Internet which have been generated by a potentially broken version of the library.
Writing a version header should be totally optional.
see also http://blog.cryptographyengineering.com/2014/08/whats-matter-with-pgp.html
and https://mailman.boum.org/pipermail/tails-dev/2013-August/003435.html