### PR TITLE
Added constructor to JceKeyTransRecipientInfoGenerator

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/util/JournalingSecureRandom.java
+++ b/core/src/main/java/org/bouncycastle/crypto/util/JournalingSecureRandom.java
@@ -21,6 +21,15 @@ public class JournalingSecureRandom
 
     private TranscriptStream tOut = new TranscriptStream();
     private int index = 0;
+    
+    /**
+     * Default constructor that takes an arbitrary SecureRandom as initial random
+     */
+    public JournalingSecureRandom() {
+    	
+    	this(new SecureRandom());
+    
+    }
 
     /**
      * Base constructor - no prior transcript.
@@ -101,6 +110,15 @@ public class JournalingSecureRandom
     {
         Arrays.fill(transcript, (byte)0);
         tOut.clear();
+    }
+    
+    /**
+     * Resets the index to zero such that the randomness will now be reused
+     */
+    public void reset() {
+    	
+    	index = 0;
+    	
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/crypto/util/JournalingSecureRandom.java
+++ b/core/src/main/java/org/bouncycastle/crypto/util/JournalingSecureRandom.java
@@ -7,7 +7,9 @@ import java.security.SecureRandom;
 import org.bouncycastle.util.Arrays;
 
 /**
- * A SecureRandom that maintains a journal of its output.
+* A SecureRandom that maintains a journal of its output.
+* This can be used to recreate an output that was based on randomness
+* For the transcript to be reusable, the order of the requests for randomness during recreation must be consistent with the initial requests and no other sources of randomness may be used.
  */
 public class JournalingSecureRandom
     extends SecureRandom
@@ -45,7 +47,7 @@ public class JournalingSecureRandom
     }
 
     /**
-     * Fill bytes with random data, journaling the random data before returning.
+     * Fill bytes with random data, journaling the random data before returning or re-use previously used random data, depending on the state of the transcript.
      *
      * @param bytes a block of bytes to be filled with random data.
      */

--- a/pkix/src/main/java/org/bouncycastle/cms/jcajce/JceKeyTransRecipientInfoGenerator.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/jcajce/JceKeyTransRecipientInfoGenerator.java
@@ -20,6 +20,11 @@ public class JceKeyTransRecipientInfoGenerator
     {
         super(new IssuerAndSerialNumber(new JcaX509CertificateHolder(recipientCert).toASN1Structure()), new JceAsymmetricKeyWrapper(recipientCert));
     }
+    
+    public JceKeyTransRecipientInfoGenerator(X509Certificate recipientCert, JceAsymmetricKeyWrapper wrapper) 
+    {
+    	super(new IssuerAndSerialNumber(new JcaX509CertificateHolder(recipientCert).toASN1Structure()), wrapper);
+    }
 
     public JceKeyTransRecipientInfoGenerator(byte[] subjectKeyIdentifier, PublicKey publicKey)
     {


### PR DESCRIPTION
The constructor allows the user to directly provide the JceAsymmetricKeyWrapper directly as a parameter. 