### PR TITLE
Make PGPKeyRing.getPublicKeys() return Iterator<PGPPublicKey>

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRing.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRing.java
@@ -108,7 +108,7 @@ public abstract class PGPKeyRing
      *
      * @return Iterator
      */
-    public abstract Iterator getPublicKeys();
+    public abstract Iterator<PGPPublicKey> getPublicKeys();
 
     /**
      * Return the public key referred to by the passed in keyID if it


### PR DESCRIPTION
This change is made in order to make iterating through the `PGPPublicKey`s of a `PGPKeyRing` more convenient.