### PR TITLE
Prevent NullPointerException during class loading in AES.class

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/AES.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/AES.java
@@ -1034,9 +1034,11 @@ public final class AES
     {
         try
         {
-            Class def = AES.class.getClassLoader().loadClass(className);
-
-            return def;
+            ClassLoader classLoader = AES.class.getClassLoader();
+            if (classLoader == null) {
+                classLoader = ClassLoader.getSystemClassLoader();
+            }
+            return classLoader.loadClass(className);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Helps to avoid NullPointerException being thrown by `AES.class.getClassLoader().loadClass(className);`.
If class loader is null, it must've been loaded with bootstrap class loader.
