### PR TITLE
Clone key in copy constructor

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/digests/Blake2bDigest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/Blake2bDigest.java
@@ -119,7 +119,7 @@ public class Blake2bDigest
 		this.bufferPos = digest.bufferPos;
 		this.buffer = Arrays.clone(digest.buffer);
 		this.keyLength = digest.keyLength;
-		this.key = Arrays.clone(key);
+		this.key = Arrays.clone(digest.key);
 		this.digestLength = digest.digestLength;
 		this.chainValue = Arrays.clone(digest.chainValue);
 		this.personalization = Arrays.clone(personalization);


### PR DESCRIPTION
The copy constructor for Blake2bDigest clones the new instance's own key rather than the key of the instance being copied.