### PR TITLE
PGP: Add method to get key signatures without user ids

### DIFF
--- a/pg/src/main/j2me/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/j2me/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -503,6 +503,26 @@ public class PGPPublicKey
         }
     }
 
+    /**
+     * Return all signatures/certifications directly associated with this key (ie, not to a user id).
+     *
+     * @return an iterator (possibly empty) with all signatures/certifications.
+     */
+    public Iterator getKeySignatures()
+    {
+        if (subSigs == null)
+        {
+            List sigs = new ArrayList();
+            sigs.addAll(keySigs);
+            
+            return sigs.iterator();
+        }
+        else
+        {
+            return subSigs.iterator();
+        }
+    }
+
     public PublicKeyPacket getPublicKeyPacket()
     {
         return publicPk;

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -542,6 +542,26 @@ public class PGPPublicKey
         }
     }
 
+    /**
+     * Return all signatures/certifications directly associated with this key (ie, not to a user id).
+     *
+     * @return an iterator (possibly empty) with all signatures/certifications.
+     */
+    public Iterator getKeySignatures()
+    {
+        if (subSigs == null)
+        {
+            List sigs = new ArrayList();
+            sigs.addAll(keySigs);
+            
+            return sigs.iterator();
+        }
+        else
+        {
+            return subSigs.iterator();
+        }
+    }
+
     public PublicKeyPacket getPublicKeyPacket()
     {
         return publicPk;


### PR DESCRIPTION
Added method to PGPPublicKey to return all signatures/certifications without the user ids.
