### PR TITLE
Fix encoding of EC private keys.

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/sec/ECPrivateKey.java
+++ b/core/src/main/java/org/bouncycastle/asn1/sec/ECPrivateKey.java
@@ -48,9 +48,19 @@ public class ECPrivateKey
     }
 
     public ECPrivateKey(
-        BigInteger key)
+        BigInteger key,
+        int orderLength)
     {
-        byte[] bytes = BigIntegers.asUnsignedByteArray(key);
+    	byte[] keyBytes = BigIntegers.asUnsignedByteArray(key);
+    	byte[] bytes;
+    	if (orderLength > 0)
+    	{
+    		bytes = new byte[orderLength];
+    		System.arraycopy(keyBytes, 0, bytes, 0, keyBytes.length);
+    	} else
+    	{
+    		bytes = keyBytes;
+    	}
 
         ASN1EncodableVector v = new ASN1EncodableVector();
 
@@ -62,17 +72,28 @@ public class ECPrivateKey
 
     public ECPrivateKey(
         BigInteger key,
-        ASN1Encodable parameters)
+        ASN1Encodable parameters,
+        int orderLength)
     {
-        this(key, null, parameters);
+        this(key, null, parameters, orderLength);
     }
 
     public ECPrivateKey(
         BigInteger key,
         DERBitString publicKey,
-        ASN1Encodable parameters)
+        ASN1Encodable parameters,
+        int orderLength)
     {
-        byte[] bytes = BigIntegers.asUnsignedByteArray(key);
+    	byte[] keyBytes = BigIntegers.asUnsignedByteArray(key);
+    	byte[] bytes;
+    	if (orderLength > 0)
+    	{
+    		bytes = new byte[orderLength];
+    		System.arraycopy(keyBytes, 0, bytes, 0, keyBytes.length);
+    	} else
+    	{
+    		bytes = keyBytes;
+    	}
 
         ASN1EncodableVector v = new ASN1EncodableVector();
 

--- a/core/src/main/java/org/bouncycastle/crypto/util/PrivateKeyInfoFactory.java
+++ b/core/src/main/java/org/bouncycastle/crypto/util/PrivateKeyInfoFactory.java
@@ -76,7 +76,7 @@ public class PrivateKeyInfoFactory
                 params = new X962Parameters(ecP);
             }
 
-            return new PrivateKeyInfo(new AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, params), new ECPrivateKey(priv.getD(), params));
+            return new PrivateKeyInfo(new AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, params), new ECPrivateKey(priv.getD(), params, domainParams.getCurve().getOrder().toByteArray().length));
         }
         else
         {

--- a/core/src/test/java/org/bouncycastle/asn1/test/X9Test.java
+++ b/core/src/test/java/org/bouncycastle/asn1/test/X9Test.java
@@ -31,13 +31,15 @@ public class X9Test
                 "yUmqLG2UhT0OZgu/hUsclQX+laAh5///////////////9///+XXetBs6YFfDxDIUZSZVECAQED" +
                 "IAADG5xRI+Iki/JrvL20hoDUa7Cggzorv5B9yyqSMjYu");
 
