### PR TITLE
Rejuvenate log levels

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/pkix/jcajce/X509RevocationChecker.java
+++ b/pkix/src/main/java/org/bouncycastle/pkix/jcajce/X509RevocationChecker.java
@@ -396,7 +396,7 @@ public class X509RevocationChecker
 
         if (issuerList.isEmpty())
         {
-            LOG.log(Level.INFO, "configured with 0 pre-loaded CRLs");
+            LOG.log(Level.FINEST, "configured with 0 pre-loaded CRLs");
         }
         else
         {
@@ -582,7 +582,7 @@ public class X509RevocationChecker
 
                             urlStream.close();
 
-                            LOG.log(Level.INFO, "downloaded CRL from CrlDP " + url + " for issuer \"" + issuer + "\"");
+                            LOG.log(Level.FINEST, "downloaded CRL from CrlDP " + url + " for issuer \"" + issuer + "\"");
 
                             crlCache.put(name, new WeakReference<X509CRL>(crl));
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/PropertyUtils.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/PropertyUtils.java
@@ -51,17 +51,17 @@ class PropertyUtils
         {
             if ("true".equals(propertyValue))
             {
-                LOG.log(Level.INFO, "Found boolean system property [" + propertyName + "]: " + true);
+                LOG.log(Level.FINEST, "Found boolean system property [" + propertyName + "]: " + true);
                 return true;
             }
             if ("false".equals(propertyValue))
             {
-                LOG.log(Level.INFO, "Found boolean system property [" + propertyName + "]: " + false);
+                LOG.log(Level.FINEST, "Found boolean system property [" + propertyName + "]: " + false);
                 return false;
             }
             LOG.log(Level.WARNING, "Unrecognized value for boolean system property [" + propertyName + "]: " + propertyValue);
         }
-        LOG.log(Level.FINE, "Boolean system property [" + propertyName + "] defaulted to: " + defaultValue);
+        LOG.log(Level.FINEST, "Boolean system property [" + propertyName + "] defaulted to: " + defaultValue);
         return defaultValue;
     }
 
@@ -75,7 +75,7 @@ class PropertyUtils
                  int parsedValue = Integer.parseInt(propertyValue);
                  if (parsedValue >= minimumValue && parsedValue <= maximumValue)
                  {
-                     LOG.log(Level. INFO, "Found integer system property [" + propertyName + "]: " + parsedValue);
+                     LOG.log(Level.FINEST, "Found integer system property [" + propertyName + "]: " + parsedValue);
                      return parsedValue;
                  }
                  if (LOG.isLoggable(Level.WARNING))
@@ -89,7 +89,7 @@ class PropertyUtils
                 LOG.log(Level.WARNING, "Unrecognized value for integer system property [" + propertyName + "]: " + propertyValue);
             }
         }
-        LOG.log(Level.FINE, "Integer system property [" + propertyName + "] defaulted to: " + defaultValue);
+        LOG.log(Level.FINEST, "Integer system property [" + propertyName + "] defaulted to: " + defaultValue);
         return defaultValue;
     }
 
@@ -98,7 +98,7 @@ class PropertyUtils
         String propertyValue = getSystemProperty(propertyName);
         if (null != propertyValue)
         {
-            LOG.log(Level. INFO, "Found string system property [" + propertyName + "]: " + propertyValue);
+            LOG.log(Level.FINEST, "Found string system property [" + propertyName + "]: " + propertyValue);
             return propertyValue;
         }
         return null;

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvKeyManagerFactorySpi.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvKeyManagerFactorySpi.java
@@ -57,11 +57,11 @@ class ProvKeyManagerFactorySpi
         {
             if (null == ksPath)
             {
-                LOG.info("Initializing empty key store");
+                LOG.finest("Initializing empty key store");
             }
             else
             {
-                LOG.info("Initializing with key store at path: " + ksPath);
+                LOG.finest("Initializing with key store at path: " + ksPath);
                 ksInput = new BufferedInputStream(new FileInputStream(ksPath));
             }
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLSessionContext.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLSessionContext.java
@@ -259,7 +259,7 @@ class ProvSSLSessionContext
 
         if (count > 0)
         {
-            LOG.fine("Processed " + count + " session entries (soft references) from the reference queue");
+            LOG.finest("Processed " + count + " session entries (soft references) from the reference queue");
         }
     }
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsClient.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsClient.java
@@ -378,7 +378,7 @@ class ProvTlsClient
     {
         manager.getContext().validateNegotiatedCipherSuite(selectedCipherSuite);
 
-        LOG.fine("Client notified of selected cipher suite: " + manager.getContext().getCipherSuiteString(selectedCipherSuite));
+        LOG.finest("Client notified of selected cipher suite: " + manager.getContext().getCipherSuiteString(selectedCipherSuite));
 
         super.notifySelectedCipherSuite(selectedCipherSuite);
     }
