### PR TITLE
SPHINCS-256 signatures are deterministic and no RNG is required.

### DIFF
--- a/core/src/main/java/org/bouncycastle/pqc/crypto/sphincs/SPHINCS256Signer.java
+++ b/core/src/main/java/org/bouncycastle/pqc/crypto/sphincs/SPHINCS256Signer.java
@@ -2,6 +2,7 @@ package org.bouncycastle.pqc.crypto.sphincs;
 
 import org.bouncycastle.crypto.CipherParameters;
 import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.params.ParametersWithRandom;
 import org.bouncycastle.pqc.crypto.MessageSigner;
 import org.bouncycastle.util.Pack;
 
@@ -48,7 +49,12 @@ public class SPHINCS256Signer
     {
          if (forSigning)
          {
-             keyData = ((SPHINCSPrivateKeyParameters)param).getKeyData();
+             if (param instanceof ParametersWithRandom) {
+                 // SPHINCS-256 signatures are deterministic, RNG is not required.
+                 keyData = ((SPHINCSPrivateKeyParameters)((ParametersWithRandom) param).getParameters()).getKeyData();
+             } else {
+                 keyData = ((SPHINCSPrivateKeyParameters) param).getKeyData();
+             }
          }
          else
          {

--- a/prov/src/main/java/org/bouncycastle/pqc/jcajce/provider/sphincs/SignatureSpi.java
+++ b/prov/src/main/java/org/bouncycastle/pqc/jcajce/provider/sphincs/SignatureSpi.java
@@ -58,7 +58,6 @@ public class SignatureSpi
         {
             CipherParameters param = ((BCSphincs256PrivateKey)privateKey).getKeyParams();
 
-            // TODO consider omitting this, as SPHINCS-256 is deterministic and RNG is not required at this stage anyway.
             if (random != null)
             {
                 param = new ParametersWithRandom(param, random);

--- a/prov/src/main/java/org/bouncycastle/pqc/jcajce/provider/sphincs/SignatureSpi.java
+++ b/prov/src/main/java/org/bouncycastle/pqc/jcajce/provider/sphincs/SignatureSpi.java
@@ -58,6 +58,7 @@ public class SignatureSpi
         {
             CipherParameters param = ((BCSphincs256PrivateKey)privateKey).getKeyParams();
 
+            // TODO consider omitting this, as SPHINCS-256 is deterministic and RNG is not required at this stage anyway.
             if (random != null)
             {
                 param = new ParametersWithRandom(param, random);


### PR DESCRIPTION
A solution to the https://github.com/bcgit/bc-java/issues/415 where Sphincs fails with ClassCastException when signature.initSign gets a PRNG as an input.
We could possibly delete code from `sphincs/SignatureSpi.java`, but just in case a newer version of Sphincs requires some RNG, I've changed the `SPHINCS256Signer` logic only. 

Note: In the meantime `SignatureSpi.java` has been updated in master, but we should also do in `SPHINCS256Signer` to handle direct access/invocation.