### PR TITLE
Support for session resumption using RFC5077 session ticket (TLSClient only)

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
@@ -90,8 +90,8 @@ public abstract class AbstractTlsClient
             // TODO Provide a way for the user to specify the acceptable
             // hash/signature algorithms.
 
-            short[] hashAlgorithms = new short[] { HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
-                    HashAlgorithm.sha224, HashAlgorithm.sha1 };
+            short[] hashAlgorithms = new short[] { HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256, HashAlgorithm.sha224,
+                    HashAlgorithm.sha1 };
 
             // TODO Sort out ECDSA signatures and add them as the preferred
             // option here
@@ -102,16 +102,14 @@ public abstract class AbstractTlsClient
             {
                 for (int j = 0; j < signatureAlgorithms.length; ++j)
                 {
-                    this.supportedSignatureAlgorithms
-                            .addElement(new SignatureAndHashAlgorithm(hashAlgorithms[i], signatureAlgorithms[j]));
+                    this.supportedSignatureAlgorithms.addElement(new SignatureAndHashAlgorithm(hashAlgorithms[i], signatureAlgorithms[j]));
                 }
             }
 
             /*
              * RFC 5264 7.4.3. Currently, DSA [DSS] may only be used with SHA-1.
              */
-            this.supportedSignatureAlgorithms
-                    .addElement(new SignatureAndHashAlgorithm(HashAlgorithm.sha1, SignatureAlgorithm.dsa));
+            this.supportedSignatureAlgorithms.addElement(new SignatureAndHashAlgorithm(HashAlgorithm.sha1, SignatureAlgorithm.dsa));
 
             clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
 
@@ -133,8 +131,8 @@ public abstract class AbstractTlsClient
              * configuration options.
              */
             this.namedCurves = new int[] { NamedCurve.secp256r1, NamedCurve.secp384r1 };
-            this.clientECPointFormats = new short[] { ECPointFormat.uncompressed,
-                    ECPointFormat.ansiX962_compressed_prime, ECPointFormat.ansiX962_compressed_char2, };
+            this.clientECPointFormats = new short[] { ECPointFormat.uncompressed, ECPointFormat.ansiX962_compressed_prime,
+                    ECPointFormat.ansiX962_compressed_char2, };
 
             clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
 
@@ -240,8 +238,7 @@ public abstract class AbstractTlsClient
         }
     }
 
-    public void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters)
-        throws IOException
+    public void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters) throws IOException
     {
     }
 

--- a/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
@@ -86,12 +86,12 @@ public abstract class AbstractTlsClient
             // TODO Provide a way for the user to specify the acceptable
             // hash/signature algorithms.
 
-            short[] hashAlgorithms = new short[] { HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
-                    HashAlgorithm.sha224, HashAlgorithm.sha1 };
+            short[] hashAlgorithms = new short[]{HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
+                    HashAlgorithm.sha224, HashAlgorithm.sha1};
 
             // TODO Sort out ECDSA signatures and add them as the preferred
             // option here
-            short[] signatureAlgorithms = new short[] { SignatureAlgorithm.rsa };
+            short[] signatureAlgorithms = new short[]{SignatureAlgorithm.rsa};
 
             this.supportedSignatureAlgorithms = new Vector();
             for (int i = 0; i < hashAlgorithms.length; ++i)
@@ -126,9 +126,9 @@ public abstract class AbstractTlsClient
              * TODO Could just add all the curves since we support them all, but users may not want to use unnecessarily
              * large fields. Need configuration options.
              */
-            this.namedCurves = new int[] { NamedCurve.secp256r1, NamedCurve.secp384r1 };
-            this.clientECPointFormats = new short[] { ECPointFormat.uncompressed,
-                    ECPointFormat.ansiX962_compressed_prime, ECPointFormat.ansiX962_compressed_char2, };
+            this.namedCurves = new int[]{NamedCurve.secp256r1, NamedCurve.secp384r1};
+            this.clientECPointFormats = new short[]{ECPointFormat.uncompressed, ECPointFormat.ansiX962_compressed_prime,
+                    ECPointFormat.ansiX962_compressed_char2,};
 
             clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
 
@@ -154,7 +154,7 @@ public abstract class AbstractTlsClient
 
     public short[] getCompressionMethods()
     {
-        return new short[] { CompressionMethod._null };
+        return new short[]{CompressionMethod._null};
     }
 
     public void notifySessionID(byte[] sessionID)

--- a/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
@@ -4,242 +4,218 @@ import java.io.IOException;
 import java.util.Hashtable;
 import java.util.Vector;
 
