### PR TITLE
Fixed the InvalidKeyException message when initializing EDEC Signatur…

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/edec/SignatureSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/edec/SignatureSpi.java
@@ -72,7 +72,7 @@ public class SignatureSpi
         }
         else
         {
-            throw new InvalidKeyException("cannot identify EdDSA public key");
+            throw new InvalidKeyException("cannot identify EdDSA private key");
         }
     }
 


### PR DESCRIPTION
…eSpi from public to private when initializing for signing.