### PR TITLE
Moved get*Name methods to public PGPUtil.

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPUtil.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPUtil.java
@@ -15,6 +15,7 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.bcpg.ArmoredInputStream;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
 import org.bouncycastle.bcpg.MPInteger;
+import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
 import org.bouncycastle.util.encoders.Base64;
 
@@ -326,6 +327,100 @@ public class PGPUtil
                 result = Integer.MAX_VALUE;
             }
             return result;
+        }
+    }
+
+    public static String getDigestName(
+            int hashAlgorithm)
+            throws PGPException
+    {
+        switch (hashAlgorithm)
+        {
+            case HashAlgorithmTags.SHA1:
+                return "SHA1";
+            case HashAlgorithmTags.MD2:
+                return "MD2";
+            case HashAlgorithmTags.MD5:
+                return "MD5";
+            case HashAlgorithmTags.RIPEMD160:
+                return "RIPEMD160";
+            case HashAlgorithmTags.SHA256:
+                return "SHA256";
+            case HashAlgorithmTags.SHA384:
+                return "SHA384";
+            case HashAlgorithmTags.SHA512:
+                return "SHA512";
+            case HashAlgorithmTags.SHA224:
+                return "SHA224";
+            case HashAlgorithmTags.TIGER_192:
+                return "TIGER";
+            default:
+                throw new PGPException("unknown hash algorithm tag in getDigestName: " + hashAlgorithm);
+        }
+    }
+
+    public static String getSignatureName(
+            int        keyAlgorithm,
+            int        hashAlgorithm)
+            throws PGPException
+    {
+        String     encAlg;
+
+        switch (keyAlgorithm)
+        {
+            case PublicKeyAlgorithmTags.RSA_GENERAL:
+            case PublicKeyAlgorithmTags.RSA_SIGN:
+                encAlg = "RSA";
+                break;
+            case PublicKeyAlgorithmTags.DSA:
+                encAlg = "DSA";
+                break;
+            case PublicKeyAlgorithmTags.ELGAMAL_ENCRYPT: // in some malformed cases.
+            case PublicKeyAlgorithmTags.ELGAMAL_GENERAL:
+                encAlg = "ElGamal";
+                break;
+            default:
+                throw new PGPException("unknown algorithm tag in signature:" + keyAlgorithm);
+        }
+
+        return getDigestName(hashAlgorithm) + "with" + encAlg;
+    }
+
+    public static String getSymmetricCipherName(
+            int algorithm)
+    {
+        switch (algorithm)
+        {
+            case SymmetricKeyAlgorithmTags.NULL:
+                return null;
+            case SymmetricKeyAlgorithmTags.TRIPLE_DES:
+                return "DESEDE";
+            case SymmetricKeyAlgorithmTags.IDEA:
+                return "IDEA";
+            case SymmetricKeyAlgorithmTags.CAST5:
+                return "CAST5";
+            case SymmetricKeyAlgorithmTags.BLOWFISH:
+                return "Blowfish";
+            case SymmetricKeyAlgorithmTags.SAFER:
+                return "SAFER";
+            case SymmetricKeyAlgorithmTags.DES:
+                return "DES";
+            case SymmetricKeyAlgorithmTags.AES_128:
+                return "AES";
+            case SymmetricKeyAlgorithmTags.AES_192:
+                return "AES";
+            case SymmetricKeyAlgorithmTags.AES_256:
+                return "AES";
+            case SymmetricKeyAlgorithmTags.CAMELLIA_128:
+                return "Camellia";
+            case SymmetricKeyAlgorithmTags.CAMELLIA_192:
+                return "Camellia";
+            case SymmetricKeyAlgorithmTags.CAMELLIA_256:
+                return "Camellia";
+            case SymmetricKeyAlgorithmTags.TWOFISH:
+                return "Twofish";
+            default:
+                throw new IllegalArgumentException("unknown symmetric algorithm: " + algorithm);
         }
     }
 }

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEDataDecryptorFactoryBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEDataDecryptorFactoryBuilder.java
@@ -6,6 +6,8 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import static org.bouncycastle.openpgp.PGPUtil.getSymmetricCipherName;
+
 import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
 import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
 import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
