### PR TITLE
Ignore JavaDoc doclint errors which kill release under Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,14 @@ buildscript {
    }
 }
 
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}
+
 allprojects {
    apply plugin: 'java'
    apply plugin: 'idea'


### PR DESCRIPTION
The Bouncy Castle project has dozens of javadoc errors which doclint tolerated under Java 7 but are now fatal under Java 8. When releasing to Maven Central (using `gradle uploadArchives`) the `javadoc` task gets run, and will fail when running under Java 8, blocking the release.

The solution here was taken from Stephen Colebourne's blog: http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html

See also: http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#quiet

Several of the javadoc errors in Bouncy Castle are valid errors - for instance:

```
core/src/main/java/org/bouncycastle/pqc/crypto/mceliece/McElieceCipher.java:160:
error: exception not thrown: java.lang.Exception
     * @throws Exception if the cipher text is invalid.
```

You can quickly see these by running `gradle javadoc` under Java 8.

cc @cwgit 