### PR TITLE
Add test artifacts generated in Gradle build to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@
 bin/
 build/
 .settings/
+
+pg/*.asc
+pg/*.bak
+pg/*.bpg
+pg/*.txt


### PR DESCRIPTION
When running a Gradle build, a number of test artifacts are created in the `pg` directory.  Adding to gitignore.