@@ -76,7 +78,7 @@ public class JcePBEDataDecryptorFactoryBuilder
                  {
                      if (secKeyData != null && secKeyData.length > 0)
                      {
-                         String cipherName = PGPUtil.getSymmetricCipherName(keyAlgorithm);
+                         String cipherName = getSymmetricCipherName(keyAlgorithm);
                          Cipher keyCipher = helper.createCipher(cipherName + "/CFB/NoPadding");
 
                          keyCipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, cipherName), new IvParameterSpec(new byte[keyCipher.getBlockSize()]));

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEKeyEncryptionMethodGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEKeyEncryptionMethodGenerator.java
@@ -12,6 +12,8 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import static org.bouncycastle.openpgp.PGPUtil.getSymmetricCipherName;
+
 import org.bouncycastle.bcpg.S2K;
 import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
 import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
@@ -114,9 +116,9 @@ public class JcePBEKeyEncryptionMethodGenerator
     {
         try
         {
-            String cName = PGPUtil.getSymmetricCipherName(encAlgorithm);
+            String cName = getSymmetricCipherName(encAlgorithm);
             Cipher c = helper.createCipher(cName + "/CFB/NoPadding");
-            SecretKey sKey = new SecretKeySpec(key, PGPUtil.getSymmetricCipherName(encAlgorithm));
+            SecretKey sKey = new SecretKeySpec(key, getSymmetricCipherName(encAlgorithm));
 
             c.init(Cipher.ENCRYPT_MODE, sKey, new IvParameterSpec(new byte[c.getBlockSize()]));
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEProtectionRemoverFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEProtectionRemoverFactory.java
@@ -9,6 +9,8 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.spec.IvParameterSpec;
 
+import static org.bouncycastle.openpgp.PGPUtil.getSymmetricCipherName;
+
 import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
 import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
 import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
@@ -78,7 +80,7 @@ public class JcePBEProtectionRemoverFactory
             {
                 try
                 {
-                    Cipher c = helper.createCipher(PGPUtil.getSymmetricCipherName(encAlgorithm) + "/CBC/NoPadding");
+                    Cipher c = helper.createCipher(getSymmetricCipherName(encAlgorithm) + "/CBC/NoPadding");
 
                     c.init(Cipher.DECRYPT_MODE, PGPUtil.makeSymmetricKey(encAlgorithm, key), new IvParameterSpec(iv));
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyDecryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyDecryptorBuilder.java
@@ -9,6 +9,8 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.spec.IvParameterSpec;
 
+import static org.bouncycastle.openpgp.PGPUtil.getSymmetricCipherName;
+
 import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
 import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
 import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
@@ -72,7 +74,7 @@ public class JcePBESecretKeyDecryptorBuilder
             {
                 try
                 {
-                    Cipher c = helper.createCipher(PGPUtil.getSymmetricCipherName(encAlgorithm) + "/CFB/NoPadding");
+                    Cipher c = helper.createCipher(getSymmetricCipherName(encAlgorithm) + "/CFB/NoPadding");
 
                     c.init(Cipher.DECRYPT_MODE, PGPUtil.makeSymmetricKey(encAlgorithm, key), new IvParameterSpec(iv));
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyEncryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyEncryptorBuilder.java
@@ -10,6 +10,8 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.spec.IvParameterSpec;
 
+import static org.bouncycastle.openpgp.PGPUtil.getSymmetricCipherName;
+
 import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
 import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
 import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
@@ -118,7 +120,7 @@ public class JcePBESecretKeyEncryptorBuilder
             {
                 try
                 {
-                    c = helper.createCipher(PGPUtil.getSymmetricCipherName(this.encAlgorithm) + "/CFB/NoPadding");
+                    c = helper.createCipher(getSymmetricCipherName(this.encAlgorithm) + "/CFB/NoPadding");
 
                     c.init(Cipher.ENCRYPT_MODE, PGPUtil.makeSymmetricKey(this.encAlgorithm, key), this.random);
 
@@ -145,7 +147,7 @@ public class JcePBESecretKeyEncryptorBuilder
             {
                 try
                 {
-                    c = helper.createCipher(PGPUtil.getSymmetricCipherName(this.encAlgorithm) + "/CFB/NoPadding");
+                    c = helper.createCipher(getSymmetricCipherName(this.encAlgorithm) + "/CFB/NoPadding");
 
                     c.init(Cipher.ENCRYPT_MODE, PGPUtil.makeSymmetricKey(this.encAlgorithm, key), new IvParameterSpec(iv));
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePublicKeyKeyEncryptionMethodGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePublicKeyKeyEncryptionMethodGenerator.java
@@ -18,6 +18,8 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.KeyAgreement;
 import javax.crypto.spec.SecretKeySpec;
 
+import static org.bouncycastle.openpgp.PGPUtil.getSymmetricCipherName;
+
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x9.X962Parameters;
 import org.bouncycastle.asn1.x9.X9ECParameters;
@@ -119,7 +121,7 @@ public class JcePublicKeyKeyEncryptionMethodGenerator
 
                 byte[] paddedSessionData = PGPPad.padSessionData(sessionInfo);
 
-                byte[] C = c.wrap(new SecretKeySpec(paddedSessionData, PGPUtil.getSymmetricCipherName(sessionInfo[0])));
+                byte[] C = c.wrap(new SecretKeySpec(paddedSessionData, getSymmetricCipherName(sessionInfo[0])));
 
                 SubjectPublicKeyInfo epPubKey = SubjectPublicKeyInfo.getInstance(ephKP.getPublic().getEncoded());
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/OperatorHelper.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/OperatorHelper.java
@@ -17,6 +17,9 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import static org.bouncycastle.openpgp.PGPUtil.getDigestName;
+import static org.bouncycastle.openpgp.PGPUtil.getSymmetricCipherName;
+
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
 import org.bouncycastle.jcajce.util.JcaJceHelper;
@@ -39,7 +42,7 @@ class OperatorHelper
     {
         MessageDigest dig;
 
-        dig = helper.createDigest(PGPUtil.getDigestName(algorithm));
+        dig = helper.createDigest(getDigestName(algorithm));
 
         return dig;
     }
@@ -67,7 +70,7 @@ class OperatorHelper
     {
         try
         {
-            SecretKey secretKey = new SecretKeySpec(key, PGPUtil.getSymmetricCipherName(encAlgorithm));
+            SecretKey secretKey = new SecretKeySpec(key, getSymmetricCipherName(encAlgorithm));
 
             final Cipher c = createStreamCipher(encAlgorithm, withIntegrityPacket);
 
@@ -117,7 +120,7 @@ class OperatorHelper
             ? "CFB"
             : "OpenPGPCFB";
 
-        String cName = PGPUtil.getSymmetricCipherName(encAlgorithm)
+        String cName = getSymmetricCipherName(encAlgorithm)
             + "/" + mode + "/NoPadding";
 
         return createCipher(cName);
@@ -219,7 +222,7 @@ class OperatorHelper
             throw new PGPException("unknown algorithm tag in signature:" + keyAlgorithm);
         }
 
-        return createSignature(PGPUtil.getDigestName(hashAlgorithm) + "with" + encAlg);
+        return createSignature(getDigestName(hashAlgorithm) + "with" + encAlg);
     }
 
     public AlgorithmParameters createAlgorithmParameters(String algorithm)

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/PGPUtil.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/PGPUtil.java
@@ -2,16 +2,14 @@ package org.bouncycastle.openpgp.operator.jcajce;
 
 import java.io.IOException;
 import java.math.BigInteger;
-
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+
+import static org.bouncycastle.openpgp.PGPUtil.getSymmetricCipherName;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
-import org.bouncycastle.bcpg.HashAlgorithmTags;
-import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
-import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
 import org.bouncycastle.math.ec.ECCurve;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.openpgp.PGPException;
@@ -22,100 +20,7 @@ import org.bouncycastle.util.BigIntegers;
  */
 class PGPUtil
 {
-    static String getDigestName(
-        int        hashAlgorithm)
-        throws PGPException
-    {
-        switch (hashAlgorithm)
-        {
-        case HashAlgorithmTags.SHA1:
-            return "SHA1";
-        case HashAlgorithmTags.MD2:
-            return "MD2";
-        case HashAlgorithmTags.MD5:
-            return "MD5";
-        case HashAlgorithmTags.RIPEMD160:
-            return "RIPEMD160";
-        case HashAlgorithmTags.SHA256:
-            return "SHA256";
-        case HashAlgorithmTags.SHA384:
-            return "SHA384";
-        case HashAlgorithmTags.SHA512:
-            return "SHA512";
-        case HashAlgorithmTags.SHA224:
-            return "SHA224";
-        case HashAlgorithmTags.TIGER_192:
-            return "TIGER";
-        default:
-            throw new PGPException("unknown hash algorithm tag in getDigestName: " + hashAlgorithm);
-        }
-    }
 
-    static String getSignatureName(
-        int        keyAlgorithm,
-        int        hashAlgorithm)
-        throws PGPException
-    {
-        String     encAlg;
-                
-        switch (keyAlgorithm)
-        {
-        case PublicKeyAlgorithmTags.RSA_GENERAL:
-        case PublicKeyAlgorithmTags.RSA_SIGN:
-            encAlg = "RSA";
-            break;
-        case PublicKeyAlgorithmTags.DSA:
-            encAlg = "DSA";
-            break;
-        case PublicKeyAlgorithmTags.ELGAMAL_ENCRYPT: // in some malformed cases.
-        case PublicKeyAlgorithmTags.ELGAMAL_GENERAL:
-            encAlg = "ElGamal";
-            break;
-        default:
-            throw new PGPException("unknown algorithm tag in signature:" + keyAlgorithm);
-        }
-
-        return getDigestName(hashAlgorithm) + "with" + encAlg;
-    }
-    
-    static String getSymmetricCipherName(
-        int    algorithm)
-    {
-        switch (algorithm)
-        {
-        case SymmetricKeyAlgorithmTags.NULL:
-            return null;
-        case SymmetricKeyAlgorithmTags.TRIPLE_DES:
-            return "DESEDE";
-        case SymmetricKeyAlgorithmTags.IDEA:
-            return "IDEA";
-        case SymmetricKeyAlgorithmTags.CAST5:
-            return "CAST5";
-        case SymmetricKeyAlgorithmTags.BLOWFISH:
-            return "Blowfish";
-        case SymmetricKeyAlgorithmTags.SAFER:
-            return "SAFER";
-        case SymmetricKeyAlgorithmTags.DES:
-            return "DES";
-        case SymmetricKeyAlgorithmTags.AES_128:
-            return "AES";
-        case SymmetricKeyAlgorithmTags.AES_192:
-            return "AES";
-        case SymmetricKeyAlgorithmTags.AES_256:
-            return "AES";
-        case SymmetricKeyAlgorithmTags.CAMELLIA_128:
-            return "Camellia";
-        case SymmetricKeyAlgorithmTags.CAMELLIA_192:
-            return "Camellia";
-        case SymmetricKeyAlgorithmTags.CAMELLIA_256:
-            return "Camellia";
-        case SymmetricKeyAlgorithmTags.TWOFISH:
-            return "Twofish";
-        default:
-            throw new IllegalArgumentException("unknown symmetric algorithm: " + algorithm);
-        }
-    }
-    
     public static SecretKey makeSymmetricKey(
         int             algorithm,
         byte[]          keyBytes)


### PR DESCRIPTION
When we want to display info about some PGP object
it will be useful to have name insted of id.