-    private byte[] namedPriv = Base64.decode("MCICAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQEECDAGAgEBBAEK");
+    private byte[] namedPriv = Base64.decode("MD8CAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQEEJTAjAgEBB" +
+                "B4KAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
     private byte[] expPriv = Base64.decode(
-                "MIHnAgEAMIHXBgcqhkjOPQIBMIHLAgEBMCkGByqGSM49AQECHn///////////////3///////4"
-              + "AAAAAAAH///////zBXBB5///////////////9///////+AAAAAAAB///////wEHiVXBfoqMGZU"
-              + "sfTLA9anUKMMJQEC1JiHF9m6FattPgMVAH1zdBaP/jRxtgqFdoahlHXTv6L/BB8DZ2iujhi7ks"
-              + "/PAFyUmqLG2UhT0OZgu/hUsclQX+laAh5///////////////9///+XXetBs6YFfDxDIUZSZVEC"
-              + "AQEECDAGAgEBBAEU");
+                "MIIBBAIBADCB1wYHKoZIzj0CATCBywIBATApBgcqhkjOPQEBAh5///////////////9///////" +
+                "+AAAAAAAB///////8wVwQef///////////////f///////gAAAAAAAf//////8BB4lVwX6KjBm" +
+                "VLH0ywPWp1CjDCUBAtSYhxfZuhWrbT4DFQB9c3QWj/40cbYKhXaGoZR107+i/wQfA2doro4Yu5" +
+                "LPzwBclJqixtlIU9DmYLv4VLHJUF/pWgIef///////////////f///l13rQbOmBXw8QyFGUmVR" +
+                "AgEBBCUwIwIBAQQeFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    
  
     private void encodePublicKey()
         throws Exception
@@ -114,7 +116,7 @@ public class X9Test
         //
         X962Parameters          params = new X962Parameters(X9ObjectIdentifiers.prime192v1);
 
-        PrivateKeyInfo          info = new PrivateKeyInfo(new AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, params), new ECPrivateKey(BigInteger.valueOf(10)));
+        PrivateKeyInfo          info = new PrivateKeyInfo(new AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, params), new ECPrivateKey(BigInteger.valueOf(10), ecP.getCurve().getOrder().toByteArray().length));
 
         if (!areEqual(info.getEncoded(), namedPriv))
         {
@@ -133,7 +135,7 @@ public class X9Test
         //
         params = new X962Parameters(ecP);
         
-        info = new PrivateKeyInfo(new AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, params), new ECPrivateKey(BigInteger.valueOf(20)));
+        info = new PrivateKeyInfo(new AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, params), new ECPrivateKey(BigInteger.valueOf(20), ecP.getCurve().getOrder().toByteArray().length));
 
         if (!areEqual(info.getEncoded(), expPriv))
         {

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/dstu/BCDSTU4145PrivateKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/dstu/BCDSTU4145PrivateKey.java
@@ -312,14 +312,26 @@ public class BCDSTU4145PrivateKey
 
         PrivateKeyInfo info;
         org.bouncycastle.asn1.sec.ECPrivateKey keyStructure;
-
+        
+        /**
+         * RFC 5915 http://tools.ietf.org/html/rfc5915#page-3:
+         * privateKey is the private key.  It is an octet string of length
+         *     ceiling (log2(n)/8) (where n is the order of the curve) obtained
+         *     from the unsigned integer via the Integer-to-Octet-String-
+         *     Primitive (I2OSP) defined in [RFC3447].
+         */
+        int orderLength = 0;
+        if (ecSpec != null)
+        {
+        	orderLength = ecSpec.getOrder().toByteArray().length;
+        }
         if (publicKey != null)
         {
-            keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), publicKey, params);
+            keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), publicKey, params, orderLength);
         }
         else
         {
-            keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), params);
+            keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), params, orderLength);
         }
 
         try

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/BCECPrivateKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/BCECPrivateKey.java
@@ -314,14 +314,26 @@ public class BCECPrivateKey
         
         PrivateKeyInfo          info;
         org.bouncycastle.asn1.sec.ECPrivateKey            keyStructure;
-
+        
+        /**
+         * RFC 5915 http://tools.ietf.org/html/rfc5915#page-3:
+         * privateKey is the private key.  It is an octet string of length
+         *     ceiling (log2(n)/8) (where n is the order of the curve) obtained
+         *     from the unsigned integer via the Integer-to-Octet-String-
+         *     Primitive (I2OSP) defined in [RFC3447].
+         */
+        int orderLength = 0;
+        if (ecSpec != null)
+        {
+        	orderLength = ecSpec.getOrder().toByteArray().length;
+        }
         if (publicKey != null)
         {
-            keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), publicKey, params);
+            keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), publicKey, params, orderLength);
         }
         else
         {
-            keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), params);
+            keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), params, orderLength);
         }
 
         try
@@ -459,4 +471,5 @@ public class BCECPrivateKey
 
         out.writeObject(this.getEncoded());
     }
+    
 }

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost/BCECGOST3410PrivateKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost/BCECGOST3410PrivateKey.java
@@ -377,14 +377,27 @@ public class BCECGOST3410PrivateKey
 
             PrivateKeyInfo info;
             org.bouncycastle.asn1.sec.ECPrivateKey keyStructure;
+            
+            /**
+             * RFC 5915 http://tools.ietf.org/html/rfc5915#page-3:
+             * privateKey is the private key.  It is an octet string of length
+             *     ceiling (log2(n)/8) (where n is the order of the curve) obtained
+             *     from the unsigned integer via the Integer-to-Octet-String-
+             *     Primitive (I2OSP) defined in [RFC3447].
+             */
+            int orderLength = 0;
+            if (ecSpec != null)
+            {
+            	orderLength = ecSpec.getOrder().toByteArray().length;
+            }
 
             if (publicKey != null)
             {
-                keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), publicKey, params);
+                keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), publicKey, params, orderLength);
             }
             else
             {
-                keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), params);
+                keyStructure = new org.bouncycastle.asn1.sec.ECPrivateKey(this.getS(), params, orderLength);
             }
 
             try


### PR DESCRIPTION
If the byte length of the key is shorter than the byte length of the order, the resulting octet string of the private key bits is also shortended. This does not match the specification in  RFC 5915 which demands:

      privateKey is the private key.  It is an octet string of length
      ceiling (log2(n)/8) (where n is the order of the curve) obtained
      from the unsigned integer via the Integer-to-Octet-String-
      Primitive (I2OSP) defined in [RFC3447].

OpenSSL has the same issue, https://rt.openssl.org/Ticket/Display.html?id=3644