### PR TITLE
DSS-1415: Support legacy encoding of ts tokens preserving cert ordering.

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/tsp/TimeStampResponseGenerator.java
+++ b/pkix/src/main/java/org/bouncycastle/tsp/TimeStampResponseGenerator.java
@@ -1,5 +1,6 @@
 package org.bouncycastle.tsp;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Date;
@@ -8,6 +9,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.DERBitString;
@@ -20,6 +22,7 @@ import org.bouncycastle.asn1.cmp.PKIStatusInfo;
 import org.bouncycastle.asn1.cms.ContentInfo;
 import org.bouncycastle.asn1.tsp.TimeStampResp;
 import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.cms.CMSSignedData;
 
 /**
  * Generator for RFC 3161 Time Stamp Responses.
@@ -239,6 +242,32 @@ public class TimeStampResponseGenerator
         Extensions          additionalExtensions)
         throws TSPException
     {
+        return generateGrantedResponse(request, serialNumber, genTime, statusString, additionalExtensions, false);
+    }
+
+    /**
+     * Return a granted response, if the passed in request passes validation with the passed in status string and extra extensions.
+     * <p>
+     * If genTime is null a timeNotAvailable or a validation exception occurs a TSPValidationException will
+     * be thrown. The parent TSPException will only occur on some sort of system failure.
+     * </p>
+     * @param request the request this response is for.
+     * @param serialNumber serial number for the response token.
+     * @param genTime generation time for the response token.
+     * @param additionalExtensions extra extensions to be added to the response token.
+     * @param legacyEncoding encodes the token as before BC 1.50.
+     * @return  the TimeStampResponse with a status of  PKIStatus.GRANTED
+     * @throws TSPException on validation exception or internal error.
+     */
+    public TimeStampResponse generateGrantedResponse(
+        TimeStampRequest    request,
+        BigInteger          serialNumber,
+        Date                genTime,
+        String              statusString,
+        Extensions          additionalExtensions,
+        boolean             legacyEncoding)
+        throws TSPException
+    {
         if (genTime == null)
         {
             throw new TSPValidationException("The time source is not available.", PKIFailureInfo.timeNotAvailable);
@@ -259,7 +288,17 @@ public class TimeStampResponseGenerator
         ContentInfo tstTokenContentInfo;
         try
         {
-            tstTokenContentInfo = tokenGenerator.generate(request, serialNumber, genTime, additionalExtensions).toCMSSignedData().toASN1Structure();
+            CMSSignedData token = tokenGenerator.generate(request, serialNumber, genTime, additionalExtensions).toCMSSignedData();
+            if (legacyEncoding)
+            {
+                ByteArrayInputStream bIn = new ByteArrayInputStream(token.getEncoded());
+                ASN1InputStream aIn = new ASN1InputStream(bIn);
+                tstTokenContentInfo = ContentInfo.getInstance(aIn.readObject());
+            }
+            else
+            {
+                tstTokenContentInfo = token.toASN1Structure();
+            }
         }
         catch (TSPException e)
         {


### PR DESCRIPTION
Regarding the discussion in the thread https://bouncycastle.org/devmailarchive/msg15273.html , the attached patch adds a parameter that can be used to get the same behavior as before BC 1.50 for instance when it comes to the ordering of the certificate in the output.