### PR TITLE
Explicitly check for short buffers in RSA Ciphers.

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/CipherSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/CipherSpi.java
@@ -18,6 +18,7 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.ShortBufferException;
 import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 
@@ -488,8 +489,12 @@ public class CipherSpi
         int     inputLen,
         byte[]  output,
         int     outputOffset) 
-        throws IllegalBlockSizeException, BadPaddingException
+        throws IllegalBlockSizeException, BadPaddingException, ShortBufferException
     {
+        if (engineGetOutputSize(inputLen) > output.length - outputOffset)
+        {
+            throw new ShortBufferException("output buffer too short for input.");
+        }
         if (input != null)
         {
             bOut.write(input, inputOffset, inputLen);


### PR DESCRIPTION
Cipher.doFinal() says that ShortBufferException should be thrown when
an insufficiently-long output buffer is provided.  Other BC ciphers
check for a too-short output buffer before beginning the requested
operation, but the RSA cipher doesn't, it just begins the operation
and throws ArrayIndexOutOfBoundsException.  Switch to checking for and
throwing ShortBufferException.

Fixes #322.