-public abstract class AbstractTlsClient
-    extends AbstractTlsPeer
-    implements TlsClient
-{
-    protected TlsCipherFactory cipherFactory;
+public abstract class AbstractTlsClient extends AbstractTlsPeer implements TlsClient {
+	protected TlsCipherFactory cipherFactory;
 
-    protected TlsClientContext context;
+	protected TlsClientContext context;
 
-    protected Vector supportedSignatureAlgorithms;
-    protected int[] namedCurves;
-    protected short[] clientECPointFormats, serverECPointFormats;
+	protected Vector supportedSignatureAlgorithms;
+	protected int[] namedCurves;
+	protected short[] clientECPointFormats, serverECPointFormats;
 
-    protected int selectedCipherSuite;
-    protected short selectedCompressionMethod;
+	protected int selectedCipherSuite;
+	protected short selectedCompressionMethod;
 
-    public AbstractTlsClient()
-    {
-        this(new DefaultTlsCipherFactory());
-    }
+	public AbstractTlsClient() {
+		this(new DefaultTlsCipherFactory());
+	}
 
-    public AbstractTlsClient(TlsCipherFactory cipherFactory)
-    {
-        this.cipherFactory = cipherFactory;
-    }
+	public AbstractTlsClient(TlsCipherFactory cipherFactory) {
+		this.cipherFactory = cipherFactory;
+	}
 
-    public void init(TlsClientContext context)
-    {
-        this.context = context;
-    }
+	public void init(TlsClientContext context) {
+		this.context = context;
+	}
 
-    public TlsSession getSessionToResume()
-    {
-        return null;
-    }
+	public TlsSession getSessionToResume() {
+		return null;
+	}
 
-    /**
-     * RFC 5246 E.1. "TLS clients that wish to negotiate with older servers MAY send any value
-     * {03,XX} as the record layer version number. Typical values would be {03,00}, the lowest
-     * version number supported by the client, and the value of ClientHello.client_version. No
-     * single value will guarantee interoperability with all old servers, but this is a complex
-     * topic beyond the scope of this document."
-     */
-    public ProtocolVersion getClientHelloRecordLayerVersion()
-    {
-        // "{03,00}"
-        // return ProtocolVersion.SSLv3;
+	/**
+	 * RFC 5246 E.1. "TLS clients that wish to negotiate with older servers MAY
+	 * send any value {03,XX} as the record layer version number. Typical values
+	 * would be {03,00}, the lowest version number supported by the client, and
+	 * the value of ClientHello.client_version. No single value will guarantee
+	 * interoperability with all old servers, but this is a complex topic beyond
+	 * the scope of this document."
+	 */
+	public ProtocolVersion getClientHelloRecordLayerVersion() {
+		// "{03,00}"
+		// return ProtocolVersion.SSLv3;
 
-        // "the lowest version number supported by the client"
-        // return getMinimumVersion();
+		// "the lowest version number supported by the client"
+		// return getMinimumVersion();
 
-        // "the value of ClientHello.client_version"
-        return getClientVersion();
-    }
+		// "the value of ClientHello.client_version"
+		return getClientVersion();
+	}
 
-    public ProtocolVersion getClientVersion()
-    {
-        return ProtocolVersion.TLSv12;
-    }
+	public ProtocolVersion getClientVersion() {
+		return ProtocolVersion.TLSv12;
+	}
 
-    public boolean isFallback()
-    {
-        /*
-         * draft-ietf-tls-downgrade-scsv-00 4. [..] is meant for use by clients that repeat a
-         * connection attempt with a downgraded protocol in order to avoid interoperability problems
-         * with legacy servers.
-         */
-        return false;
-    }
+	public boolean isFallback() {
+		/*
+		 * draft-ietf-tls-downgrade-scsv-00 4. [..] is meant for use by clients
+		 * that repeat a connection attempt with a downgraded protocol in order
+		 * to avoid interoperability problems with legacy servers.
+		 */
+		return false;
+	}
 
-    public Hashtable getClientExtensions()
-        throws IOException
-    {
-        Hashtable clientExtensions = null;
+	public Hashtable getClientExtensions() throws IOException {
+		Hashtable clientExtensions = null;
 
-        ProtocolVersion clientVersion = context.getClientVersion();
+		ProtocolVersion clientVersion = context.getClientVersion();
 
-        /*
-         * RFC 5246 7.4.1.4.1. Note: this extension is not meaningful for TLS versions prior to 1.2.
-         * Clients MUST NOT offer it if they are offering prior versions.
-         */
-        if (TlsUtils.isSignatureAlgorithmsExtensionAllowed(clientVersion))
-        {
-            // TODO Provide a way for the user to specify the acceptable hash/signature algorithms.
+		/*
+		 * RFC 5246 7.4.1.4.1. Note: this extension is not meaningful for TLS
+		 * versions prior to 1.2. Clients MUST NOT offer it if they are offering
+		 * prior versions.
+		 */
+		if (TlsUtils.isSignatureAlgorithmsExtensionAllowed(clientVersion)) {
+			// TODO Provide a way for the user to specify the acceptable
+			// hash/signature algorithms.
 
-            short[] hashAlgorithms = new short[]{ HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
-                HashAlgorithm.sha224, HashAlgorithm.sha1 };
+			short[] hashAlgorithms = new short[] { HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
+					HashAlgorithm.sha224, HashAlgorithm.sha1 };
 
-            // TODO Sort out ECDSA signatures and add them as the preferred option here
-            short[] signatureAlgorithms = new short[]{ SignatureAlgorithm.rsa };
+			// TODO Sort out ECDSA signatures and add them as the preferred
+			// option here
+			short[] signatureAlgorithms = new short[] { SignatureAlgorithm.rsa };
 
-            this.supportedSignatureAlgorithms = new Vector();
-            for (int i = 0; i < hashAlgorithms.length; ++i)
-            {
-                for (int j = 0; j < signatureAlgorithms.length; ++j)
-                {
-                    this.supportedSignatureAlgorithms.addElement(new SignatureAndHashAlgorithm(hashAlgorithms[i],
-                        signatureAlgorithms[j]));
-                }
-            }
+			this.supportedSignatureAlgorithms = new Vector();
+			for (int i = 0; i < hashAlgorithms.length; ++i) {
+				for (int j = 0; j < signatureAlgorithms.length; ++j) {
+					this.supportedSignatureAlgorithms
+							.addElement(new SignatureAndHashAlgorithm(hashAlgorithms[i], signatureAlgorithms[j]));
+				}
+			}
 
-            /*
-             * RFC 5264 7.4.3. Currently, DSA [DSS] may only be used with SHA-1.
-             */
-            this.supportedSignatureAlgorithms.addElement(new SignatureAndHashAlgorithm(HashAlgorithm.sha1,
-                SignatureAlgorithm.dsa));
+			/*
+			 * RFC 5264 7.4.3. Currently, DSA [DSS] may only be used with SHA-1.
+			 */
+			this.supportedSignatureAlgorithms
+					.addElement(new SignatureAndHashAlgorithm(HashAlgorithm.sha1, SignatureAlgorithm.dsa));
 
-            clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
+			clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
 
-            TlsUtils.addSignatureAlgorithmsExtension(clientExtensions, supportedSignatureAlgorithms);
-        }
+			TlsUtils.addSignatureAlgorithmsExtension(clientExtensions, supportedSignatureAlgorithms);
+		}
 
-        if (TlsECCUtils.containsECCCipherSuites(getCipherSuites()))
-        {
-            /*
-             * RFC 4492 5.1. A client that proposes ECC cipher suites in its ClientHello message
-             * appends these extensions (along with any others), enumerating the curves it supports
-             * and the point formats it can parse. Clients SHOULD send both the Supported Elliptic
-             * Curves Extension and the Supported Point Formats Extension.
-             */
-            /*
-             * TODO Could just add all the curves since we support them all, but users may not want
-             * to use unnecessarily large fields. Need configuration options.
-             */
-            this.namedCurves = new int[]{ NamedCurve.secp256r1, NamedCurve.secp384r1 };
-            this.clientECPointFormats = new short[]{ ECPointFormat.uncompressed,
-                ECPointFormat.ansiX962_compressed_prime, ECPointFormat.ansiX962_compressed_char2, };
+		if (TlsECCUtils.containsECCCipherSuites(getCipherSuites())) {
+			/*
+			 * RFC 4492 5.1. A client that proposes ECC cipher suites in its
+			 * ClientHello message appends these extensions (along with any
+			 * others), enumerating the curves it supports and the point formats
+			 * it can parse. Clients SHOULD send both the Supported Elliptic
+			 * Curves Extension and the Supported Point Formats Extension.
+			 */
+			/*
+			 * TODO Could just add all the curves since we support them all, but
+			 * users may not want to use unnecessarily large fields. Need
+			 * configuration options.
+			 */
+			this.namedCurves = new int[] { NamedCurve.secp256r1, NamedCurve.secp384r1 };
+			this.clientECPointFormats = new short[] { ECPointFormat.uncompressed,
+					ECPointFormat.ansiX962_compressed_prime, ECPointFormat.ansiX962_compressed_char2, };
 
-            clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
+			clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
 
-            TlsECCUtils.addSupportedEllipticCurvesExtension(clientExtensions, namedCurves);
-            TlsECCUtils.addSupportedPointFormatsExtension(clientExtensions, clientECPointFormats);
-        }
+			TlsECCUtils.addSupportedEllipticCurvesExtension(clientExtensions, namedCurves);
+			TlsECCUtils.addSupportedPointFormatsExtension(clientExtensions, clientECPointFormats);
+		}
 
-        return clientExtensions;
-    }
+		return clientExtensions;
+	}
 
-    public ProtocolVersion getMinimumVersion()
-    {
-        return ProtocolVersion.TLSv10;
-    }
+	public ProtocolVersion getMinimumVersion() {
+		return ProtocolVersion.TLSv10;
+	}
 
-    public void notifyServerVersion(ProtocolVersion serverVersion)
-        throws IOException
-    {
-        if (!getMinimumVersion().isEqualOrEarlierVersionOf(serverVersion))
-        {
-            throw new TlsFatalAlert(AlertDescription.protocol_version);
-        }
-    }
+	public void notifyServerVersion(ProtocolVersion serverVersion) throws IOException {
+		if (!getMinimumVersion().isEqualOrEarlierVersionOf(serverVersion)) {
+			throw new TlsFatalAlert(AlertDescription.protocol_version);
+		}
+	}
 
-    public short[] getCompressionMethods()
-    {
-        return new short[]{CompressionMethod._null};
-    }
+	public short[] getCompressionMethods() {
+		return new short[] { CompressionMethod._null };
+	}
 
-    public void notifySessionID(byte[] sessionID)
-    {
-        // Currently ignored
-    }
+	public void notifySessionID(byte[] sessionID) {
+		// Currently ignored
+	}
 
-    public void notifySelectedCipherSuite(int selectedCipherSuite)
-    {
-        this.selectedCipherSuite = selectedCipherSuite;
-    }
+	public void notifySelectedCipherSuite(int selectedCipherSuite) {
+		this.selectedCipherSuite = selectedCipherSuite;
+	}
 
-    public void notifySelectedCompressionMethod(short selectedCompressionMethod)
-    {
-        this.selectedCompressionMethod = selectedCompressionMethod;
-    }
+	public void notifySelectedCompressionMethod(short selectedCompressionMethod) {
+		this.selectedCompressionMethod = selectedCompressionMethod;
+	}
 
-    public void processServerExtensions(Hashtable serverExtensions)
-        throws IOException
-    {
-        /*
-         * TlsProtocol implementation validates that any server extensions received correspond to
-         * client extensions sent. By default, we don't send any, and this method is not called.
-         */
-        if (serverExtensions != null)
-        {
-            /*
-             * RFC 5246 7.4.1.4.1. Servers MUST NOT send this extension.
-             */
-            if (serverExtensions.containsKey(TlsUtils.EXT_signature_algorithms))
-            {
-                throw new TlsFatalAlert(AlertDescription.illegal_parameter);
-            }
+	public void processServerExtensions(Hashtable serverExtensions) throws IOException {
+		/*
+		 * TlsProtocol implementation validates that any server extensions
+		 * received correspond to client extensions sent. By default, we don't
+		 * send any, and this method is not called.
+		 */
+		if (serverExtensions != null) {
+			/*
+			 * RFC 5246 7.4.1.4.1. Servers MUST NOT send this extension.
+			 */
+			if (serverExtensions.containsKey(TlsUtils.EXT_signature_algorithms)) {
+				throw new TlsFatalAlert(AlertDescription.illegal_parameter);
+			}
 
-            int[] namedCurves = TlsECCUtils.getSupportedEllipticCurvesExtension(serverExtensions);
-            if (namedCurves != null)
-            {
-                throw new TlsFatalAlert(AlertDescription.illegal_parameter);
-            }
+			int[] namedCurves = TlsECCUtils.getSupportedEllipticCurvesExtension(serverExtensions);
+			if (namedCurves != null) {
+				throw new TlsFatalAlert(AlertDescription.illegal_parameter);
+			}
 
-            this.serverECPointFormats = TlsECCUtils.getSupportedPointFormatsExtension(serverExtensions);
-            if (this.serverECPointFormats != null && !TlsECCUtils.isECCCipherSuite(this.selectedCipherSuite))
-            {
-                throw new TlsFatalAlert(AlertDescription.illegal_parameter);
-            }
-        }
-    }
+			this.serverECPointFormats = TlsECCUtils.getSupportedPointFormatsExtension(serverExtensions);
+			if (this.serverECPointFormats != null && !TlsECCUtils.isECCCipherSuite(this.selectedCipherSuite)) {
+				throw new TlsFatalAlert(AlertDescription.illegal_parameter);
+			}
+		}
+	}
 
-    public void processServerSupplementalData(Vector serverSupplementalData)
-        throws IOException
-    {
-        if (serverSupplementalData != null)
-        {
-            throw new TlsFatalAlert(AlertDescription.unexpected_message);
-        }
-    }
+	public void processServerSupplementalData(Vector serverSupplementalData) throws IOException {
+		if (serverSupplementalData != null) {
+			throw new TlsFatalAlert(AlertDescription.unexpected_message);
+		}
+	}
 
-    public Vector getClientSupplementalData()
-        throws IOException
-    {
-        return null;
-    }
+	public Vector getClientSupplementalData() throws IOException {
+		return null;
+	}
 
-    public TlsCompression getCompression()
-        throws IOException
-    {
-        switch (selectedCompressionMethod)
-        {
-        case CompressionMethod._null:
-            return new TlsNullCompression();
+	public TlsCompression getCompression() throws IOException {
+		switch (selectedCompressionMethod) {
+		case CompressionMethod._null:
+			return new TlsNullCompression();
 
-        default:
-            /*
-             * Note: internal error here; the TlsProtocol implementation verifies that the
-             * server-selected compression method was in the list of client-offered compression
-             * methods, so if we now can't produce an implementation, we shouldn't have offered it!
-             */
-            throw new TlsFatalAlert(AlertDescription.internal_error);
-        }
-    }
+		default:
+			/*
+			 * Note: internal error here; the TlsProtocol implementation
+			 * verifies that the server-selected compression method was in the
+			 * list of client-offered compression methods, so if we now can't
+			 * produce an implementation, we shouldn't have offered it!
+			 */
+			throw new TlsFatalAlert(AlertDescription.internal_error);
+		}
+	}
 
-    public void notifyNewSessionTicket(NewSessionTicket newSessionTicket)
-        throws IOException
-    {
-    }
+	public void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters) throws IOException {
+	}
+
+	public NewSessionTicket getNewSessionTicket() throws IOException {
+		return null;
+	}
+
+	public SecurityParameters getSecurityParameters() throws IOException {
+		return null;
+	}
 }

