### PR TITLE
Memory optimisation of ARGON2 implementation

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/generators/Argon2BytesGenerator.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/Argon2BytesGenerator.java
@@ -634,12 +634,14 @@ public class Argon2BytesGenerator
     
     private static class Block
     {
+    	private static final int SIZE = ARGON2_QWORDS_IN_BLOCK;
+    	
         /* 128 * 8 Byte QWords */
-        private long[] v;
+        private final long[] v;
 
         private Block()
         {
-            v = new long[ARGON2_QWORDS_IN_BLOCK];
+            v = new long[SIZE];
         }
 
         void fromBytes(byte[] input)
@@ -649,7 +651,7 @@ public class Argon2BytesGenerator
                 throw new IllegalArgumentException("input shorter than blocksize");
             }
 
-            for (int i = 0; i < v.length; i++)
+            for (int i = 0; i < SIZE; i++)
             {
                 v[i] = Pack.littleEndianToLong(input, i * 8);
             }
@@ -659,7 +661,7 @@ public class Argon2BytesGenerator
         {
             byte[] result = new byte[ARGON2_BLOCK_SIZE];
 
-            for (int i = 0; i < v.length; i++)
+            for (int i = 0; i < SIZE; i++)
             {
                 Pack.longToLittleEndian(v[i], result, i * 8);
             }
@@ -669,12 +671,12 @@ public class Argon2BytesGenerator
 
         private void copyBlock(Block other)
         {
-            System.arraycopy(other.v, 0, v, 0, v.length);
+            System.arraycopy(other.v, 0, v, 0, SIZE);
         }
 
         private void xor(Block b1, Block b2)
         {
-            for (int i = 0; i < v.length; i++)
+            for (int i = 0; i < SIZE; i++)
             {
                 v[i] = b1.v[i] ^ b2.v[i];
             }
@@ -682,7 +684,7 @@ public class Argon2BytesGenerator
 
         public void xor(Block b1, Block b2, Block b3)
         {
-            for (int i = 0; i < v.length; i++)
+            for (int i = 0; i < SIZE; i++)
             {
                 v[i] = b1.v[i] ^ b2.v[i] ^ b3.v[i];
             }
@@ -699,7 +701,7 @@ public class Argon2BytesGenerator
         public String toString()
         {
             StringBuffer result = new StringBuffer();
-            for (int i = 0; i < v.length; i++)
+            for (int i = 0; i < SIZE; i++)
             {
                 result.append(Hex.toHexString(Pack.longToLittleEndian(v[i])));
             }

--- a/core/src/main/java/org/bouncycastle/crypto/generators/Argon2BytesGenerator.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/Argon2BytesGenerator.java
@@ -125,7 +125,6 @@ public class Argon2BytesGenerator
         }
         memory = null;
         Arrays.fill(result, (byte)0);
-        doInit(parameters);
     }
 
     private void doInit(Argon2Parameters parameters)

--- a/core/src/main/java/org/bouncycastle/crypto/generators/Argon2BytesGenerator.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/Argon2BytesGenerator.java
@@ -210,13 +210,14 @@ public class Argon2BytesGenerator
 
     private void fillMemoryBlocks()
     {
+    	Position position = new Position();
         for (int i = 0; i < parameters.getIterations(); i++)
         {
             for (int j = 0; j < ARGON2_SYNC_POINTS; j++)
             {
                 for (int k = 0; k < parameters.getLanes(); k++)
                 {
-                    Position position = new Position(i, k, j, 0);
+                	position.update(i, k, j, 0);
                     fillSegment(position);
                 }
             }
@@ -710,13 +711,17 @@ public class Argon2BytesGenerator
         int lane;
         int slice;
         int index;
-
-        Position(int pass, int lane, int slice, int index)
+        
+        Position()
         {
-            this.pass = pass;
-            this.lane = lane;
-            this.slice = slice;
-            this.index = index;
+        	
         }
+
+		void update(int pass, int lane, int slice, int index) {
+			this.pass = pass;
+			this.lane = lane;
+			this.slice = slice;
+			this.index = index;
+		}
     }
 }

--- a/core/src/main/java/org/bouncycastle/crypto/generators/Argon2BytesGenerator.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/Argon2BytesGenerator.java
@@ -178,13 +178,14 @@ public class Argon2BytesGenerator
         for (int i = 0; i < 8; i++)
         {
 
-            roundFunction(Z,
-                16 * i, 16 * i + 1, 16 * i + 2,
-                16 * i + 3, 16 * i + 4, 16 * i + 5,
-                16 * i + 6, 16 * i + 7, 16 * i + 8,
-                16 * i + 9, 16 * i + 10, 16 * i + 11,
-                16 * i + 12, 16 * i + 13, 16 * i + 14,
-                16 * i + 15
+            int i16 = 16 * i;
+			roundFunction(Z,
+                i16, i16 + 1, i16 + 2,
+                i16 + 3, i16 + 4, i16 + 5,
+                i16 + 6, i16 + 7, i16 + 8,
+                i16 + 9, i16 + 10, i16 + 11,
+                i16 + 12, i16 + 13, i16 + 14,
+                i16 + 15
             );
         }
 
@@ -193,13 +194,14 @@ public class Argon2BytesGenerator
         for (int i = 0; i < 8; i++)
         {
 
-            roundFunction(Z,
-                2 * i, 2 * i + 1, 2 * i + 16,
-                2 * i + 17, 2 * i + 32, 2 * i + 33,
-                2 * i + 48, 2 * i + 49, 2 * i + 64,
-                2 * i + 65, 2 * i + 80, 2 * i + 81,
-                2 * i + 96, 2 * i + 97, 2 * i + 112,
-                2 * i + 113
+            int i2 = 2 * i;
+			roundFunction(Z,
+                i2, i2 + 1, i2 + 16,
+                i2 + 17, i2 + 32, i2 + 33,
+                i2 + 48, i2 + 49, i2 + 64,
+                i2 + 65, i2 + 80, i2 + 81,
+                i2 + 96, i2 + 97, i2 + 112,
+                i2 + 113
             );
 
         }


### PR DESCRIPTION
Hash computations allocates far to much temporary memory exhausting all system resources and requiring multiple GC runs per hash computation.

A memory profiler easily reports this issue:
![unoptimized](https://user-images.githubusercontent.com/12255010/59602835-1b949900-9108-11e9-886f-61afd86d2bad.PNG)
An optimized version reduces the temporary memory consumption in this example by nearly a factor of 10:
![optimized](https://user-images.githubusercontent.com/12255010/59602908-44b52980-9108-11e9-9072-bf7954607aad.PNG)
