### PR TITLE
#364 use ECNamedCurveTable instead of NISTNamedCurves for curve lookup

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPKeyConverter.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPKeyConverter.java
@@ -6,8 +6,8 @@ import java.util.Date;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.asn1.x9.X9ECPoint;
 import org.bouncycastle.bcpg.BCPGKey;
@@ -97,7 +97,7 @@ public class BcPGPKeyConverter
             // TODO: should probably match curve by comparison as well
             ASN1ObjectIdentifier curveOid = ASN1ObjectIdentifier.getInstance(keyInfo.getAlgorithm().getParameters());
 
-            X9ECParameters params = NISTNamedCurves.getByOID(curveOid);
+            X9ECParameters params = ECNamedCurveTable.getByOID(curveOid);
 
             ASN1OctetString key = new DEROctetString(keyInfo.getPublicKeyData().getBytes());
             X9ECPoint derQ = new X9ECPoint(params.getCurve(), key);

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPublicKeyDataDecryptorFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPublicKeyDataDecryptorFactory.java
@@ -2,7 +2,7 @@ package org.bouncycastle.openpgp.operator.bc;
 
 import java.io.IOException;
 
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.bcpg.ECDHPublicBCPGKey;
 import org.bouncycastle.bcpg.ECSecretBCPGKey;
@@ -99,7 +99,7 @@ public class BcPublicKeyDataDecryptorFactory
             else
             {
                 ECDHPublicBCPGKey ecKey = (ECDHPublicBCPGKey)privKey.getPublicKeyPacket().getKey();
-                X9ECParameters x9Params = NISTNamedCurves.getByOID(ecKey.getCurveOID());
+                X9ECParameters x9Params = ECNamedCurveTable.getByOID(ecKey.getCurveOID());
 
                 byte[] enc = secKeyData[0];
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPKeyConverter.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPKeyConverter.java
@@ -34,7 +34,6 @@ import javax.crypto.spec.DHPublicKeySpec;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
@@ -196,7 +195,7 @@ public class JcaPGPKeyConverter
             // TODO: should probably match curve by comparison as well
             ASN1ObjectIdentifier  curveOid = ASN1ObjectIdentifier.getInstance(keyInfo.getAlgorithm().getParameters());
 
-            X9ECParameters params = NISTNamedCurves.getByOID(curveOid);
+            X9ECParameters params = ECNamedCurveTable.getByOID(curveOid);
 
             ASN1OctetString key = new DEROctetString(keyInfo.getPublicKeyData().getBytes());
             X9ECPoint derQ = new X9ECPoint(params.getCurve(), key);

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePublicKeyDataDecryptorFactoryBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePublicKeyDataDecryptorFactoryBuilder.java
@@ -14,7 +14,7 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyAgreement;
 import javax.crypto.interfaces.DHKey;
 
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.bcpg.ECDHPublicBCPGKey;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
@@ -137,7 +137,7 @@ public class JcePublicKeyDataDecryptorFactoryBuilder
     {
         PublicKeyPacket pubKeyData = privKey.getPublicKeyPacket();
         ECDHPublicBCPGKey ecKey = (ECDHPublicBCPGKey)pubKeyData.getKey();
-        X9ECParameters x9Params = NISTNamedCurves.getByOID(ecKey.getCurveOID());
+        X9ECParameters x9Params = ECNamedCurveTable.getByOID(ecKey.getCurveOID());
 
         byte[] enc = secKeyData[0];
 

--- a/pg/src/main/jdk1.4/org/bouncycastle/openpgp/operator/jcajce/JcaPGPKeyConverter.java
+++ b/pg/src/main/jdk1.4/org/bouncycastle/openpgp/operator/jcajce/JcaPGPKeyConverter.java
@@ -23,8 +23,8 @@ import java.util.Date;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.asn1.x9.X9ECPoint;
 import org.bouncycastle.bcpg.BCPGKey;
@@ -190,7 +190,7 @@ public class JcaPGPKeyConverter
             // TODO: should probably match curve by comparison as well
             ASN1ObjectIdentifier  curveOid = ASN1ObjectIdentifier.getInstance(keyInfo.getAlgorithm().getParameters());
 
-            X9ECParameters params = NISTNamedCurves.getByOID(curveOid);
+            X9ECParameters params = ECNamedCurveTable.getByOID(curveOid);
 
             ASN1OctetString key = new DEROctetString(keyInfo.getPublicKeyData().getBytes());
             X9ECPoint derQ = new X9ECPoint(params.getCurve(), key);
@@ -284,7 +284,7 @@ public class JcaPGPKeyConverter
                 ECSecretBCPGKey ecdhK = (ECSecretBCPGKey)privPk;
                 ECPrivateKeySpec ecDhSpec = new ECPrivateKeySpec(
                                                     ecdhK.getX(),
-                                                    convertX9Parameters(ecdhPub.getCurveOID(), NISTNamedCurves.getByOID(ecdhPub.getCurveOID())));
+                                                    convertX9Parameters(ecdhPub.getCurveOID(), ECNamedCurveTable.getByOID(ecdhPub.getCurveOID())));
                 fact = helper.createKeyFactory("ECDH");
 
                 return fact.generatePrivate(ecDhSpec);
@@ -293,7 +293,7 @@ public class JcaPGPKeyConverter
                 ECSecretBCPGKey ecdsaK = (ECSecretBCPGKey)privPk;
                 ECPrivateKeySpec ecDsaSpec = new ECPrivateKeySpec(
                                                     ecdsaK.getX(),
-                                                    convertX9Parameters(ecdsaPub.getCurveOID(), NISTNamedCurves.getByOID(ecdsaPub.getCurveOID())));
+                                                    convertX9Parameters(ecdsaPub.getCurveOID(), ECNamedCurveTable.getByOID(ecdsaPub.getCurveOID())));
                 fact = helper.createKeyFactory("ECDSA");
 
                 return fact.generatePrivate(ecDsaSpec);

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPECDHTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPECDHTest.java
@@ -12,7 +12,7 @@ import java.security.spec.ECGenParameterSpec;
 import java.util.Date;
 import java.util.Iterator;
 
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
 import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
