### PR TITLE
Ecies options - allow EC point compression for ECIES scheme

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/engines/IESEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/IESEngine.java
@@ -400,6 +400,8 @@ public class IESEngine
                 this.privParam = ephKeyPair.getKeyPair().getPrivate();
                 this.V = ephKeyPair.getEncodedPublicKey();
 
+                // take a copy of the compressed ephemeral public key in case usePointCompression is true
+                // when it comes time to return the encrypted V,C,T triple.
                 AsymmetricKeyParameter publicKey = ephKeyPair.getKeyPair().getPublic();
                 if (publicKey instanceof ECPublicKeyParameters) {
                     this.compressedEphemeralPublicKey = ((ECPublicKeyParameters)publicKey).getQ().getEncoded(true);
@@ -438,14 +440,9 @@ public class IESEngine
         byte[] VZ;
         if (V.length != 0)
         {
-            byte[] ephPublicKey = V;
-            // when decrypting V contains the authoritative bytes (ie the bytes that came in on the wire)
-            if (usePointCompression && forEncryption) {
-                ephPublicKey = compressedEphemeralPublicKey;
-            }
-            VZ = new byte[ephPublicKey.length + Z.length];
-            System.arraycopy(ephPublicKey, 0, VZ, 0, ephPublicKey.length);
-            System.arraycopy(Z, 0, VZ, ephPublicKey.length, Z.length);
+            VZ = new byte[V.length + Z.length];
+            System.arraycopy(V, 0, VZ, 0, V.length);
+            System.arraycopy(Z, 0, VZ, V.length, Z.length);
         }
         else
         {

--- a/core/src/main/java/org/bouncycastle/crypto/engines/IESEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/IESEngine.java
@@ -121,14 +121,12 @@ public class IESEngine
      * @param publicKey      the recipient's/sender's public key parameters
      * @param params         encoding and derivation parameters, may be wrapped to include an IV for an underlying block cipher.
      * @param ephemeralKeyPairGenerator             the ephemeral key pair generator to use.
-     * @param usePointCompression if true then output compressed EC coordinates
      */
-    public void init(AsymmetricKeyParameter publicKey, CipherParameters params, EphemeralKeyPairGenerator ephemeralKeyPairGenerator, boolean usePointCompression)
+    public void init(AsymmetricKeyParameter publicKey, CipherParameters params, EphemeralKeyPairGenerator ephemeralKeyPairGenerator)
     {
         this.forEncryption = true;
         this.pubParam = publicKey;
         this.keyPairGenerator = ephemeralKeyPairGenerator;
-        this.usePointCompression = usePointCompression;
 
         extractParams(params);
     }
@@ -147,6 +145,14 @@ public class IESEngine
         this.keyParser = publicKeyParser;
 
         extractParams(params);
+    }
+
+    /**
+     * @param usePointCompression if true then processBlock() outputs compressed EC coordinates
+     */
+    public void setPointCompression(boolean usePointCompression)
+    {
+        this.usePointCompression = usePointCompression;
     }
 
     private void extractParams(CipherParameters params)
@@ -408,7 +414,6 @@ public class IESEngine
                     this.compressedEphemeralPublicKey = ((ECPublicKeyParameters)publicKey).getQ().getEncoded(true);
                 } else {
                     // this path should never be taken
-                    usePointCompression = false;
                 }
             }
         }

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/IESCipher.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/IESCipher.java
@@ -441,7 +441,7 @@ public class IESCipher
             // Encrypt the buffer
             try
             {
-                engine.init(key, params, kGen);
+                engine.init(key, params, kGen, engineSpec.getPointCompression());
 
                 return engine.processBlock(in, 0, in.length);
             }

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/IESCipher.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/IESCipher.java
@@ -404,6 +404,14 @@ public class IESCipher
 
         final byte[] V;
 
+        if (state == Cipher.ENCRYPT_MODE || state == Cipher.WRAP_MODE)
+        {
+            if (engineSpec.getPointCompression())
+            {
+                engine.setPointCompression(true);
+            }
+        }
+
         if (otherKeyParameter != null)
         {
             try
@@ -441,7 +449,7 @@ public class IESCipher
             // Encrypt the buffer
             try
             {
-                engine.init(key, params, kGen, engineSpec.getPointCompression());
+                engine.init(key, params, kGen);
 
                 return engine.processBlock(in, 0, in.length);
             }

--- a/prov/src/main/java/org/bouncycastle/jce/spec/IESParameterSpec.java
+++ b/prov/src/main/java/org/bouncycastle/jce/spec/IESParameterSpec.java
@@ -14,6 +14,7 @@ public class IESParameterSpec
     private byte[] encoding;
     private int macKeySize;
     private int cipherKeySize;
+    private boolean usePointCompression = false;
     private byte[] nonce;
 
 
@@ -47,7 +48,7 @@ public class IESParameterSpec
         int macKeySize,
         int cipherKeySize)
     {
-        this(derivation, encoding, macKeySize, cipherKeySize, null);
+        this(derivation, encoding, macKeySize, cipherKeySize, null, false);
     }
 
     /**
@@ -65,6 +66,27 @@ public class IESParameterSpec
         int macKeySize,
         int cipherKeySize,
         byte[] nonce)
+    {
+        this(derivation, encoding, macKeySize, cipherKeySize, null, false);
+    }
+
+    /**
+     * Set the IES engine parameters.
+     *
+     * @param derivation    the optional derivation vector for the KDF.
+     * @param encoding      the optional encoding vector for the KDF.
+     * @param macKeySize    the key size (in bits) for the MAC.
+     * @param cipherKeySize the key size (in bits) for the block cipher.
+     * @param nonce         an IV to use initialising the block cipher.
+     * @param usePointCompression whether to use EC point compression or not (false by default)
+     */
+    public IESParameterSpec(
+        byte[] derivation,
+        byte[] encoding,
+        int macKeySize,
+        int cipherKeySize,
+        byte[] nonce,
+        boolean usePointCompression)
     {
         if (derivation != null)
         {
@@ -89,6 +111,7 @@ public class IESParameterSpec
         this.macKeySize = macKeySize;
         this.cipherKeySize = cipherKeySize;
         this.nonce = Arrays.clone(nonce);
+        this.usePointCompression = usePointCompression;
     }
 
     /**
@@ -131,5 +154,23 @@ public class IESParameterSpec
     public byte[] getNonce()
     {
         return Arrays.clone(nonce);
+    }
+
+    /**
+     * Set the 'point compression' flag.
+     */
+    public void setPointCompression(boolean usePointCompression)
+    {
+        this.usePointCompression = usePointCompression;
+    }
+
+    /**
+     * Return the 'point compression' flag.
+     *
+     * @return the point compression flag
+     */
+    public boolean getPointCompression()
+    {
+        return usePointCompression;
     }
 }


### PR DESCRIPTION
This change allows clients to specify EC Point Compression for the output of the ECIES encryption routine.  This reduces output by 32 bytes (for EC key size 256).  Clients specify point compression by using a newly added constructor for org.spongycastle.jce.spec.IESParameterSpec in which the last argument is a boolean flag 'usePointCompression'.

The default remains (as before) no point compression.
This change does not introduce any API incompatibilities or changes.
Point Compression works equally with streaming (xor) mode or conventional block cipher.