--- a/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
@@ -5,8 +5,8 @@ import java.util.Hashtable;
 import java.util.Vector;
 
 public abstract class AbstractTlsClient
-        extends AbstractTlsPeer
-        implements TlsClient
+    extends AbstractTlsPeer
+    implements TlsClient
 {
     protected TlsCipherFactory cipherFactory;
 
@@ -88,12 +88,12 @@ public abstract class AbstractTlsClient
             // TODO Provide a way for the user to specify the acceptable
             // hash/signature algorithms.
 
-            short[] hashAlgorithms = new short[]{HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
-                    HashAlgorithm.sha224, HashAlgorithm.sha1};
+            short[] hashAlgorithms = new short[]{ HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
+                    HashAlgorithm.sha224, HashAlgorithm.sha1 };
 
             // TODO Sort out ECDSA signatures and add them as the preferred
             // option here
-            short[] signatureAlgorithms = new short[]{SignatureAlgorithm.rsa};
+            short[] signatureAlgorithms = new short[]{ SignatureAlgorithm.rsa };
 
             this.supportedSignatureAlgorithms = new Vector();
             for (int i = 0; i < hashAlgorithms.length; ++i)
@@ -128,9 +128,9 @@ public abstract class AbstractTlsClient
              * TODO Could just add all the curves since we support them all, but users may not want
              * to use unnecessarily large fields. Need configuration options.
              */
-            this.namedCurves = new int[]{NamedCurve.secp256r1, NamedCurve.secp384r1};
-            this.clientECPointFormats = new short[]{ECPointFormat.uncompressed, ECPointFormat.ansiX962_compressed_prime,
-                    ECPointFormat.ansiX962_compressed_char2,};
+            this.namedCurves = new int[]{ NamedCurve.secp256r1, NamedCurve.secp384r1 };
+            this.clientECPointFormats = new short[]{ ECPointFormat.uncompressed,
+                    ECPointFormat.ansiX962_compressed_prime, ECPointFormat.ansiX962_compressed_char2, };
 
             clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
 
@@ -156,7 +156,7 @@ public abstract class AbstractTlsClient
 
     public short[] getCompressionMethods()
     {
-        return new short[]{CompressionMethod._null};
+        return new short[]{ CompressionMethod._null };
     }
 
     public void notifySessionID(byte[] sessionID)

--- a/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
@@ -40,12 +40,10 @@ public abstract class AbstractTlsClient
     }
 
     /**
-     * RFC 5246 E.1. "TLS clients that wish to negotiate with older servers MAY
-     * send any value {03,XX} as the record layer version number. Typical values
-     * would be {03,00}, the lowest version number supported by the client, and
-     * the value of ClientHello.client_version. No single value will guarantee
-     * interoperability with all old servers, but this is a complex topic beyond
-     * the scope of this document."
+     * RFC 5246 E.1. "TLS clients that wish to negotiate with older servers MAY send any value {03,XX} as the record
+     * layer version number. Typical values would be {03,00}, the lowest version number supported by the client, and the
+     * value of ClientHello.client_version. No single value will guarantee interoperability with all old servers, but
+     * this is a complex topic beyond the scope of this document."
      */
     public ProtocolVersion getClientHelloRecordLayerVersion()
     {
@@ -67,9 +65,8 @@ public abstract class AbstractTlsClient
     public boolean isFallback()
     {
         /*
-         * draft-ietf-tls-downgrade-scsv-00 4. [..] is meant for use by clients
-         * that repeat a connection attempt with a downgraded protocol in order
-         * to avoid interoperability problems with legacy servers.
+         * draft-ietf-tls-downgrade-scsv-00 4. [..] is meant for use by clients that repeat a connection attempt with a
+         * downgraded protocol in order to avoid interoperability problems with legacy servers.
          */
         return false;
     }
@@ -81,17 +78,16 @@ public abstract class AbstractTlsClient
         ProtocolVersion clientVersion = context.getClientVersion();
 
         /*
-         * RFC 5246 7.4.1.4.1. Note: this extension is not meaningful for TLS
-         * versions prior to 1.2. Clients MUST NOT offer it if they are offering
-         * prior versions.
+         * RFC 5246 7.4.1.4.1. Note: this extension is not meaningful for TLS versions prior to 1.2. Clients MUST NOT
+         * offer it if they are offering prior versions.
          */
         if (TlsUtils.isSignatureAlgorithmsExtensionAllowed(clientVersion))
         {
             // TODO Provide a way for the user to specify the acceptable
             // hash/signature algorithms.
 
-            short[] hashAlgorithms = new short[] { HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256, HashAlgorithm.sha224,
-                    HashAlgorithm.sha1 };
+            short[] hashAlgorithms = new short[] { HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
+                    HashAlgorithm.sha224, HashAlgorithm.sha1 };
 
             // TODO Sort out ECDSA signatures and add them as the preferred
             // option here
@@ -102,14 +98,16 @@ public abstract class AbstractTlsClient
             {
                 for (int j = 0; j < signatureAlgorithms.length; ++j)
                 {
-                    this.supportedSignatureAlgorithms.addElement(new SignatureAndHashAlgorithm(hashAlgorithms[i], signatureAlgorithms[j]));
+                    this.supportedSignatureAlgorithms
+                            .addElement(new SignatureAndHashAlgorithm(hashAlgorithms[i], signatureAlgorithms[j]));
                 }
             }
 
             /*
              * RFC 5264 7.4.3. Currently, DSA [DSS] may only be used with SHA-1.
              */
-            this.supportedSignatureAlgorithms.addElement(new SignatureAndHashAlgorithm(HashAlgorithm.sha1, SignatureAlgorithm.dsa));
+            this.supportedSignatureAlgorithms
+                    .addElement(new SignatureAndHashAlgorithm(HashAlgorithm.sha1, SignatureAlgorithm.dsa));
 
             clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
 
@@ -119,20 +117,18 @@ public abstract class AbstractTlsClient
         if (TlsECCUtils.containsECCCipherSuites(getCipherSuites()))
         {
             /*
-             * RFC 4492 5.1. A client that proposes ECC cipher suites in its
-             * ClientHello message appends these extensions (along with any
-             * others), enumerating the curves it supports and the point formats
-             * it can parse. Clients SHOULD send both the Supported Elliptic
-             * Curves Extension and the Supported Point Formats Extension.
+             * RFC 4492 5.1. A client that proposes ECC cipher suites in its ClientHello message appends these
+             * extensions (along with any others), enumerating the curves it supports and the point formats it can
+             * parse. Clients SHOULD send both the Supported Elliptic Curves Extension and the Supported Point Formats
+             * Extension.
              */
             /*
-             * TODO Could just add all the curves since we support them all, but
-             * users may not want to use unnecessarily large fields. Need
-             * configuration options.
+             * TODO Could just add all the curves since we support them all, but users may not want to use unnecessarily
+             * large fields. Need configuration options.
              */
             this.namedCurves = new int[] { NamedCurve.secp256r1, NamedCurve.secp384r1 };
-            this.clientECPointFormats = new short[] { ECPointFormat.uncompressed, ECPointFormat.ansiX962_compressed_prime,
-                    ECPointFormat.ansiX962_compressed_char2, };
+            this.clientECPointFormats = new short[] { ECPointFormat.uncompressed,
+                    ECPointFormat.ansiX962_compressed_prime, ECPointFormat.ansiX962_compressed_char2, };
 
             clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
 
@@ -179,9 +175,8 @@ public abstract class AbstractTlsClient
     public void processServerExtensions(Hashtable serverExtensions) throws IOException
     {
         /*
-         * TlsProtocol implementation validates that any server extensions
-         * received correspond to client extensions sent. By default, we don't
-         * send any, and this method is not called.
+         * TlsProtocol implementation validates that any server extensions received correspond to client extensions
+         * sent. By default, we don't send any, and this method is not called.
          */
         if (serverExtensions != null)
         {
@@ -229,16 +224,16 @@ public abstract class AbstractTlsClient
 
         default:
             /*
-             * Note: internal error here; the TlsProtocol implementation
-             * verifies that the server-selected compression method was in the
-             * list of client-offered compression methods, so if we now can't
-             * produce an implementation, we shouldn't have offered it!
+             * Note: internal error here; the TlsProtocol implementation verifies that the server-selected compression
+             * method was in the list of client-offered compression methods, so if we now can't produce an
+             * implementation, we shouldn't have offered it!
              */
             throw new TlsFatalAlert(AlertDescription.internal_error);
         }
     }
 
-    public void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters) throws IOException
+    public void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters)
+        throws IOException
     {
     }
 

--- a/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
@@ -4,218 +4,254 @@ import java.io.IOException;
 import java.util.Hashtable;
 import java.util.Vector;
 
-public abstract class AbstractTlsClient extends AbstractTlsPeer implements TlsClient {
-	protected TlsCipherFactory cipherFactory;
+public abstract class AbstractTlsClient
+        extends AbstractTlsPeer
+        implements TlsClient
+{
+    protected TlsCipherFactory cipherFactory;
 
-	protected TlsClientContext context;
+    protected TlsClientContext context;
 
-	protected Vector supportedSignatureAlgorithms;
-	protected int[] namedCurves;
-	protected short[] clientECPointFormats, serverECPointFormats;
+    protected Vector supportedSignatureAlgorithms;
+    protected int[] namedCurves;
+    protected short[] clientECPointFormats, serverECPointFormats;
 
-	protected int selectedCipherSuite;
-	protected short selectedCompressionMethod;
+    protected int selectedCipherSuite;
+    protected short selectedCompressionMethod;
 
-	public AbstractTlsClient() {
-		this(new DefaultTlsCipherFactory());
-	}
+    public AbstractTlsClient()
+    {
+        this(new DefaultTlsCipherFactory());
+    }
 
-	public AbstractTlsClient(TlsCipherFactory cipherFactory) {
-		this.cipherFactory = cipherFactory;
-	}
+    public AbstractTlsClient(TlsCipherFactory cipherFactory)
+    {
+        this.cipherFactory = cipherFactory;
+    }
 
-	public void init(TlsClientContext context) {
-		this.context = context;
-	}
+    public void init(TlsClientContext context)
+    {
+        this.context = context;
+    }
 
-	public TlsSession getSessionToResume() {
-		return null;
-	}
+    public TlsSession getSessionToResume()
+    {
+        return null;
+    }
 
-	/**
-	 * RFC 5246 E.1. "TLS clients that wish to negotiate with older servers MAY
-	 * send any value {03,XX} as the record layer version number. Typical values
-	 * would be {03,00}, the lowest version number supported by the client, and
-	 * the value of ClientHello.client_version. No single value will guarantee
-	 * interoperability with all old servers, but this is a complex topic beyond
-	 * the scope of this document."
-	 */
-	public ProtocolVersion getClientHelloRecordLayerVersion() {
-		// "{03,00}"
-		// return ProtocolVersion.SSLv3;
+    /**
+     * RFC 5246 E.1. "TLS clients that wish to negotiate with older servers MAY
+     * send any value {03,XX} as the record layer version number. Typical values
+     * would be {03,00}, the lowest version number supported by the client, and
+     * the value of ClientHello.client_version. No single value will guarantee
+     * interoperability with all old servers, but this is a complex topic beyond
+     * the scope of this document."
+     */
+    public ProtocolVersion getClientHelloRecordLayerVersion()
+    {
+        // "{03,00}"
+        // return ProtocolVersion.SSLv3;
 
-		// "the lowest version number supported by the client"
-		// return getMinimumVersion();
+        // "the lowest version number supported by the client"
+        // return getMinimumVersion();
 
-		// "the value of ClientHello.client_version"
-		return getClientVersion();
-	}
+        // "the value of ClientHello.client_version"
+        return getClientVersion();
+    }
 
-	public ProtocolVersion getClientVersion() {
-		return ProtocolVersion.TLSv12;
-	}
+    public ProtocolVersion getClientVersion()
+    {
+        return ProtocolVersion.TLSv12;
+    }
 
-	public boolean isFallback() {
-		/*
-		 * draft-ietf-tls-downgrade-scsv-00 4. [..] is meant for use by clients
-		 * that repeat a connection attempt with a downgraded protocol in order
-		 * to avoid interoperability problems with legacy servers.
-		 */
-		return false;
-	}
+    public boolean isFallback()
+    {
+        /*
+         * draft-ietf-tls-downgrade-scsv-00 4. [..] is meant for use by clients
+         * that repeat a connection attempt with a downgraded protocol in order
+         * to avoid interoperability problems with legacy servers.
+         */
+        return false;
+    }
 
-	public Hashtable getClientExtensions() throws IOException {
-		Hashtable clientExtensions = null;
+    public Hashtable getClientExtensions() throws IOException
+    {
+        Hashtable clientExtensions = null;
 
-		ProtocolVersion clientVersion = context.getClientVersion();
+        ProtocolVersion clientVersion = context.getClientVersion();
 
-		/*
-		 * RFC 5246 7.4.1.4.1. Note: this extension is not meaningful for TLS
-		 * versions prior to 1.2. Clients MUST NOT offer it if they are offering
-		 * prior versions.
-		 */
-		if (TlsUtils.isSignatureAlgorithmsExtensionAllowed(clientVersion)) {
-			// TODO Provide a way for the user to specify the acceptable
-			// hash/signature algorithms.
+        /*
+         * RFC 5246 7.4.1.4.1. Note: this extension is not meaningful for TLS
+         * versions prior to 1.2. Clients MUST NOT offer it if they are offering
+         * prior versions.
+         */
+        if (TlsUtils.isSignatureAlgorithmsExtensionAllowed(clientVersion))
+        {
+            // TODO Provide a way for the user to specify the acceptable
+            // hash/signature algorithms.
 
-			short[] hashAlgorithms = new short[] { HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
-					HashAlgorithm.sha224, HashAlgorithm.sha1 };
+            short[] hashAlgorithms = new short[] { HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
+                    HashAlgorithm.sha224, HashAlgorithm.sha1 };
 
-			// TODO Sort out ECDSA signatures and add them as the preferred
-			// option here
-			short[] signatureAlgorithms = new short[] { SignatureAlgorithm.rsa };
+            // TODO Sort out ECDSA signatures and add them as the preferred
+            // option here
+            short[] signatureAlgorithms = new short[] { SignatureAlgorithm.rsa };
 
-			this.supportedSignatureAlgorithms = new Vector();
-			for (int i = 0; i < hashAlgorithms.length; ++i) {
-				for (int j = 0; j < signatureAlgorithms.length; ++j) {
-					this.supportedSignatureAlgorithms
-							.addElement(new SignatureAndHashAlgorithm(hashAlgorithms[i], signatureAlgorithms[j]));
-				}
-			}
+            this.supportedSignatureAlgorithms = new Vector();
+            for (int i = 0; i < hashAlgorithms.length; ++i)
+            {
+                for (int j = 0; j < signatureAlgorithms.length; ++j)
+                {
+                    this.supportedSignatureAlgorithms
+                            .addElement(new SignatureAndHashAlgorithm(hashAlgorithms[i], signatureAlgorithms[j]));
+                }
+            }
 
-			/*
-			 * RFC 5264 7.4.3. Currently, DSA [DSS] may only be used with SHA-1.
-			 */
-			this.supportedSignatureAlgorithms
-					.addElement(new SignatureAndHashAlgorithm(HashAlgorithm.sha1, SignatureAlgorithm.dsa));
+            /*
+             * RFC 5264 7.4.3. Currently, DSA [DSS] may only be used with SHA-1.
+             */
+            this.supportedSignatureAlgorithms
+                    .addElement(new SignatureAndHashAlgorithm(HashAlgorithm.sha1, SignatureAlgorithm.dsa));
 
-			clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
+            clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
 
-			TlsUtils.addSignatureAlgorithmsExtension(clientExtensions, supportedSignatureAlgorithms);
-		}
+            TlsUtils.addSignatureAlgorithmsExtension(clientExtensions, supportedSignatureAlgorithms);
+        }
 
-		if (TlsECCUtils.containsECCCipherSuites(getCipherSuites())) {
-			/*
-			 * RFC 4492 5.1. A client that proposes ECC cipher suites in its
-			 * ClientHello message appends these extensions (along with any
-			 * others), enumerating the curves it supports and the point formats
-			 * it can parse. Clients SHOULD send both the Supported Elliptic
-			 * Curves Extension and the Supported Point Formats Extension.
-			 */
-			/*
-			 * TODO Could just add all the curves since we support them all, but
-			 * users may not want to use unnecessarily large fields. Need
-			 * configuration options.
-			 */
-			this.namedCurves = new int[] { NamedCurve.secp256r1, NamedCurve.secp384r1 };
-			this.clientECPointFormats = new short[] { ECPointFormat.uncompressed,
-					ECPointFormat.ansiX962_compressed_prime, ECPointFormat.ansiX962_compressed_char2, };
+        if (TlsECCUtils.containsECCCipherSuites(getCipherSuites()))
+        {
+            /*
+             * RFC 4492 5.1. A client that proposes ECC cipher suites in its
+             * ClientHello message appends these extensions (along with any
+             * others), enumerating the curves it supports and the point formats
+             * it can parse. Clients SHOULD send both the Supported Elliptic
+             * Curves Extension and the Supported Point Formats Extension.
+             */
+            /*
+             * TODO Could just add all the curves since we support them all, but
+             * users may not want to use unnecessarily large fields. Need
+             * configuration options.
+             */
+            this.namedCurves = new int[] { NamedCurve.secp256r1, NamedCurve.secp384r1 };
+            this.clientECPointFormats = new short[] { ECPointFormat.uncompressed,
+                    ECPointFormat.ansiX962_compressed_prime, ECPointFormat.ansiX962_compressed_char2, };
 
-			clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
+            clientExtensions = TlsExtensionsUtils.ensureExtensionsInitialised(clientExtensions);
 
-			TlsECCUtils.addSupportedEllipticCurvesExtension(clientExtensions, namedCurves);
-			TlsECCUtils.addSupportedPointFormatsExtension(clientExtensions, clientECPointFormats);
-		}
+            TlsECCUtils.addSupportedEllipticCurvesExtension(clientExtensions, namedCurves);
+            TlsECCUtils.addSupportedPointFormatsExtension(clientExtensions, clientECPointFormats);
+        }
 
-		return clientExtensions;
-	}
+        return clientExtensions;
+    }
 
-	public ProtocolVersion getMinimumVersion() {
-		return ProtocolVersion.TLSv10;
-	}
+    public ProtocolVersion getMinimumVersion()
+    {
+        return ProtocolVersion.TLSv10;
+    }
 
-	public void notifyServerVersion(ProtocolVersion serverVersion) throws IOException {
-		if (!getMinimumVersion().isEqualOrEarlierVersionOf(serverVersion)) {
-			throw new TlsFatalAlert(AlertDescription.protocol_version);
-		}
-	}
+    public void notifyServerVersion(ProtocolVersion serverVersion) throws IOException
+    {
+        if (!getMinimumVersion().isEqualOrEarlierVersionOf(serverVersion))
+        {
+            throw new TlsFatalAlert(AlertDescription.protocol_version);
+        }
+    }
 
-	public short[] getCompressionMethods() {
-		return new short[] { CompressionMethod._null };
-	}
+    public short[] getCompressionMethods()
+    {
+        return new short[] { CompressionMethod._null };
+    }
 
-	public void notifySessionID(byte[] sessionID) {
-		// Currently ignored
-	}
+    public void notifySessionID(byte[] sessionID)
+    {
+        // Currently ignored
+    }
 
-	public void notifySelectedCipherSuite(int selectedCipherSuite) {
-		this.selectedCipherSuite = selectedCipherSuite;
-	}
+    public void notifySelectedCipherSuite(int selectedCipherSuite)
+    {
+        this.selectedCipherSuite = selectedCipherSuite;
+    }
 
-	public void notifySelectedCompressionMethod(short selectedCompressionMethod) {
-		this.selectedCompressionMethod = selectedCompressionMethod;
-	}
+    public void notifySelectedCompressionMethod(short selectedCompressionMethod)
+    {
+        this.selectedCompressionMethod = selectedCompressionMethod;
+    }
 
-	public void processServerExtensions(Hashtable serverExtensions) throws IOException {
-		/*
-		 * TlsProtocol implementation validates that any server extensions
-		 * received correspond to client extensions sent. By default, we don't
-		 * send any, and this method is not called.
-		 */
-		if (serverExtensions != null) {
-			/*
-			 * RFC 5246 7.4.1.4.1. Servers MUST NOT send this extension.
-			 */
-			if (serverExtensions.containsKey(TlsUtils.EXT_signature_algorithms)) {
-				throw new TlsFatalAlert(AlertDescription.illegal_parameter);
-			}
+    public void processServerExtensions(Hashtable serverExtensions) throws IOException
+    {
+        /*
+         * TlsProtocol implementation validates that any server extensions
+         * received correspond to client extensions sent. By default, we don't
+         * send any, and this method is not called.
+         */
+        if (serverExtensions != null)
+        {
+            /*
+             * RFC 5246 7.4.1.4.1. Servers MUST NOT send this extension.
+             */
+            if (serverExtensions.containsKey(TlsUtils.EXT_signature_algorithms))
+            {
+                throw new TlsFatalAlert(AlertDescription.illegal_parameter);
+            }
 
-			int[] namedCurves = TlsECCUtils.getSupportedEllipticCurvesExtension(serverExtensions);
-			if (namedCurves != null) {
-				throw new TlsFatalAlert(AlertDescription.illegal_parameter);
-			}
+            int[] namedCurves = TlsECCUtils.getSupportedEllipticCurvesExtension(serverExtensions);
+            if (namedCurves != null)
+            {
+                throw new TlsFatalAlert(AlertDescription.illegal_parameter);
+            }
 
-			this.serverECPointFormats = TlsECCUtils.getSupportedPointFormatsExtension(serverExtensions);
-			if (this.serverECPointFormats != null && !TlsECCUtils.isECCCipherSuite(this.selectedCipherSuite)) {
-				throw new TlsFatalAlert(AlertDescription.illegal_parameter);
-			}
-		}
-	}
+            this.serverECPointFormats = TlsECCUtils.getSupportedPointFormatsExtension(serverExtensions);
+            if (this.serverECPointFormats != null && !TlsECCUtils.isECCCipherSuite(this.selectedCipherSuite))
+            {
+                throw new TlsFatalAlert(AlertDescription.illegal_parameter);
+            }
+        }
+    }
 
-	public void processServerSupplementalData(Vector serverSupplementalData) throws IOException {
-		if (serverSupplementalData != null) {
-			throw new TlsFatalAlert(AlertDescription.unexpected_message);
-		}
-	}
+    public void processServerSupplementalData(Vector serverSupplementalData) throws IOException
+    {
+        if (serverSupplementalData != null)
+        {
+            throw new TlsFatalAlert(AlertDescription.unexpected_message);
+        }
+    }
 
-	public Vector getClientSupplementalData() throws IOException {
-		return null;
-	}
+    public Vector getClientSupplementalData() throws IOException
+    {
+        return null;
+    }
 
-	public TlsCompression getCompression() throws IOException {
-		switch (selectedCompressionMethod) {
-		case CompressionMethod._null:
-			return new TlsNullCompression();
+    public TlsCompression getCompression() throws IOException
+    {
+        switch (selectedCompressionMethod)
+        {
+        case CompressionMethod._null:
+            return new TlsNullCompression();
 
-		default:
-			/*
-			 * Note: internal error here; the TlsProtocol implementation
-			 * verifies that the server-selected compression method was in the
-			 * list of client-offered compression methods, so if we now can't
-			 * produce an implementation, we shouldn't have offered it!
-			 */
-			throw new TlsFatalAlert(AlertDescription.internal_error);
-		}
-	}
+        default:
+            /*
+             * Note: internal error here; the TlsProtocol implementation
+             * verifies that the server-selected compression method was in the
+             * list of client-offered compression methods, so if we now can't
+             * produce an implementation, we shouldn't have offered it!
+             */
+            throw new TlsFatalAlert(AlertDescription.internal_error);
+        }
+    }
 
-	public void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters) throws IOException {
-	}
+    public void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters)
+            throws IOException
+    {
+    }
 
-	public NewSessionTicket getNewSessionTicket() {
-		return null;
-	}
+    public NewSessionTicket getNewSessionTicket()
+    {
+        return null;
+    }
 
-	public SecurityParameters getSecurityParameters() {
-		return null;
-	}
+    public SecurityParameters getSecurityParameters()
+    {
+        return null;
+    }
 }

