### PR TITLE
Rejuvenate log levels

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/pkix/jcajce/X509RevocationChecker.java
+++ b/pkix/src/main/java/org/bouncycastle/pkix/jcajce/X509RevocationChecker.java
@@ -396,7 +396,7 @@ public class X509RevocationChecker
 
         if (issuerList.isEmpty())
         {
-            LOG.log(Level.INFO, "configured with 0 pre-loaded CRLs");
+            LOG.log(Level.FINEST, "configured with 0 pre-loaded CRLs");
         }
         else
         {

--- a/pkix/src/main/java/org/bouncycastle/pkix/jcajce/X509RevocationChecker.java
+++ b/pkix/src/main/java/org/bouncycastle/pkix/jcajce/X509RevocationChecker.java
@@ -582,7 +582,7 @@ public class X509RevocationChecker
 
                             urlStream.close();
 
-                            LOG.log(Level.INFO, "downloaded CRL from CrlDP " + url + " for issuer \"" + issuer + "\"");
+                            LOG.log(Level.FINEST, "downloaded CRL from CrlDP " + url + " for issuer \"" + issuer + "\"");
 
                             crlCache.put(name, new WeakReference<X509CRL>(crl));
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/PropertyUtils.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/PropertyUtils.java
@@ -61,7 +61,7 @@ class PropertyUtils
             }
             LOG.log(Level.WARNING, "Unrecognized value for boolean system property [" + propertyName + "]: " + propertyValue);
         }
-        LOG.log(Level.FINE, "Boolean system property [" + propertyName + "] defaulted to: " + defaultValue);
+        LOG.log(Level.FINEST, "Boolean system property [" + propertyName + "] defaulted to: " + defaultValue);
         return defaultValue;
     }
 
@@ -89,7 +89,7 @@ class PropertyUtils
                 LOG.log(Level.WARNING, "Unrecognized value for integer system property [" + propertyName + "]: " + propertyValue);
             }
         }
