### PR TITLE
Issue 552 Performance problem when signing and with DNS resolve problems for localhost

### DIFF
--- a/mail/src/main/java/org/bouncycastle/mail/smime/SMIMEGenerator.java
+++ b/mail/src/main/java/org/bouncycastle/mail/smime/SMIMEGenerator.java
@@ -6,7 +6,6 @@ import java.security.Provider;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.crypto.KeyGenerator;
 import javax.mail.Header;
@@ -25,8 +24,6 @@ import org.bouncycastle.util.Strings;
 public class SMIMEGenerator
 {
     private static Map BASE_CIPHER_NAMES = new HashMap();
-    private final static Properties dummyProps = new Properties();
-    private final static Session dummySession;
     
     static
     {
@@ -34,9 +31,6 @@ public class SMIMEGenerator
         BASE_CIPHER_NAMES.put(CMSEnvelopedGenerator.AES128_CBC,  "AES");
         BASE_CIPHER_NAMES.put(CMSEnvelopedGenerator.AES192_CBC,  "AES");
         BASE_CIPHER_NAMES.put(CMSEnvelopedGenerator.AES256_CBC,  "AES");
-        
-        dummyProps.put("mail.from", "dummy@example.com");
-        dummySession = Session.getDefaultInstance(dummyProps);
     }
 
     protected boolean                     useBase64 = true;
@@ -76,7 +70,14 @@ public class SMIMEGenerator
         //
         try
         {
-            MimeMessage     msg = new MimeMessage(dummySession);
+            MimeMessage     msg = new MimeMessage((Session) null) {
+                // avoid the call of updateMessageID to prevent
+                // DNS issues when trying to evaluate the local host's name
+                @Override
+                protected void updateMessageID() throws MessagingException {
+                    // do nothing
+                }
+            };
 
             Enumeration     e = content.getAllHeaders();
 

--- a/mail/src/main/java/org/bouncycastle/mail/smime/SMIMEGenerator.java
+++ b/mail/src/main/java/org/bouncycastle/mail/smime/SMIMEGenerator.java
@@ -73,7 +73,6 @@ public class SMIMEGenerator
             MimeMessage     msg = new MimeMessage((Session) null) {
                 // avoid the call of updateMessageID to prevent
                 // DNS issues when trying to evaluate the local host's name
-                @Override
                 protected void updateMessageID() throws MessagingException {
                     // do nothing
                 }

--- a/mail/src/main/java/org/bouncycastle/mail/smime/SMIMEGenerator.java
+++ b/mail/src/main/java/org/bouncycastle/mail/smime/SMIMEGenerator.java
@@ -6,6 +6,7 @@ import java.security.Provider;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import javax.crypto.KeyGenerator;
 import javax.mail.Header;
@@ -24,6 +25,8 @@ import org.bouncycastle.util.Strings;
 public class SMIMEGenerator
 {
     private static Map BASE_CIPHER_NAMES = new HashMap();
+    private final static Properties dummyProps = new Properties();
+    private final static Session dummySession;
     
     static
     {
@@ -31,6 +34,9 @@ public class SMIMEGenerator
         BASE_CIPHER_NAMES.put(CMSEnvelopedGenerator.AES128_CBC,  "AES");
         BASE_CIPHER_NAMES.put(CMSEnvelopedGenerator.AES192_CBC,  "AES");
         BASE_CIPHER_NAMES.put(CMSEnvelopedGenerator.AES256_CBC,  "AES");
+        
+        dummyProps.put("mail.from", "dummy@example.com");
+        dummySession = Session.getDefaultInstance(dummyProps);
     }
 
     protected boolean                     useBase64 = true;
@@ -70,7 +76,7 @@ public class SMIMEGenerator
         //
         try
         {
-            MimeMessage     msg = new MimeMessage((Session)null);
+            MimeMessage     msg = new MimeMessage(dummySession);
 
             Enumeration     e = content.getAllHeaders();
 


### PR DESCRIPTION
avoid long delays if there are DNS issues resolving the host's name while unnecessarily generating a message-id that is not needed here because the MimeMessage is only used to generate and copy MIME-headers for a given body part.