### PR TITLE
Fix typo in javadoc comment

### DIFF
--- a/tls/src/main/java/org/bouncycastle/tls/AbstractTlsServer.java
+++ b/tls/src/main/java/org/bouncycastle/tls/AbstractTlsServer.java
@@ -9,7 +9,7 @@ import org.bouncycastle.tls.crypto.TlsDHConfig;
 import org.bouncycastle.tls.crypto.TlsECConfig;
 
 /**
- * Base class for a TLS client.
+ * Base class for a TLS server.
  */
 public abstract class AbstractTlsServer
     extends AbstractTlsPeer


### PR DESCRIPTION
`AbstractTlsServer` seems like a base class for a TLS server.