### PR TITLE
PGP: Expose S2K packet

### DIFF
--- a/pg/src/main/j2me/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/j2me/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -280,6 +280,16 @@ public class PGPSecretKey
     }
     
     /**
+     * Return the S2K object used to encrypt this secret key.
+     *
+     * @return this secret key's s2k object
+     */
+    public S2K getS2K()
+    {
+        return secret.getS2K();
+    }
+    
+    /**
      * Return any user attribute vectors associated with the key.
      * 
      * @return an iterator of Strings.

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -344,6 +344,16 @@ public class PGPSecretKey
     }
     
     /**
+     * Return the S2K object used to encrypt this secret key.
+     *
+     * @return this secret key's s2k object
+     */
+    public S2K getS2K()
+    {
+        return secret.getS2K();
+    }
+    
+    /**
      * Return any user attribute vectors associated with the key.
      * 
      * @return an iterator of PGPUserAttributeSubpacketVector.


### PR DESCRIPTION
To know if we deal with a key that contains no secret key (GNU extension) we would like to expose the S2K packet. This pull requests adds a method to PGPSecretKey to get the packet.