### PR TITLE
Change return type of PGPSecretKey.getUserIds() to Iterator<String>

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -357,7 +357,7 @@ public class PGPSecretKey
      *
      * @return an iterator of Strings.
      */
-    public Iterator getUserIDs()
+    public Iterator<String> getUserIDs()
     {
         return pub.getUserIDs();
     }


### PR DESCRIPTION
`PGPPublicKey.getUserIds()` returns an `Iterator<String>`. `PGPSecretKey.getUserIds()` internally calls `.getUserIds()` of its public key, it however has the return type `Iterator`, which overlays (I'm not sure what the correct term is :D) the Iterators real generic type.

My PR changes the return type of `PGPSecretKey.getUserIds()` to `Iterator<String>` to match that of the public key.