### PR TITLE
Fix PGPObjectFactory iterator pre-read of packets

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.bouncycastle.bcpg.BCPGInputStream;
 import org.bouncycastle.bcpg.PacketTags;
@@ -163,20 +164,28 @@ public class PGPObjectFactory
     {
         return new Iterator()
         {
-            private Object obj = getObject();
+            private boolean triedNext = false;
+            private Object obj = null;
 
             public boolean hasNext()
             {
+                if (!triedNext)
+                {
+                    triedNext = true;
+                    obj = getObject();
+                }
                 return obj != null;
             }
 
             public Object next()
             {
-                Object rv = obj;
+                if (!hasNext())
+                {
+                    throw new NoSuchElementException();
+                }
+                triedNext = false;
 
-                obj = getObject();;
-
-                return rv;
+                return obj;
             }
 
             public void remove()


### PR DESCRIPTION
The next() method of PGPObjectFactory's iterator currently reads
the _next_ next packet on every call. When it is initialized,
it reads packet 1; on the first call to next(), it reads packet 2
and returns packet 1; on the second call to next(), it reads packet 3
and returns packet 2; and so on.

This is a problem because the underlying BCPGInputStream on which
PGPObjectFactory relies cannot always read the next packet until the
content of the previous packet has been read fully (such as
in the case of literal, compressed, or encrypted data packets).
Depending on the literal content of these packets, attempting to read
the next packet before the previous packet bas been read fully
will result in error messages such as "unknown object in stream"
or "invalid header encountered" or "unknown packet type encountered".

This patch fixes this problem by delaying the read of the next packet
until the iterator's next() method is actually called. This allows
code which uses PGPObjectFactory.iterator(), like this:

PGPObjectFactory factory = new BcPGPObjectFactory(stream);
Iterator packets = factory.iterator();
while (packet.hasNext()) {
    Object packet = packets.next();
    // ... read packet content ...
}

To work the same as code which uses PGPObjectFactory.nextObject(),
like this:

PGPObjectFactory factory = new BcPGPObjectFactory(stream);
Object packet = factory.nextObject();
while (packet != null) {
    // ... read packet content ...
    packet = factory.nextObject();
}

Instead of how it used to work, effectively like this:

PGPObjectFactory factory = new BcPGPObjectFactory(stream);
Object packet = factory.nextObject();
while (packet != null) {
    Object nextPacket = factory.nextObject();
    // ... read packet content ...
    packet = nextPacket;
    nextPacket = factory.nextObject();
}

This patch also includes a new iteratorTest() method
in the PGPPacketTest class, which will fail with an error
"unknown object in stream: 34" before the patch is applied;
but will work without errors after the patch is applied.