### PR TITLE
Fix some lgtm alerts

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/cms/CMSSignedDataParser.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSSignedDataParser.java
@@ -185,22 +185,19 @@ public class CMSSignedDataParser
             {
                 ASN1OctetStringParser octs = (ASN1OctetStringParser)contentParser;
 
-                if (octs != null)
-                {
-                    CMSTypedStream ctStr = new CMSTypedStream(
-                        cont.getContentType(), octs.getOctetStream());
+                CMSTypedStream ctStr = new CMSTypedStream(
+                    cont.getContentType(), octs.getOctetStream());
 
-                    if (_signedContent == null)
-                    {
-                        _signedContent = ctStr;
-                    }
-                    else
-                    {
-                        //
-                        // content passed in, need to read past empty encapsulated content info object if present
-                        //
-                        ctStr.drain();
-                    }
+                if (_signedContent == null)
+                {
+                    _signedContent = ctStr;
+                }
+                else
+                {
+                    //
+                    // content passed in, need to read past empty encapsulated content info object if present
+                    //
+                    ctStr.drain();
                 }
             }
             else if (contentParser != null)

--- a/prov/src/main/java/org/bouncycastle/jce/provider/BrokenKDF2BytesGenerator.java
+++ b/prov/src/main/java/org/bouncycastle/jce/provider/BrokenKDF2BytesGenerator.java
@@ -77,7 +77,7 @@ public class BrokenKDF2BytesGenerator
             throw new DataLengthException("output buffer too small");
         }
 
-        long    oBits = len * 8;
+        long    oBits = len * 8L;
 
         //
         // this is at odds with the standard implementation, the

--- a/prov/src/main/java/org/bouncycastle/jce/provider/BrokenKDF2BytesGenerator.java
+++ b/prov/src/main/java/org/bouncycastle/jce/provider/BrokenKDF2BytesGenerator.java
@@ -85,7 +85,7 @@ public class BrokenKDF2BytesGenerator
         // is the digest output size in bits. We can't have an
         // array with a long index at the moment...
         //
-        if (oBits > (digest.getDigestSize() * 8 * (2L^32 - 1)))
+        if (oBits > (digest.getDigestSize() * 8 * ((1L << 23) - 1)))
         {
             new IllegalArgumentException("Output length to large");
         }


### PR DESCRIPTION
I hope this is the right way to contribute.  I've fixed a few alerts flagged by lgtm.com.

- https://lgtm.com/projects/g/bcgit/bc-java/snapshot/0695a8c2cbd8b595de4702c97ec40796084d1f4d/files/prov/src/main/java/org/bouncycastle/jce/provider/BrokenKDF2BytesGenerator.java#V88
- https://lgtm.com/projects/g/bcgit/bc-java/snapshot/0695a8c2cbd8b595de4702c97ec40796084d1f4d/files/pkix/src/main/java/org/bouncycastle/cms/CMSSignedDataParser.java#V188

There are a number of additional alerts flagged by lgtm.com: https://lgtm.com/projects/g/bcgit/bc-java/alerts/

(You can also enable pull request integration on lgtm.com for fully automated PR reviews)