### PR TITLE
Return specific template type when possible

### DIFF
--- a/pkix/src/main/j2me/org/bouncycastle/tsp/TimeStampToken.java
+++ b/pkix/src/main/j2me/org/bouncycastle/tsp/TimeStampToken.java
@@ -148,17 +148,17 @@ public class TimeStampToken
         return tsaSignerInfo.getUnsignedAttributes();
     }
 
-    public Store getCertificates()
+    public Store<X509CertificateHolder> getCertificates()
     {
         return tsToken.getCertificates();
     }
 
-    public Store getCRLs()
+    public Store<X509CRLHolder> getCRLs()
     {
         return tsToken.getCRLs();
     }
 
-    public Store getAttributeCertificates()
+    public Store<X509AttributeCertificateHolder> getAttributeCertificates()
     {
         return tsToken.getAttributeCertificates();
     }

--- a/pkix/src/main/java/org/bouncycastle/tsp/TimeStampToken.java
+++ b/pkix/src/main/java/org/bouncycastle/tsp/TimeStampToken.java
@@ -150,17 +150,17 @@ public class TimeStampToken
         return tsaSignerInfo.getUnsignedAttributes();
     }
 
-    public Store getCertificates()
+    public Store<X509CertificateHolder> getCertificates()
     {
         return tsToken.getCertificates();
     }
 
-    public Store getCRLs()
+    public Store<X509CRLHolder> getCRLs()
     {
         return tsToken.getCRLs();
     }
 
-    public Store getAttributeCertificates()
+    public Store<X509AttributeCertificateHolder> getAttributeCertificates()
     {
         return tsToken.getAttributeCertificates();
     }


### PR DESCRIPTION
I suggest to change the return types to Store with the specific type template, this would remove the "unchecked method invocation" or "unchecked conversion" warnings. I've seen this done in other methods in recent version changes, although I can't remember specifics.