### PR TITLE
Added ECGOST oids to public/private keys

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/rosstandart/RosstandartObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/rosstandart/RosstandartObjectIdentifiers.java
@@ -30,13 +30,17 @@ public interface RosstandartObjectIdentifiers
 
     static final ASN1ObjectIdentifier id_tc26_agreement_gost_3410_12_512  = id_tc26_agreement.branch("2");
 
-    static final ASN1ObjectIdentifier id_tc26_gost_3410_12_256_paramSetA = id_tc26.branch("2.1.1.1");
+    static final ASN1ObjectIdentifier id_tc26_gost_3410_12_256_paramSet = id_tc26.branch("2.1.1");
 
-    static final ASN1ObjectIdentifier id_tc26_gost_3410_12_512_paramSetA = id_tc26.branch("2.1.2.1");
+    static final ASN1ObjectIdentifier id_tc26_gost_3410_12_512_paramSet = id_tc26.branch("2.1.2");
 
-    static final ASN1ObjectIdentifier id_tc26_gost_3410_12_512_paramSetB = id_tc26.branch("2.1.2.2");
+    static final ASN1ObjectIdentifier id_tc26_gost_3410_12_256_paramSetA = id_tc26_gost_3410_12_256_paramSet.branch("1");
 
-    static final ASN1ObjectIdentifier id_tc26_gost_3410_12_512_paramSetC = id_tc26.branch("2.1.2.3");
+    static final ASN1ObjectIdentifier id_tc26_gost_3410_12_512_paramSetA = id_tc26_gost_3410_12_512_paramSet.branch("1");
+
+    static final ASN1ObjectIdentifier id_tc26_gost_3410_12_512_paramSetB = id_tc26_gost_3410_12_512_paramSet.branch("2");
+
+    static final ASN1ObjectIdentifier id_tc26_gost_3410_12_512_paramSetC = id_tc26_gost_3410_12_512_paramSet.branch("3");
 
     static final ASN1ObjectIdentifier id_tc26_gost_28147_param_Z = id_tc26.branch("2.5.1.1");
 }

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost/BCECGOST3410PublicKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost/BCECGOST3410PublicKey.java
@@ -110,6 +110,15 @@ public class BCECGOST3410PublicKey
     }
 
     public BCECGOST3410PublicKey(
+            String algorithm,
+            ECPublicKeyParameters params,
+            ECParameterSpec spec, ASN1Encodable gostParams)
+    {
+        this(algorithm, params, spec);
+        this.gostParams = gostParams;
+    }
+
+    public BCECGOST3410PublicKey(
         String algorithm,
         ECPublicKeyParameters params,
         org.bouncycastle.jce.spec.ECParameterSpec spec)

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost/KeyPairGeneratorSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost/KeyPairGeneratorSpi.java
@@ -8,7 +8,10 @@ import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECGenParameterSpec;
 
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.cryptopro.CryptoProObjectIdentifiers;
 import org.bouncycastle.asn1.cryptopro.ECGOST3410NamedCurves;
+import org.bouncycastle.asn1.cryptopro.GOST3410PublicKeyAlgParameters;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
 import org.bouncycastle.crypto.params.ECDomainParameters;
@@ -175,9 +178,19 @@ public class KeyPairGeneratorSpi
         }
         else
         {
+            BCECGOST3410PublicKey pubKey;
             java.security.spec.ECParameterSpec p = (java.security.spec.ECParameterSpec)ecParams;
 
-            BCECGOST3410PublicKey pubKey = new BCECGOST3410PublicKey(algorithm, pub, p);
+            if(ecParams instanceof ECNamedCurveSpec){
+                ECNamedCurveSpec namedCurveSpec = (ECNamedCurveSpec) ecParams;
+                ASN1ObjectIdentifier oid = ECGOST3410NamedCurves.getOID(namedCurveSpec.getName());
+                GOST3410PublicKeyAlgParameters algParameters = new GOST3410PublicKeyAlgParameters(oid,
+                        CryptoProObjectIdentifiers.gostR3411);
+                pubKey = new BCECGOST3410PublicKey(algorithm, pub, p, algParameters);
+            }
+            else {
+                pubKey = new BCECGOST3410PublicKey(algorithm, pub, p);
+            }
 
             return new KeyPair(pubKey, new BCECGOST3410PrivateKey(algorithm, priv, pubKey, p));
         }

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost12/BCECGOST3410_2012PublicKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost12/BCECGOST3410_2012PublicKey.java
@@ -113,6 +113,14 @@ public class BCECGOST3410_2012PublicKey
     }
 
     public BCECGOST3410_2012PublicKey(
+            String algorithm,
+            ECPublicKeyParameters params,
+            ECParameterSpec spec, GOST3410PublicKeyAlgParameters gostParams){
+        this(algorithm, params, spec);
+        this.gostParams = gostParams;
+    }
+
+    public BCECGOST3410_2012PublicKey(
         String algorithm,
         ECPublicKeyParameters params,
         org.bouncycastle.jce.spec.ECParameterSpec spec)

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost12/KeyPairGeneratorSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost12/KeyPairGeneratorSpi.java
@@ -1,6 +1,9 @@
 package org.bouncycastle.jcajce.provider.asymmetric.ecgost12;
 
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.cryptopro.ECGOST3410NamedCurves;
+import org.bouncycastle.asn1.cryptopro.GOST3410PublicKeyAlgParameters;
+import org.bouncycastle.asn1.rosstandart.RosstandartObjectIdentifiers;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
 import org.bouncycastle.crypto.params.ECDomainParameters;
@@ -179,8 +182,20 @@ public class KeyPairGeneratorSpi
         else
         {
             java.security.spec.ECParameterSpec p = (java.security.spec.ECParameterSpec)ecParams;
-
-            BCECGOST3410_2012PublicKey pubKey = new BCECGOST3410_2012PublicKey(algorithm, pub, p);
+            BCECGOST3410_2012PublicKey pubKey;
+            if(ecParams instanceof ECNamedCurveSpec){
+                ECNamedCurveSpec namedCurveSpec = (ECNamedCurveSpec) ecParams;
+                ASN1ObjectIdentifier oid = ECGOST3410NamedCurves.getOID(namedCurveSpec.getName());
+                ASN1ObjectIdentifier digestOid = (oid.on(RosstandartObjectIdentifiers.id_tc26_gost_3410_12_256_paramSet)) ?
+                        RosstandartObjectIdentifiers.id_tc26_gost_3411_12_256:
+                        RosstandartObjectIdentifiers.id_tc26_gost_3411_12_512;
+                GOST3410PublicKeyAlgParameters algParameters = new GOST3410PublicKeyAlgParameters(oid,
+                        digestOid);
+                pubKey = new BCECGOST3410_2012PublicKey(algorithm, pub, p, algParameters);
+            }
+            else {
+                pubKey = new BCECGOST3410_2012PublicKey(algorithm, pub, p);
+            }
 
             return new KeyPair(pubKey, new BCECGOST3410_2012PrivateKey(algorithm, priv, pubKey, p));
         }


### PR DESCRIPTION
Added gost oids to public/private keys for ECGOST 2001/2012.  The presence of identifiers allows to read the keys generated using [openssl gost-engine](https://github.com/gost-engine/engine)  and vice versa