### PR TITLE
fix a bug in SM4Engine.decrypt(byte[] in, int inOff, int inLen)

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/engines/SM2Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/SM2Engine.java
@@ -164,7 +164,7 @@ public class SM2Engine
         int check = 0;
         for (int i = 0; i != c3.length; i++)
         {
-            check |= c3[i] ^ in[c1.length + c2.length + i];
+            check |= c3[i] ^ in[inOff + c1.length + c2.length + i];
         }
 
         Arrays.fill(c1, (byte)0);


### PR DESCRIPTION
if the parameter "inOff" is not zero, it can not be decrypted successully