--- a/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
@@ -40,10 +40,11 @@ public abstract class AbstractTlsClient
     }
 
     /**
-     * RFC 5246 E.1. "TLS clients that wish to negotiate with older servers MAY send any value {03,XX} as the record
-     * layer version number. Typical values would be {03,00}, the lowest version number supported by the client, and the
-     * value of ClientHello.client_version. No single value will guarantee interoperability with all old servers, but
-     * this is a complex topic beyond the scope of this document."
+     * RFC 5246 E.1. "TLS clients that wish to negotiate with older servers MAY send any value
+     * {03,XX} as the record layer version number. Typical values would be {03,00}, the lowest
+     * version number supported by the client, and the value of ClientHello.client_version. No
+     * single value will guarantee interoperability with all old servers, but this is a complex
+     * topic beyond the scope of this document."
      */
     public ProtocolVersion getClientHelloRecordLayerVersion()
     {
@@ -65,8 +66,9 @@ public abstract class AbstractTlsClient
     public boolean isFallback()
     {
         /*
-         * draft-ietf-tls-downgrade-scsv-00 4. [..] is meant for use by clients that repeat a connection attempt with a
-         * downgraded protocol in order to avoid interoperability problems with legacy servers.
+         * draft-ietf-tls-downgrade-scsv-00 4. [..] is meant for use by clients that repeat a
+         * connection attempt with a downgraded protocol in order to avoid interoperability problems
+         * with legacy servers.
          */
         return false;
     }
@@ -78,8 +80,8 @@ public abstract class AbstractTlsClient
         ProtocolVersion clientVersion = context.getClientVersion();
 
         /*
-         * RFC 5246 7.4.1.4.1. Note: this extension is not meaningful for TLS versions prior to 1.2. Clients MUST NOT
-         * offer it if they are offering prior versions.
+         * RFC 5246 7.4.1.4.1. Note: this extension is not meaningful for TLS versions prior to 1.2.
+         * Clients MUST NOT offer it if they are offering prior versions.
          */
         if (TlsUtils.isSignatureAlgorithmsExtensionAllowed(clientVersion))
         {
@@ -117,14 +119,14 @@ public abstract class AbstractTlsClient
         if (TlsECCUtils.containsECCCipherSuites(getCipherSuites()))
         {
             /*
-             * RFC 4492 5.1. A client that proposes ECC cipher suites in its ClientHello message appends these
-             * extensions (along with any others), enumerating the curves it supports and the point formats it can
-             * parse. Clients SHOULD send both the Supported Elliptic Curves Extension and the Supported Point Formats
-             * Extension.
+             * RFC 4492 5.1. A client that proposes ECC cipher suites in its ClientHello message
+             * appends these extensions (along with any others), enumerating the curves it supports
+             * and the point formats it can parse. Clients SHOULD send both the Supported Elliptic
+             * Curves Extension and the Supported Point Formats Extension.
              */
             /*
-             * TODO Could just add all the curves since we support them all, but users may not want to use unnecessarily
-             * large fields. Need configuration options.
+             * TODO Could just add all the curves since we support them all, but users may not want
+             * to use unnecessarily large fields. Need configuration options.
              */
             this.namedCurves = new int[]{NamedCurve.secp256r1, NamedCurve.secp384r1};
             this.clientECPointFormats = new short[]{ECPointFormat.uncompressed, ECPointFormat.ansiX962_compressed_prime,
@@ -175,8 +177,8 @@ public abstract class AbstractTlsClient
     public void processServerExtensions(Hashtable serverExtensions) throws IOException
     {
         /*
-         * TlsProtocol implementation validates that any server extensions received correspond to client extensions
-         * sent. By default, we don't send any, and this method is not called.
+         * TlsProtocol implementation validates that any server extensions received correspond to
+         * client extensions sent. By default, we don't send any, and this method is not called.
          */
         if (serverExtensions != null)
         {
@@ -224,9 +226,9 @@ public abstract class AbstractTlsClient
 
         default:
             /*
-             * Note: internal error here; the TlsProtocol implementation verifies that the server-selected compression
-             * method was in the list of client-offered compression methods, so if we now can't produce an
-             * implementation, we shouldn't have offered it!
+             * Note: internal error here; the TlsProtocol implementation verifies that the
+             * server-selected compression method was in the list of client-offered compression
+             * methods, so if we now can't produce an implementation, we shouldn't have offered it!
              */
             throw new TlsFatalAlert(AlertDescription.internal_error);
         }

--- a/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
@@ -211,11 +211,11 @@ public abstract class AbstractTlsClient extends AbstractTlsPeer implements TlsCl
 	public void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters) throws IOException {
 	}
 
-	public NewSessionTicket getNewSessionTicket() throws IOException {
+	public NewSessionTicket getNewSessionTicket() {
 		return null;
 	}
 
-	public SecurityParameters getSecurityParameters() throws IOException {
+	public SecurityParameters getSecurityParameters() {
 		return null;
 	}
 }

--- a/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
@@ -241,7 +241,7 @@ public abstract class AbstractTlsClient
     }
 
     public void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters)
-            throws IOException
+        throws IOException
     {
     }
 

--- a/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/AbstractTlsClient.java
@@ -73,7 +73,8 @@ public abstract class AbstractTlsClient
         return false;
     }
 
-    public Hashtable getClientExtensions() throws IOException
+    public Hashtable getClientExtensions()
+        throws IOException
     {
         Hashtable clientExtensions = null;
 
@@ -146,7 +147,8 @@ public abstract class AbstractTlsClient
         return ProtocolVersion.TLSv10;
     }
 
-    public void notifyServerVersion(ProtocolVersion serverVersion) throws IOException
+    public void notifyServerVersion(ProtocolVersion serverVersion)
+        throws IOException
     {
         if (!getMinimumVersion().isEqualOrEarlierVersionOf(serverVersion))
         {
@@ -174,7 +176,8 @@ public abstract class AbstractTlsClient
         this.selectedCompressionMethod = selectedCompressionMethod;
     }
 
-    public void processServerExtensions(Hashtable serverExtensions) throws IOException
+    public void processServerExtensions(Hashtable serverExtensions)
+        throws IOException
     {
         /*
          * TlsProtocol implementation validates that any server extensions received correspond to
@@ -204,7 +207,8 @@ public abstract class AbstractTlsClient
         }
     }
 
-    public void processServerSupplementalData(Vector serverSupplementalData) throws IOException
+    public void processServerSupplementalData(Vector serverSupplementalData)
+        throws IOException
     {
         if (serverSupplementalData != null)
         {
@@ -212,12 +216,14 @@ public abstract class AbstractTlsClient
         }
     }
 
-    public Vector getClientSupplementalData() throws IOException
+    public Vector getClientSupplementalData()
+        throws IOException
     {
         return null;
     }
 
-    public TlsCompression getCompression() throws IOException
+    public TlsCompression getCompression()
+        throws IOException
     {
         switch (selectedCompressionMethod)
         {

--- a/core/src/main/java/org/bouncycastle/crypto/tls/DTLSClientProtocol.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/DTLSClientProtocol.java
@@ -602,8 +602,15 @@ public class DTLSClientProtocol
         NewSessionTicket newSessionTicket = NewSessionTicket.parse(buf);
 
         TlsProtocol.assertEmpty(buf);
-
-        state.client.notifyNewSessionTicket(newSessionTicket);
+        
+        /*
+         * RFC 5077 - notify client so it can save the ticket and security
+         * parameters for session resumption.
+         */
+        SecurityParameters securityParameters = new SecurityParameters();
+        securityParameters.copySecurityParametersFrom(state.clientContext.getSecurityParameters());
+        
+        state.client.notifyNewSessionTicket(newSessionTicket, securityParameters);
     }
 
     protected Certificate processServerCertificate(ClientHandshakeState state, byte[] body)

--- a/core/src/main/java/org/bouncycastle/crypto/tls/NewSessionTicket.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/NewSessionTicket.java
@@ -37,6 +37,13 @@ public class NewSessionTicket
         TlsUtils.writeUint32(ticketLifetimeHint, output);
         TlsUtils.writeOpaque16(ticket, output);
     }
+    
+    public void encodeWithoutLifetime(OutputStream output) throws IOException
+    {
+        // just raw ticket bytes
+        // length will be added later
+        output.write(ticket);
+    }
 
     /**
      * Parse a {@link NewSessionTicket} from an {@link InputStream}.

--- a/core/src/main/java/org/bouncycastle/crypto/tls/SecurityParameters.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/SecurityParameters.java
@@ -19,6 +19,24 @@ public class SecurityParameters
     boolean truncatedHMac = false;
     boolean encryptThenMAC = false;
     boolean extendedMasterSecret = false;
+    
+	/**
+	 * Copies the security parameters from another instance if it is not null,
+	 * otherwise this is a no-op.
+	 * 
+	 * @param other
+	 */
+    void copySecurityParametersFrom(SecurityParameters other)
+    {
+    	if (other != null) {
+	        this.entity = other.entity;
+	        this.cipherSuite = other.cipherSuite;
+	        this.compressionAlgorithm = other.compressionAlgorithm;
+	        this.prfAlgorithm = other.prfAlgorithm;
+	        this.verifyDataLength = other.verifyDataLength;
+	        this.masterSecret = Arrays.clone(other.masterSecret);
+    	}
+    }
 
     void clear()
     {

--- a/core/src/main/java/org/bouncycastle/crypto/tls/TlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/TlsClient.java
@@ -4,78 +4,90 @@ import java.io.IOException;
 import java.util.Hashtable;
 import java.util.Vector;
 
-public interface TlsClient
-    extends TlsPeer
-{
-    void init(TlsClientContext context);
+public interface TlsClient extends TlsPeer {
+	void init(TlsClientContext context);
 
-    /**
-     * Return the session this client wants to resume, if any. Note that the peer's certificate
-     * chain for the session (if any) may need to be periodically revalidated.
-     * 
-     * @return A {@link TlsSession} representing the resumable session to be used for this
-     *         connection, or null to use a new session.
-     * @see SessionParameters#getPeerCertificate()
-     */
-    TlsSession getSessionToResume();
+	/**
+	 * Return the session this client wants to resume, if any. Note that the
+	 * peer's certificate chain for the session (if any) may need to be
+	 * periodically revalidated.
+	 * 
+	 * @return A {@link TlsSession} representing the resumable session to be
+	 *         used for this connection, or null to use a new session.
+	 * @see SessionParameters#getPeerCertificate()
+	 */
+	TlsSession getSessionToResume();
 
-    ProtocolVersion getClientHelloRecordLayerVersion();
+	ProtocolVersion getClientHelloRecordLayerVersion();
 
-    ProtocolVersion getClientVersion();
+	ProtocolVersion getClientVersion();
 
-    boolean isFallback();
+	boolean isFallback();
 
-    int[] getCipherSuites();
+	int[] getCipherSuites();
 
-    short[] getCompressionMethods();
+	short[] getCompressionMethods();
 
-    // Hashtable is (Integer -> byte[])
-    Hashtable getClientExtensions()
-        throws IOException;
+	// Hashtable is (Integer -> byte[])
+	Hashtable getClientExtensions() throws IOException;
 
-    void notifyServerVersion(ProtocolVersion selectedVersion)
-        throws IOException;
+	void notifyServerVersion(ProtocolVersion selectedVersion) throws IOException;
 
-    /**
-     * Notifies the client of the session_id sent in the ServerHello.
-     *
-     * @param sessionID
-     * @see TlsContext#getResumableSession()
-     */
-    void notifySessionID(byte[] sessionID);
+	/**
+	 * Notifies the client of the session_id sent in the ServerHello.
+	 *
+	 * @param sessionID
+	 * @see TlsContext#getResumableSession()
+	 */
+	void notifySessionID(byte[] sessionID);
 
-    void notifySelectedCipherSuite(int selectedCipherSuite);
+	void notifySelectedCipherSuite(int selectedCipherSuite);
 
-    void notifySelectedCompressionMethod(short selectedCompressionMethod);
+	void notifySelectedCompressionMethod(short selectedCompressionMethod);
 
-    // Hashtable is (Integer -> byte[])
-    void processServerExtensions(Hashtable serverExtensions)
-        throws IOException;
+	// Hashtable is (Integer -> byte[])
+	void processServerExtensions(Hashtable serverExtensions) throws IOException;
 
-    // Vector is (SupplementalDataEntry)
-    void processServerSupplementalData(Vector serverSupplementalData)
-        throws IOException;
+	// Vector is (SupplementalDataEntry)
+	void processServerSupplementalData(Vector serverSupplementalData) throws IOException;
 
-    TlsKeyExchange getKeyExchange()
-        throws IOException;
+	TlsKeyExchange getKeyExchange() throws IOException;
 
-    TlsAuthentication getAuthentication()
-        throws IOException;
+	TlsAuthentication getAuthentication() throws IOException;
 
-    // Vector is (SupplementalDataEntry)
-    Vector getClientSupplementalData()
-        throws IOException;
+	// Vector is (SupplementalDataEntry)
+	Vector getClientSupplementalData() throws IOException;
 
-    /**
-     * RFC 5077 3.3. NewSessionTicket Handshake Message
-     * <p>
-     * This method will be called (only) when a NewSessionTicket handshake message is received. The
-     * ticket is opaque to the client and clients MUST NOT examine the ticket under the assumption
-     * that it complies with e.g. <i>RFC 5077 4. Recommended Ticket Construction</i>.
-     *
-     * @param newSessionTicket The ticket.
-     * @throws IOException
-     */
-    void notifyNewSessionTicket(NewSessionTicket newSessionTicket)
-        throws IOException;
+	/**
+	 * RFC 5077 3.3. NewSessionTicket Handshake Message
+	 * <p>
+	 * This method will be called (only) when a NewSessionTicket handshake
+	 * message is received. The ticket is opaque to the client and clients MUST
+	 * NOT examine the ticket under the assumption that it complies with e.g.
+	 * <i>RFC 5077 4. Recommended Ticket Construction</i>.
+	 *
+	 * @param newSessionTicket
+	 *            The ticket.
+	 * @param sessionParameters
+	 * @throws IOException
+	 */
+	void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters) throws IOException;
+
+	/**
+	 * 
+	 * @return a {@link NewSessionTicket}
+	 * @throws IOException
+	 */
+	NewSessionTicket getNewSessionTicket() throws IOException;
+
+	/**
+	 * In the case of TLS resumption using session tickets,
+	 * {@link TlsClient#getSessionToResume()} may return a null TlsSession. Use
+	 * this method to retrieve the security parameters needed for session
+	 * resumption.
+	 * 
+	 * @return A {@link SecurityParameters} object
+	 * @throws IOException
+	 */
+	SecurityParameters getSecurityParameters() throws IOException;
 }

--- a/core/src/main/java/org/bouncycastle/crypto/tls/TlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/TlsClient.java
@@ -30,9 +30,11 @@ public interface TlsClient
     short[] getCompressionMethods();
 
     // Hashtable is (Integer -> byte[])
-    Hashtable getClientExtensions() throws IOException;
+    Hashtable getClientExtensions()
+        throws IOException;
 
-    void notifyServerVersion(ProtocolVersion selectedVersion) throws IOException;
+    void notifyServerVersion(ProtocolVersion selectedVersion)
+        throws IOException;
 
     /**
      * Notifies the client of the session_id sent in the ServerHello.
@@ -47,17 +49,22 @@ public interface TlsClient
     void notifySelectedCompressionMethod(short selectedCompressionMethod);
 
     // Hashtable is (Integer -> byte[])
-    void processServerExtensions(Hashtable serverExtensions) throws IOException;
+    void processServerExtensions(Hashtable serverExtensions)
+        throws IOException;
 
     // Vector is (SupplementalDataEntry)
-    void processServerSupplementalData(Vector serverSupplementalData) throws IOException;
+    void processServerSupplementalData(Vector serverSupplementalData)
+        throws IOException;
 
-    TlsKeyExchange getKeyExchange() throws IOException;
+    TlsKeyExchange getKeyExchange()
+        throws IOException;
 
-    TlsAuthentication getAuthentication() throws IOException;
+    TlsAuthentication getAuthentication()
+        throws IOException;
 
     // Vector is (SupplementalDataEntry)
-    Vector getClientSupplementalData() throws IOException;
+    Vector getClientSupplementalData()
+        throws IOException;
 
     /**
      * RFC 5077 3.3. NewSessionTicket Handshake Message

--- a/core/src/main/java/org/bouncycastle/crypto/tls/TlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/TlsClient.java
@@ -76,9 +76,8 @@ public interface TlsClient extends TlsPeer {
 	/**
 	 * 
 	 * @return a {@link NewSessionTicket}
-	 * @throws IOException
 	 */
-	NewSessionTicket getNewSessionTicket() throws IOException;
+	NewSessionTicket getNewSessionTicket();
 
 	/**
 	 * In the case of TLS resumption using session tickets,
@@ -89,5 +88,5 @@ public interface TlsClient extends TlsPeer {
 	 * @return A {@link SecurityParameters} object
 	 * @throws IOException
 	 */
-	SecurityParameters getSecurityParameters() throws IOException;
+	SecurityParameters getSecurityParameters();
 }

--- a/core/src/main/java/org/bouncycastle/crypto/tls/TlsClient.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/TlsClient.java
@@ -4,89 +4,89 @@ import java.io.IOException;
 import java.util.Hashtable;
 import java.util.Vector;
 
-public interface TlsClient extends TlsPeer {
-	void init(TlsClientContext context);
+public interface TlsClient
+    extends TlsPeer
+{
+    void init(TlsClientContext context);
 
-	/**
-	 * Return the session this client wants to resume, if any. Note that the
-	 * peer's certificate chain for the session (if any) may need to be
-	 * periodically revalidated.
-	 * 
-	 * @return A {@link TlsSession} representing the resumable session to be
-	 *         used for this connection, or null to use a new session.
-	 * @see SessionParameters#getPeerCertificate()
-	 */
-	TlsSession getSessionToResume();
+    /**
+     * Return the session this client wants to resume, if any. Note that the peer's certificate
+     * chain for the session (if any) may need to be periodically revalidated.
+     * 
+     * @return A {@link TlsSession} representing the resumable session to be used for this
+     *         connection, or null to use a new session.
+     * @see SessionParameters#getPeerCertificate()
+     */
+    TlsSession getSessionToResume();
 
-	ProtocolVersion getClientHelloRecordLayerVersion();
+    ProtocolVersion getClientHelloRecordLayerVersion();
 
-	ProtocolVersion getClientVersion();
+    ProtocolVersion getClientVersion();
 
-	boolean isFallback();
+    boolean isFallback();
 
-	int[] getCipherSuites();
+    int[] getCipherSuites();
 
-	short[] getCompressionMethods();
+    short[] getCompressionMethods();
 
-	// Hashtable is (Integer -> byte[])
-	Hashtable getClientExtensions() throws IOException;
+    // Hashtable is (Integer -> byte[])
+    Hashtable getClientExtensions() throws IOException;
 
-	void notifyServerVersion(ProtocolVersion selectedVersion) throws IOException;
+    void notifyServerVersion(ProtocolVersion selectedVersion) throws IOException;
 
-	/**
-	 * Notifies the client of the session_id sent in the ServerHello.
-	 *
-	 * @param sessionID
-	 * @see TlsContext#getResumableSession()
-	 */
-	void notifySessionID(byte[] sessionID);
+    /**
+     * Notifies the client of the session_id sent in the ServerHello.
+     *
+     * @param sessionID
+     * @see TlsContext#getResumableSession()
+     */
+    void notifySessionID(byte[] sessionID);
 
-	void notifySelectedCipherSuite(int selectedCipherSuite);
+    void notifySelectedCipherSuite(int selectedCipherSuite);
 
-	void notifySelectedCompressionMethod(short selectedCompressionMethod);
+    void notifySelectedCompressionMethod(short selectedCompressionMethod);
 
-	// Hashtable is (Integer -> byte[])
-	void processServerExtensions(Hashtable serverExtensions) throws IOException;
+    // Hashtable is (Integer -> byte[])
+    void processServerExtensions(Hashtable serverExtensions) throws IOException;
 
-	// Vector is (SupplementalDataEntry)
-	void processServerSupplementalData(Vector serverSupplementalData) throws IOException;
+    // Vector is (SupplementalDataEntry)
+    void processServerSupplementalData(Vector serverSupplementalData) throws IOException;
 
-	TlsKeyExchange getKeyExchange() throws IOException;
+    TlsKeyExchange getKeyExchange() throws IOException;
 
-	TlsAuthentication getAuthentication() throws IOException;
+    TlsAuthentication getAuthentication() throws IOException;
 
-	// Vector is (SupplementalDataEntry)
-	Vector getClientSupplementalData() throws IOException;
+    // Vector is (SupplementalDataEntry)
+    Vector getClientSupplementalData() throws IOException;
 
-	/**
-	 * RFC 5077 3.3. NewSessionTicket Handshake Message
-	 * <p>
-	 * This method will be called (only) when a NewSessionTicket handshake
-	 * message is received. The ticket is opaque to the client and clients MUST
-	 * NOT examine the ticket under the assumption that it complies with e.g.
-	 * <i>RFC 5077 4. Recommended Ticket Construction</i>.
-	 *
-	 * @param newSessionTicket
-	 *            The ticket.
-	 * @param sessionParameters
-	 * @throws IOException
-	 */
-	void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters) throws IOException;
+    /**
+     * RFC 5077 3.3. NewSessionTicket Handshake Message
+     * <p>
+     * This method will be called (only) when a NewSessionTicket handshake message is received. The
+     * ticket is opaque to the client and clients MUST NOT examine the ticket under the assumption
+     * that it complies with e.g. <i>RFC 5077 4. Recommended Ticket Construction</i>.
+     *
+     * @param newSessionTicket
+     *            The ticket.
+     * @param sessionParameters
+     * @throws IOException
+     */
+    void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters)
+        throws IOException;
 
-	/**
-	 * 
-	 * @return a {@link NewSessionTicket}
-	 */
-	NewSessionTicket getNewSessionTicket();
+    /**
+     * 
+     * @return a {@link NewSessionTicket}
+     */
+    NewSessionTicket getNewSessionTicket();
 
-	/**
-	 * In the case of TLS resumption using session tickets,
-	 * {@link TlsClient#getSessionToResume()} may return a null TlsSession. Use
-	 * this method to retrieve the security parameters needed for session
-	 * resumption.
-	 * 
-	 * @return A {@link SecurityParameters} object
-	 * @throws IOException
-	 */
-	SecurityParameters getSecurityParameters();
+    /**
+     * In the case of TLS resumption using session tickets, {@link TlsClient#getSessionToResume()}
+     * may return a null TlsSession. Use this method to retrieve the security parameters needed for
+     * session resumption.
+     * 
+     * @return A {@link SecurityParameters} object
+     * @throws IOException
+     */
+    SecurityParameters getSecurityParameters();
 }

--- a/core/src/main/java/org/bouncycastle/crypto/tls/TlsClientProtocol.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/TlsClientProtocol.java
@@ -577,7 +577,13 @@ public class TlsClientProtocol
 
         assertEmpty(buf);
 
-        tlsClient.notifyNewSessionTicket(newSessionTicket);
+        /*
+         * RFC 5077 - notify client so it can save the ticket and security
+         * parameters for session resumption.
+         */
+        SecurityParameters securityParameters = new SecurityParameters();
+        securityParameters.copySecurityParametersFrom(this.securityParameters);
+        tlsClient.notifyNewSessionTicket(newSessionTicket, securityParameters);
     }
 
     protected void receiveServerHelloMessage(ByteArrayInputStream buf)

