### PR TITLE
Use two-byte checksum for unencrypted secret keys

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -112,12 +112,12 @@ public class PGPSecretKey
 
             byte[]    keyData = bOut.toByteArray();
 
-            pOut.write(checksum(checksumCalculator, keyData, keyData.length));
-
             int encAlgorithm = (keyEncryptor != null) ? keyEncryptor.getAlgorithm() : SymmetricKeyAlgorithmTags.NULL;
 
             if (encAlgorithm != SymmetricKeyAlgorithmTags.NULL)
             {
+                pOut.write(checksum(checksumCalculator, keyData, keyData.length));
+
                 keyData = bOut.toByteArray(); // include checksum
 
                 byte[] encData = keyEncryptor.encryptKeyData(keyData, 0, keyData.length);
@@ -151,13 +151,15 @@ public class PGPSecretKey
             }
             else
             {
+                pOut.write(checksum(null, keyData, keyData.length));
+
                 if (isMasterKey)
                 {
-                    return new SecretKeyPacket(pubKey.publicPk, encAlgorithm, null, null, bOut.toByteArray());
+                    return new SecretKeyPacket(pubKey.publicPk, SymmetricKeyAlgorithmTags.NULL, SecretKeyPacket.USAGE_NONE, null, null, bOut.toByteArray());
                 }
                 else
                 {
-                    return new SecretSubkeyPacket(pubKey.publicPk, encAlgorithm, null, null, bOut.toByteArray());
+                    return new SecretSubkeyPacket(pubKey.publicPk, SymmetricKeyAlgorithmTags.NULL, SecretKeyPacket.USAGE_NONE, null, null, bOut.toByteArray());
                 }
             }
         }


### PR DESCRIPTION
Fixes #348 by unconditionally using a 2-byte checksum instead of SHA1 if encryption algorithm is NULL.