@@ -388,7 +388,7 @@ class ProvTlsClient
     {
         String protocolString = manager.getContext().getProtocolString(serverVersion);
 
-        LOG.fine("Client notified of selected protocol version: " + protocolString);
+        LOG.finest("Client notified of selected protocol version: " + protocolString);
 
         super.notifyServerVersion(serverVersion);
     }
@@ -401,17 +401,17 @@ class ProvTlsClient
 
         if (isResumed)
         {
-            LOG.fine("Server resumed session: " + Hex.toHexString(sessionID));
+            LOG.finest("Server resumed session: " + Hex.toHexString(sessionID));
         }
         else
         {
             if (sessionID == null || sessionID.length < 1)
             {
-                LOG.fine("Server did not specify a session ID");
+                LOG.finest("Server did not specify a session ID");
             }
             else
             {
-                LOG.fine("Server specified new session: " + Hex.toHexString(sessionID));
+                LOG.finest("Server specified new session: " + Hex.toHexString(sessionID));
             }
 
             if (!manager.getEnableSessionCreation())

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsServer.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsServer.java
@@ -124,7 +124,7 @@ class ProvTlsServer
     {
         if (!selectCredentials(cipherSuite))
         {
-            LOG.finer("Server found no credentials for cipher suite: "
+            LOG.finest("Server found no credentials for cipher suite: "
                 + manager.getContext().getCipherSuiteString(cipherSuite));
             return false;
         }
@@ -277,7 +277,7 @@ class ProvTlsServer
 
         int selectedCipherSuite = super.getSelectedCipherSuite();
 
-        LOG.fine("Server selected cipher suite: " + manager.getContext().getCipherSuiteString(selectedCipherSuite));
+        LOG.finest("Server selected cipher suite: " + manager.getContext().getCipherSuiteString(selectedCipherSuite));
 
         keyManagerMissCache = null;
 
@@ -367,7 +367,7 @@ class ProvTlsServer
 
         String protocolString = manager.getContext().getProtocolString(serverVersion);
 
-        LOG.fine("Server selected protocol version: " + protocolString);
+        LOG.finest("Server selected protocol version: " + protocolString);
 
         return serverVersion;
     }
@@ -459,7 +459,7 @@ class ProvTlsServer
             Collection<BCSNIMatcher> sniMatchers = sslParameters.getSNIMatchers();
             if (null == sniMatchers || sniMatchers.isEmpty())
             {
-                LOG.fine("Server ignored SNI (no matchers specified)");
+                LOG.finest("Server ignored SNI (no matchers specified)");
             }
             else
             {
@@ -469,7 +469,7 @@ class ProvTlsServer
                     throw new TlsFatalAlert(AlertDescription.unrecognized_name);
                 }
 
-                LOG.fine("Server accepted SNI: " + matchedSNIServerName);
+                LOG.finest("Server accepted SNI: " + matchedSNIServerName);
             }
         }
     }

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTrustManagerFactorySpi.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTrustManagerFactorySpi.java
@@ -87,11 +87,11 @@ class ProvTrustManagerFactorySpi
         {
             if (null == tsPath)
             {
-                LOG.info("Initializing empty trust store");
+                LOG.finest("Initializing empty trust store");
             }
             else
             {
-                LOG.info("Initializing with trust store at path: " + tsPath);
+                LOG.finest("Initializing with trust store at path: " + tsPath);
                 tsInput = new BufferedInputStream(new FileInputStream(tsPath));
             }
 


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Settings

We have several analysis settings . We can vary these settings and rerun our if you desire. The settings we are using in this pull request are:

- Treat  CONFIG, WARNING, and SEVERE levels as a category and not a traditional level, i.e., our tool ignores these log level.
- Never lower the logging level of logging statements within catch blocks.
- Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
- The greatest number of commits evaluated: 6000.

The head at time of analysis was: 4b133f18afe84364498f6f238a11e105e3e6df32