--- a/core/src/main/java/org/bouncycastle/crypto/tls/TlsClientProtocol.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/TlsClientProtocol.java
@@ -1001,7 +1001,7 @@ public class TlsClientProtocol
         if (sessionTicketExtSupported && sessionTicketPresent)
         {
             ByteArrayOutputStream output = new ByteArrayOutputStream();
-            sessionTicket.encode(output);
+            sessionTicket.encodeWithoutLifetime(output);
             clientExtensions.put(EXT_SessionTicket, output.toByteArray());
         }
 

--- a/core/src/main/java/org/bouncycastle/crypto/tls/TlsExtensionsUtils.java
+++ b/core/src/main/java/org/bouncycastle/crypto/tls/TlsExtensionsUtils.java
@@ -16,6 +16,7 @@ public class TlsExtensionsUtils
     public static final Integer EXT_server_name = Integers.valueOf(ExtensionType.server_name);
     public static final Integer EXT_status_request = Integers.valueOf(ExtensionType.status_request);
     public static final Integer EXT_truncated_hmac = Integers.valueOf(ExtensionType.truncated_hmac);
+    public static final Integer EXT_session_tickets = Integer.valueOf(ExtensionType.session_ticket);
 
     public static Hashtable ensureExtensionsInitialised(Hashtable extensions)
     {
@@ -59,6 +60,11 @@ public class TlsExtensionsUtils
     public static void addTruncatedHMacExtension(Hashtable extensions)
     {
         extensions.put(EXT_truncated_hmac, createTruncatedHMacExtension());
+    }
+    
+    public static void addSessionTicketExtension(Hashtable extensions)
+    {
+        extensions.put(EXT_session_tickets, createEmptyExtensionData());
     }
 
     public static HeartbeatExtension getHeartbeatExtension(Hashtable extensions)

--- a/core/src/test/java/org/bouncycastle/crypto/tls/test/MockTlsClient.java
+++ b/core/src/test/java/org/bouncycastle/crypto/tls/test/MockTlsClient.java
@@ -12,7 +12,9 @@ import org.bouncycastle.crypto.tls.CertificateRequest;
 import org.bouncycastle.crypto.tls.ClientCertificateType;
 import org.bouncycastle.crypto.tls.DefaultTlsClient;
 import org.bouncycastle.crypto.tls.MaxFragmentLength;
+import org.bouncycastle.crypto.tls.NewSessionTicket;
 import org.bouncycastle.crypto.tls.ProtocolVersion;
+import org.bouncycastle.crypto.tls.SecurityParameters;
 import org.bouncycastle.crypto.tls.SignatureAlgorithm;
 import org.bouncycastle.crypto.tls.SignatureAndHashAlgorithm;
 import org.bouncycastle.crypto.tls.TlsAuthentication;
@@ -26,6 +28,8 @@ class MockTlsClient
     extends DefaultTlsClient
 {
     TlsSession session;
+    NewSessionTicket sessionTicket;
+    SecurityParameters securityParameters;
 
     MockTlsClient(TlsSession session)
     {
@@ -166,5 +170,23 @@ class MockTlsClient
 
             this.session = newSession;
         }
+    }
+
+    public void notifyNewSessionTicket(NewSessionTicket newSessionTicket, SecurityParameters securityParameters)
+            throws IOException
+    {
+        super.notifyNewSessionTicket(newSessionTicket, securityParameters);
+        this.sessionTicket = newSessionTicket;
+        this.securityParameters = securityParameters;
+    }
+
+    public NewSessionTicket getSessionTicket()
+    {
+        return sessionTicket;
+    }
+
+    public SecurityParameters getSecurityParameters()
+    {
+        return this.securityParameters;
     }
 }

