### PR TITLE
Fix off by one error in SCrypt.

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/generators/SCrypt.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/SCrypt.java
@@ -43,7 +43,7 @@ public class SCrypt
             throw new IllegalArgumentException("Cost parameter N must be > 1 and a power of 2");
         }
         // Only value of r that cost (as an int) could be exceeded for is 1
-        if (r == 1 && N > 65536)
+        if (r == 1 && N >= 65536)
         {
             throw new IllegalArgumentException("Cost parameter N must be > 1 and < 65536.");
         }

--- a/core/src/test/java/org/bouncycastle/crypto/test/SCryptTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/SCryptTest.java
@@ -30,7 +30,7 @@ public class SCryptTest extends SimpleTest
         checkOK("Minimal values", new byte[0], new byte[0], 2, 1, 1, 1);
         checkIllegal("Cost parameter must be > 1", new byte[0], new byte[0], 1, 1, 1, 1);
         checkOK("Cost parameter 65536 OK for r == 1", new byte[0], new byte[0], 65536, 1, 1, 1);
-        checkIllegal("Cost parameter must <= 65536 for r == 1", new byte[0], new byte[0], 65537, 1, 1, 1);
+        checkIllegal("Cost parameter must < 65536 for r == 1", new byte[0], new byte[0], 65536, 1, 1, 1);
         checkIllegal("Block size must be >= 1", new byte[0], new byte[0], 2, 0, 2, 1);
         checkIllegal("Parallelisation parameter must be >= 1", new byte[0], new byte[0], 2, 1, 0, 1);
         // checkOK("Parallelisation parameter 65535 OK for r = 4", new byte[0], new byte[0], 2, 32,


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7914#page-7 the cost parameter, N in the code, must be strictly less than 2^(128 * r / 8). In our case this is 65536. The argument checks formerly contained an off by one error checking that N was less than or equal to 65536 rather than strictly less than 65536.