### PR TITLE
AddCounterSigners bug fix in SignerInformation

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/cms/SignerInformation.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/SignerInformation.java
@@ -663,14 +663,10 @@ public class SignerInformation
             v = new ASN1EncodableVector();
         }
 
-        ASN1EncodableVector sigs = new ASN1EncodableVector();
-
         for (Iterator it = counterSigners.getSigners().iterator(); it.hasNext();)
         {
-            sigs.add(((SignerInformation)it.next()).toASN1Structure());
+            v.add(new Attribute(CMSAttributes.counterSignature, new DERSet(((SignerInformation)it.next()).toASN1Structure())));
         }
-
-        v.add(new Attribute(CMSAttributes.counterSignature, new DERSet(sigs)));
 
         return new SignerInformation(
                 new SignerInfo(sInfo.getSID(), sInfo.getDigestAlgorithm(),


### PR DESCRIPTION
The old method was functionnal for only one counter signer. It added only one CounterSigner attribute for all counterSigners present in the input store. It adds one for each in this version.