--- a/core/src/test/java/org/bouncycastle/crypto/tls/test/MockTlsClient.java
+++ b/core/src/test/java/org/bouncycastle/crypto/tls/test/MockTlsClient.java
@@ -35,6 +35,12 @@ class MockTlsClient
     {
         this.session = session;
     }
+    
+    MockTlsClient(NewSessionTicket sessionTicket, SecurityParameters securityParameters)
+    {
+        this.sessionTicket = sessionTicket;
+        this.securityParameters = securityParameters;
+    }
 
     public TlsSession getSessionToResume()
     {

--- a/core/src/test/java/org/bouncycastle/crypto/tls/test/MockTlsClient.java
+++ b/core/src/test/java/org/bouncycastle/crypto/tls/test/MockTlsClient.java
@@ -90,6 +90,7 @@ class MockTlsClient
 //        TlsExtensionsUtils.addExtendedMasterSecretExtension(clientExtensions);
         TlsExtensionsUtils.addMaxFragmentLengthExtension(clientExtensions, MaxFragmentLength.pow2_9);
         TlsExtensionsUtils.addTruncatedHMacExtension(clientExtensions);
+        TlsExtensionsUtils.addSessionTicketExtension(clientExtensions);
         return clientExtensions;
     }
 
@@ -186,7 +187,7 @@ class MockTlsClient
         this.securityParameters = securityParameters;
     }
 
