### PR TITLE
Fix ed25519 ignoring the public key offset

### DIFF
--- a/core/src/main/java/org/bouncycastle/math/ec/rfc8032/Ed25519.java
+++ b/core/src/main/java/org/bouncycastle/math/ec/rfc8032/Ed25519.java
@@ -334,7 +334,7 @@ public abstract class Ed25519
 
         dom2(d, phflag, ctx);
         d.update(R, 0, POINT_BYTES);
-        d.update(pk, 0, POINT_BYTES);
+        d.update(pk, pkOff, POINT_BYTES);
         d.update(m, mOff, mLen);
         d.doFinal(h, 0);
 


### PR DESCRIPTION
The same issue also exists in the c# version of this. Should I make a separate PR there?