@@ -252,7 +252,7 @@ public class PGPECDHTest
         }
     }
 
-    private void encryptDecryptBCTest()
+    private void encryptDecryptBCTest(final String curve)
         throws Exception
     {
         byte[]    text = { (byte)'h', (byte)'e', (byte)'l', (byte)'l', (byte)'o', (byte)' ', (byte)'w', (byte)'o', (byte)'r', (byte)'l', (byte)'d', (byte)'!', (byte)'\n' };
@@ -260,8 +260,8 @@ public class PGPECDHTest
 
         ECKeyPairGenerator keyGen = new ECKeyPairGenerator();
 
-        X9ECParameters x9ECParameters = NISTNamedCurves.getByName("P-256");
-        keyGen.init(new ECKeyGenerationParameters(new ECNamedDomainParameters(NISTNamedCurves.getOID("P-256"), x9ECParameters.getCurve(), x9ECParameters.getG(), x9ECParameters.getN()), new SecureRandom()));
+        X9ECParameters x9ECParameters = ECNamedCurveTable.getByName(curve);
+        keyGen.init(new ECKeyGenerationParameters(new ECNamedDomainParameters(ECNamedCurveTable.getOID(curve), x9ECParameters.getCurve(), x9ECParameters.getG(), x9ECParameters.getN()), new SecureRandom()));
 
         AsymmetricCipherKeyPair kpEnc = keyGen.generateKeyPair();
 
@@ -336,7 +336,8 @@ public class PGPECDHTest
         testDecrypt(secretKeyRing);
 
         encryptDecryptTest();
-        encryptDecryptBCTest();
+        encryptDecryptBCTest("P-256");
+        encryptDecryptBCTest("brainpoolP512r1");
 
         generate();
     }

--- a/prov/src/main/jdk1.4/org/bouncycastle/jcajce/provider/asymmetric/util/ECUtil.java
+++ b/prov/src/main/jdk1.4/org/bouncycastle/jcajce/provider/asymmetric/util/ECUtil.java
@@ -332,6 +332,10 @@ public class ECUtil
             {
                 oid = GMNamedCurves.getOID(name);
             }
+            if (oid == null)
+            {
+                oid = ECNamedCurveTable.getOID(name);
+            }
         }
 
         return oid;
@@ -364,6 +368,10 @@ public class ECUtil
             if (params == null)
             {
                 params = GMNamedCurves.getByOID(oid);
+            }
+            if (params == null)
+            {
+                params = ECNamedCurveTable.getByOID(oid);
             }
         }
 
@@ -398,6 +406,10 @@ public class ECUtil
             {
                 params = GMNamedCurves.getByName(curveName);
             }
+            if (params == null)
+            {
+                params = ECNamedCurveTable.getByName(curveName);
+            }
         }
 
         return params;
@@ -430,6 +442,10 @@ public class ECUtil
             if (name == null)
             {
                 name = GMNamedCurves.getName(oid);
+            }
+            if (name == null)
+            {
+                name = ECNamedCurveTable.getName(oid);
             }
         }
 


### PR DESCRIPTION
support more curves when decrypting or verifying or when converting EC key pairs to JCA key pair.
this will fix #364 