-    public NewSessionTicket getSessionTicket()
+    public NewSessionTicket getNewSessionTicket()
     {
         return sessionTicket;
     }

--- a/core/src/test/java/org/bouncycastle/crypto/tls/test/TlsClientTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/tls/test/TlsClientTest.java
@@ -60,7 +60,7 @@ public class TlsClientTest
         protocol.close();
         
         // session resumption using session tickets
-        client = new MockTlsClient(client.getSessionTicket(), client.getSecurityParameters());
+        client = new MockTlsClient(client.getNewSessionTicket(), client.getSecurityParameters());
         protocol = openTlsConnection(address, port, client);
         protocol.close();
         

--- a/core/src/test/java/org/bouncycastle/crypto/tls/test/TlsClientTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/tls/test/TlsClientTest.java
@@ -37,6 +37,7 @@ public class TlsClientTest
         long time2 = System.currentTimeMillis();
         System.out.println("Elapsed 1: " + (time2 - time1) + "ms");
 
+        // session resumption using session id
         client = new MockTlsClient(client.getSessionToResume());
         protocol = openTlsConnection(address, port, client);
 
@@ -57,6 +58,12 @@ public class TlsClientTest
         }
 
         protocol.close();
+        
+        // session resumption using session tickets
+        client = new MockTlsClient(client.getSessionTicket(), client.getSecurityParameters());
+        protocol = openTlsConnection(address, port, client);
+        protocol.close();
+        
     }
 
     static TlsClientProtocol openTlsConnection(InetAddress address, int port, TlsClient client) throws IOException


