### PR TITLE
Fix an incorrect Blake2b calculation if hashing 2^64-127 to 2^64 bytes

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/digests/Blake2bDigest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/Blake2bDigest.java
@@ -392,9 +392,7 @@ public class Blake2bDigest
 
         f0 = 0xFFFFFFFFFFFFFFFFL;
         t0 += bufferPos;
-        // bufferPos may be < 128, so (t0 == 0) does not work
-        // for 2^64 < message length > 2^64 - 127
-        if ((t0 < 0) && (bufferPos > -t0))
+        if (bufferPos > 0 && t0 == 0)
         {
             t1++;
         }


### PR DESCRIPTION
I was porting the Blake2b implementation to a different language and I may have noticed a bug. I think if you hashed between 2^64 - 127 bytes and 2^64 bytes, then it would produce the wrong hash. I know this is just a theoretical bug because hashing that much data is impossible for the foreseeable future, but the code is there so I figure it should be correct.

In `doFinal()`, it increments `t1` even though `t0` has not made it back to 0 yet. So instead of the byte count being the correct value of just under 2^64, it would be almost 2^65 bytes. ~~For a little while, I thought the if statement should be changed, but then I realized, shouldn't it just be deleted? If `t0` hasn't made it back to zero yet, then `t1` should not be incremented. And `bufferPos` is guaranteed to be < 128 here, so `t0` can't hit zero in this method.~~ Edit: Of course `t0` can be 128 here, so it should be checking for `t0` being zero, as it does other places.

I ran `gradle test` and didn't get any new test failures.