### PR TITLE
Fix Null Pointer Exception in WNafUtil.java

### DIFF
--- a/core/src/main/java/org/bouncycastle/math/ec/WNafUtil.java
+++ b/core/src/main/java/org/bouncycastle/math/ec/WNafUtil.java
@@ -440,7 +440,7 @@ public abstract class WNafUtil
                          *      1) additions do not use the curve's A, B coefficients.
                          *      2) no special cases (i.e. Q +/- Q) when calculating 1P, 3P, 5P, ...
                          */
-                        if (ECAlgorithms.isFpCurve(c) && c.getFieldSize() >= 64)
+                        if (!twiceP.isInfinity() && ECAlgorithms.isFpCurve(c) && c.getFieldSize() >= 64)
                         {
                             switch (c.getCoordinateSystem())
                             {


### PR DESCRIPTION
BouncyCastle tries to precompute 2P for some optimization purpose
```java
twiceP = c.createPoint(twiceP.getXCoord().toBigInteger(), 
                       twiceP.getYCoord().toBigInteger());
```
If `twiceP`[1] is infinity then `twiceP.getXCoord()` returns `NULL` which causes `twiceP.getXCoord().toBigInteger()` to throw a Null Pointer Exception.

[1] An example is in curve255519, if P = (0, 0) then twiceP is infinity.

This issue was originally discovered by Thai Duong and Quan Nguyen