### PR DESCRIPTION
Obtaining a Session Ticket
--------------------------
C -> S: Client Hello (empty SessionTicket ext)
C <- S: Server Hello (empty SessionTicket ext)
C <- S: Certificate
C <- S: Server Hello Done
C -> S: Client Key Exchange
C -> S: ChangeCipherSpec
C -> S: Finished
C <- S: NewSessionTicket //client should store this ticket as ticketA
C <- S: ChangeCipherSpec
C <- S: Finished

Using a session ticket
----------------------
C -> S: Client Hello (SessionTicket ext = ticketA; session id not set) 
C <- S: Server Hello (empty SessionTicket ext)
C <- S: ChangeCipherSpec
C <- S: Finished
C -> S: ChangeCipherSpec
C -> S: Finished

For session resumption using session ids (i.e., without using session tickets), there are two methods in TlsClient and AbstractTlsPeer to allow you to store and reuse TLSSession: notifyHandshakeComplete() and getSessionToResume(). In contrast, for session resumption using session tickets, there is only one method in TLSClient called notifyNewSessionTicket(NewSessionTicket newSessionTicket) to store the session ticket given by the server. I don't see a method to use the session ticket for session resumption. 

To resume a TLS session with a ticket, the RFC says: 

"The client caches this ticket along with the master secret and other parameters associated with the current session.  When the client wishes to resume the session, it includes the ticket in the SessionTicket extension within the ClientHello message." 

# Summary of changes

All class references below are in package org.bouncycastle.crypto.tls.
* TlsClient
 * added 2 new abstract methods: NewSessionTicket getNewSessionTicket() and SecurityParameters getSecurityParameters() 
 * modified notifyNewSessionTicket() method and added a parameter to pass in SecurityParameters. Note that this breaks backwards compatibility but I assume there aren't many implementations of the TLSClient interface given that BC didn't fully support session tickets. Perhaps we could refractor the session resumption stuff out in to an interface called "SessionResumable" or something like that. Need some guidance here.
* AbstractTlsClient
 * updated to implement the new TlsClient
* NewSessionTicket
 * added a new method to encode the ticket without the lifetime. This was added when resuming a session using a session ticket from server (I was using nginx/openssl for testing).
* SecurityParameters
 * added a new method to copy parameters safely (to pass to the TlsClient)
* TlsClientProtocol
 * this is where most of important changes are!
 * resume session if the TlsClient has a session ticket (in client hello)
 * notify TlsClient if the server sends a session ticket so that the client can store for later use
* DTlsClientProtocol
 * I don't know much about DTLS. I took an initial stab at making it support session resumption but I need someone to take over.
* TlsExtensionUtils
 * new session ticket extension
* MockTlsClient
 * reference implementation of TlsClient that can resume sessions using tickets
* TlsClientTest
 * shows how to use the MockTlsClient

I did system testing with nginx. No special config needed. This is what I have:

server {
    listen       1443 ssl;
    server_name  _;

    ssl_certificate     cert.pem;
    ssl_certificate_key keyNoPassphrase.pem;
    ssl_session_cache   shared:SSL:10m;
    ...
}

I didn't write any unit tests but because I need a TLS server that can issue session resumption. Please do let me know if you can think of ways to unit-test my changes.

I do have pcaps but I can't attach them here without masking the IPs.

Please note that I've never contributed to BC so I don't know what the process is. Please feel free to educate me. :)