### PR TITLE
Remove junit from prov build.gradle

### DIFF
--- a/prov/build.gradle
+++ b/prov/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     compile project(':core')
-  compile 'junit:junit:4.12'
 }
 
 cobertura {


### PR DESCRIPTION
I am using the SpongyCastle and found out that junit was added to the classpath same as here.

To fix the problem and for later if SpongyCastle pull the change, I think `compile 'junit:junit:4.12'` should be removed from prov module and use only the testCompile dependency which defined in root project's gradle.