### PR TITLE
Documentation of Test S/MIME Sign Encrypt and Decrease in Memory Use for SMIME Decryption

### DIFF
--- a/pkix/src/test/java/org/bouncycastle/mime/test/TestSMIMESignEncrypt.java
+++ b/pkix/src/test/java/org/bouncycastle/mime/test/TestSMIMESignEncrypt.java
@@ -175,11 +175,11 @@ public class TestSMIMESignEncrypt_commented
                 assertNotNull(recipInfo);
                 
                 //decrypt the file using the receiver's private key before verifying signature
-                byte[] content = recipInfo.getContent(new JceKeyTransEnvelopedRecipient(_reciKP.getPrivate()));
+                CMSTypedStream content = recipInfo.getContentStream(new JceKeyTransEnvelopedRecipient(_reciKP.getPrivate()));
 
                 MimeParserProvider provider = new SMimeParserProvider("7bit", new BcDigestCalculatorProvider());
                 
-                MimeParser p = provider.createParser(new ReadOnceInputStream(content));
+                MimeParser p = provider.createParser(content.getContentStream());
 
                 p.parse(new SMimeParserListener()
                 {


### PR DESCRIPTION
Documentation to be able to understand better how the decryption and signing work in the example test. 