### PR TITLE
fixing two special character encoding issues when testing on other locales

### DIFF
--- a/core/src/test/java/org/bouncycastle/crypto/test/OpenBSDBCryptTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/OpenBSDBCryptTest.java
@@ -28,7 +28,7 @@ public class OpenBSDBCryptTest
     };
 
     private final static String[] bcryptTest2b = { // from: http://stackoverflow.com/questions/11654684/verifying-a-bcrypt-hash
-        "$2a$10$.TtQJ4Jr6isd4Hp.mVfZeuh6Gws4rOQ/vdBczhDx.19NFK0Y84Dle", "ππππππππ"
+        "$2a$10$.TtQJ4Jr6isd4Hp.mVfZeuh6Gws4rOQ/vdBczhDx.19NFK0Y84Dle", "\u03c0\u03c0\u03c0\u03c0\u03c0\u03c0\u03c0\u03c0"
     };
 
     private final static String[][] bcryptTest3 = // from: https://bitbucket.org/vadim/bcrypt.net/src/464c41416dc9/BCrypt.Net.Test/TestBCrypt.cs - plain - salt - expected

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPUnicodeTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPUnicodeTest.java
@@ -74,7 +74,7 @@ public class PGPUnicodeTest
         {
             BigInteger keyId = new BigInteger("362961283C48132B9F14C5C3EC87272EFCB986D2", 16);
 
-            String passphrase = new String("Händle".getBytes("UTF-16"), "UTF-16");
+            String passphrase = new String("H\u00e4ndle".getBytes("UTF-16"), "UTF-16");
 //            FileInputStream passwordFile = new FileInputStream("testdata/passphrase_for_test.txt");
 //            byte[] password = new byte[passwordFile.available()];
 //            passwordFile.read(password);

--- a/pkix/src/main/java/org/bouncycastle/cms/jcajce/JceKeyAgreeRecipient.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/jcajce/JceKeyAgreeRecipient.java
@@ -197,7 +197,7 @@ public abstract class JceKeyAgreeRecipient
         }
     }
 
-    private Key unwrapSessionKey(ASN1ObjectIdentifier wrapAlg, SecretKey agreedKey, ASN1ObjectIdentifier contentEncryptionAlgorithm, byte[] encryptedContentEncryptionKey)
+    protected Key unwrapSessionKey(ASN1ObjectIdentifier wrapAlg, SecretKey agreedKey, ASN1ObjectIdentifier contentEncryptionAlgorithm, byte[] encryptedContentEncryptionKey)
         throws CMSException, InvalidKeyException, NoSuchAlgorithmException
     {
         Cipher keyCipher = helper.createCipher(wrapAlg);


### PR DESCRIPTION
Hi,

we have 2 minor issues when building bc-java on a German windows system. Both come from some strings in test cases, containing special characters  (ä and π), which we encode as \u????. Afterwards all tests work fine on our systems.

I hope there is no problem with this pull request.

thanks & regards,

daniel