### PR TITLE
Fix log message

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPublicKeyDataDecryptorFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPublicKeyDataDecryptorFactory.java
@@ -130,7 +130,7 @@ public class BcPublicKeyDataDecryptorFactory
         }
         catch (InvalidCipherTextException e)
         {
-            throw new PGPException("exception encrypting session info: " + e.getMessage(), e);
+            throw new PGPException("exception decrypting session info: " + e.getMessage(), e);
         }
 
     }


### PR DESCRIPTION
This PR fixes a log message in `BcPublicKeyDataDecryptorFactory`, which falsely states that the data cannot be *encrypted*, while in fact it could not be *decrypted*.