-        LOG.log(Level.FINE, "Integer system property [" + propertyName + "] defaulted to: " + defaultValue);
+        LOG.log(Level.FINEST, "Integer system property [" + propertyName + "] defaulted to: " + defaultValue);
         return defaultValue;
     }
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvKeyManagerFactorySpi.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvKeyManagerFactorySpi.java
@@ -57,7 +57,7 @@ class ProvKeyManagerFactorySpi
         {
             if (null == ksPath)
             {
-                LOG.info("Initializing empty key store");
+                LOG.finest("Initializing empty key store");
             }
             else
             {

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvKeyManagerFactorySpi.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvKeyManagerFactorySpi.java
@@ -61,7 +61,7 @@ class ProvKeyManagerFactorySpi
             }
             else
             {
-                LOG.info("Initializing with key store at path: " + ksPath);
+                LOG.finest("Initializing with key store at path: " + ksPath);
                 ksInput = new BufferedInputStream(new FileInputStream(ksPath));
             }
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLContextSpi.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLContextSpi.java
@@ -260,7 +260,7 @@ class ProvSSLContextSpi
 
             if (!supportedProtocols.containsKey(protocol))
             {
-                LOG.warning("'" + propertyName + "' contains unsupported protocol: " + protocol);
+                LOG.finest("'" + propertyName + "' contains unsupported protocol: " + protocol);
             }
             else if (!JsseUtils.contains(result, protocol))
             {

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsClient.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsClient.java
@@ -378,7 +378,7 @@ class ProvTlsClient
     {
         manager.getContext().validateNegotiatedCipherSuite(selectedCipherSuite);
 
-        LOG.fine("Client notified of selected cipher suite: " + manager.getContext().getCipherSuiteString(selectedCipherSuite));
+        LOG.finest("Client notified of selected cipher suite: " + manager.getContext().getCipherSuiteString(selectedCipherSuite));
 
         super.notifySelectedCipherSuite(selectedCipherSuite);
     }
@@ -388,7 +388,7 @@ class ProvTlsClient
     {
         String protocolString = manager.getContext().getProtocolString(serverVersion);
 
-        LOG.fine("Client notified of selected protocol version: " + protocolString);
+        LOG.finest("Client notified of selected protocol version: " + protocolString);
 
         super.notifyServerVersion(serverVersion);
     }
@@ -411,7 +411,7 @@ class ProvTlsClient
             }
             else
             {
-                LOG.fine("Server specified new session: " + Hex.toHexString(sessionID));
+                LOG.finest("Server specified new session: " + Hex.toHexString(sessionID));
             }
 
             if (!manager.getEnableSessionCreation())

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsClient.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsClient.java
@@ -401,13 +401,13 @@ class ProvTlsClient
 
         if (isResumed)
         {
-            LOG.fine("Server resumed session: " + Hex.toHexString(sessionID));
+            LOG.finest("Server resumed session: " + Hex.toHexString(sessionID));
         }
         else
         {
             if (sessionID == null || sessionID.length < 1)
             {
-                LOG.fine("Server did not specify a session ID");
+                LOG.finest("Server did not specify a session ID");
             }
             else
             {

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsServer.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsServer.java
@@ -459,7 +459,7 @@ class ProvTlsServer
             Collection<BCSNIMatcher> sniMatchers = sslParameters.getSNIMatchers();
             if (null == sniMatchers || sniMatchers.isEmpty())
             {
-                LOG.fine("Server ignored SNI (no matchers specified)");
+                LOG.finest("Server ignored SNI (no matchers specified)");
             }
             else
             {

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsServer.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsServer.java
@@ -277,7 +277,7 @@ class ProvTlsServer
 
         int selectedCipherSuite = super.getSelectedCipherSuite();
 
-        LOG.fine("Server selected cipher suite: " + manager.getContext().getCipherSuiteString(selectedCipherSuite));
+        LOG.finest("Server selected cipher suite: " + manager.getContext().getCipherSuiteString(selectedCipherSuite));
 
         keyManagerMissCache = null;
 
@@ -367,7 +367,7 @@ class ProvTlsServer
 
         String protocolString = manager.getContext().getProtocolString(serverVersion);
 
-        LOG.fine("Server selected protocol version: " + protocolString);
+        LOG.finest("Server selected protocol version: " + protocolString);
 
         return serverVersion;
     }
@@ -469,7 +469,7 @@ class ProvTlsServer
                     throw new TlsFatalAlert(AlertDescription.unrecognized_name);
                 }
 
-                LOG.fine("Server accepted SNI: " + matchedSNIServerName);
+                LOG.finest("Server accepted SNI: " + matchedSNIServerName);
             }
         }
     }

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTrustManagerFactorySpi.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTrustManagerFactorySpi.java
@@ -87,7 +87,7 @@ class ProvTrustManagerFactorySpi
         {
             if (null == tsPath)
             {
-                LOG.info("Initializing empty trust store");
+                LOG.finest("Initializing empty trust store");
             }
             else
             {

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTrustManagerFactorySpi.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTrustManagerFactorySpi.java
@@ -91,7 +91,7 @@ class ProvTrustManagerFactorySpi
             }
             else
             {
-                LOG.info("Initializing with trust store at path: " + tsPath);
+                LOG.finest("Initializing with trust store at path: " + tsPath);
                 tsInput = new BufferedInputStream(new FileInputStream(tsPath));
             }
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/SupportedGroups.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/SupportedGroups.java
@@ -70,11 +70,11 @@ abstract class SupportedGroups
             int namedGroup = NamedGroup.getByName(name);
             if (namedGroup < 0)
             {
-                LOG.warning("'" + PROPERTY_NAMEDGROUPS + "' contains unrecognised NamedGroup: " + name);
+                LOG.finest("'" + PROPERTY_NAMEDGROUPS + "' contains unrecognised NamedGroup: " + name);
             }
             else if (provDisableChar2 && NamedGroup.isChar2Curve(namedGroup))
             {
-                LOG.warning("'" + PROPERTY_NAMEDGROUPS + "' contains disabled characteristic-2 curve: " + name);
+                LOG.finest("'" + PROPERTY_NAMEDGROUPS + "' contains disabled characteristic-2 curve: " + name);
             }
             else
             {


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Settings

We have several analysis settings . We can vary these settings and rerun our if you desire. The settings we are using in this pull request are:

- Treat  CONFIG level as a category and not a traditional level, i.e., our tool ignores CONFIG log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).
- Never lower the logging level of logging statements within if statements (setting 3).
- Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels (setting 4).
- The greatest number of commits evaluated: 6000 (setting 5).

The head at time of analysis was: 4b133f18afe84364498f6f238a11e105e3e6df32