### PR TITLE
CMS : register ECDSA encryption algorithm

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/cms/DefaultCMSSignatureAlgorithmNameGenerator.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/DefaultCMSSignatureAlgorithmNameGenerator.java
@@ -92,6 +92,7 @@ public class DefaultCMSSignatureAlgorithmNameGenerator
         encryptionAlgs.put(TeleTrusTObjectIdentifiers.teleTrusTRSAsignatureAlgorithm, "RSA");
         encryptionAlgs.put(X509ObjectIdentifiers.id_ea_rsa, "RSA");
         encryptionAlgs.put(PKCSObjectIdentifiers.id_RSASSA_PSS, "RSAandMGF1");
+        encryptionAlgs.put(X9ObjectIdentifiers.id_ecPublicKey, "ECDSA");
         encryptionAlgs.put(CryptoProObjectIdentifiers.gostR3410_94, "GOST3410");
         encryptionAlgs.put(CryptoProObjectIdentifiers.gostR3410_2001, "ECGOST3410");
         encryptionAlgs.put(new ASN1ObjectIdentifier("1.3.6.1.4.1.5849.1.6.2"), "ECGOST3410");


### PR DESCRIPTION
Hello,

I'm facing to the following exception when I validate an ECDSA signature

> java.lang.IllegalArgumentException: Unknown signature type requested: SHA1WITH1.2.840.10045.2.1
	at org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder.generate(Unknown Source) ~[bcpkix-jdk15on-1.59.jar!/:1.59.0]
	at org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder.find(Unknown Source) ~[bcpkix-jdk15on-1.59.jar!/:1.59.0]
	at org.bouncycastle.cms.SignerInformationVerifier.getContentVerifier(Unknown Source) ~[bcpkix-jdk15on-1.59.jar!/:1.59.0]
	at org.bouncycastle.cms.SignerInformation.doVerify(Unknown Source) ~[bcpkix-jdk15on-1.59.jar!/:1.59.0]
	at org.bouncycastle.cms.SignerInformation.verify(Unknown Source) ~[bcpkix-jdk15on-1.59.jar!/:1.59.0]

The ECDSA encryption algorithm is not registered. 

Regards,

Pierrick