### PR TITLE
Add possibility to generate secret keys in GNU Divert-to-card format

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/GnuExtendedS2K.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/GnuExtendedS2K.java
@@ -1,0 +1,26 @@
+package org.bouncycastle.bcpg;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.bouncycastle.bcpg.BCPGOutputStream;
+import org.bouncycastle.bcpg.S2K;
+
+/**
+ * Add a constructor fort GNU-extended S2K
+ *
+ * This extension is documented on GnuPG documentation DETAILS file,
+ * section "GNU extensions to the S2K algorithm". Its support is
+ * already present in S2K class but lack for a constructor.
+ *
+ * @author Léonard Dallot <leonard.dallot@taztag.com>
+ */
+public class GnuExtendedS2K extends S2K {
+
+	public GnuExtendedS2K(int mode) {
+		super(0x0);
+		this.type = GNU_DUMMY_S2K;
+		this.protectionMode = mode;
+	}
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -661,7 +661,7 @@ public class PGPSecretKey
         byte[]      keyData;
         int         newEncAlgorithm = SymmetricKeyAlgorithmTags.NULL;
 
-        if (newKeyEncryptor == null || newKeyEncryptor.getAlgorithm() == SymmetricKeyAlgorithmTags.NULL)
+        if (newKeyEncryptor == null || (newKeyEncryptor.getAlgorithm() == SymmetricKeyAlgorithmTags.NULL  && !(newKeyEncryptor instanceof GnuDivertToCardSecretKeyEncryptor)))
         {
             s2kUsage = SecretKeyPacket.USAGE_NONE;
             if (key.secret.getS2KUsage() == SecretKeyPacket.USAGE_SHA1)   // SHA-1 hash, need to rewrite checksum

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/GnuDivertToCardSecretKeyEncryptor.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/GnuDivertToCardSecretKeyEncryptor.java
@@ -1,0 +1,50 @@
+package org.bouncycastle.openpgp.operator;
+
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.operator.PBESecretKeyEncryptor;
+import org.bouncycastle.openpgp.operator.PGPDigestCalculator;
+
+import org.bouncycastle.bcpg.GnuExtendedS2K;
+import org.bouncycastle.bcpg.S2K;
+
+/**
+ * Secret key encryptor that allows to represent a secret key embedded
+ * on a smartcard, using GNU S2K extensions.
+ *
+ * This extension is documented on GnuPG documentation DETAILS file,
+ * section "GNU extensions to the S2K algorithm".
+ *
+ * @author Léonard Dallot <leonard.dallot@taztag.com>
+ */
+public class GnuDivertToCardSecretKeyEncryptor extends PBESecretKeyEncryptor {
+	private byte[] serial;
+
+	public GnuDivertToCardSecretKeyEncryptor(PGPDigestCalculator s2kDigestCalculator, byte[] serial) {
+		super(0, s2kDigestCalculator, 0, null, null);
+		this.s2k = new GnuExtendedS2K(S2K.GNU_PROTECTION_MODE_DIVERT_TO_CARD );
+		this.serial = new byte[serial.length+1];
+		this.serial[0] = (byte) serial.length;
+		System.arraycopy(serial, 0, this.serial, 1, serial.length);
+	}
+
+	@Override
+	public byte[] encryptKeyData(byte[] key, byte[] keyData, int keyOff,
+			int keyLen) throws PGPException {
+		if (serial != null && serial.length > 16) {
+			byte[] result = new byte[17];
+			System.arraycopy(serial, 0, result, 0, result.length);
+			return result;
+		}
+		return serial;
+	}
+
+	@Override
+	public byte[] getKey() throws PGPException {
+		return null;
+	}
+
+	@Override
+	public byte[] getCipherIV() {
+		return new byte[0];
+	}
+}


### PR DESCRIPTION
Allows to generate keys in the format used by GPG to store secret keys that are embedded on a smartcard.
