### PR TITLE
Real Time ChaCha20Poly1305

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/modes/ChaChaPoly1305.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/ChaChaPoly1305.java
@@ -1,0 +1,484 @@
+package org.bouncycastle.crypto.modes;
+
+import org.bouncycastle.crypto.CipherParameters;
+import org.bouncycastle.crypto.DataLengthException;
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.OutputLengthException;
+import org.bouncycastle.crypto.StreamCipher;
+import org.bouncycastle.crypto.macs.Poly1305;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.Pack;
+
+/**
+ * ChaCha20Poly1305 Engine.
+ */
+public class ChaChaPoly1305
+    implements StreamCipher {
+    /**
+     * The MacSize.
+     */
+    private static final int MACSIZE = 16;
+
+    /**
+     * The Zero padding.
+     */
+    private static final byte[] PADDING = new byte[MACSIZE - 1];
+
+    /**
+     * The Underlying cipher.
+     */
+    private final StreamCipher theCipher;
+
+    /**
+     * The Poly1305Mac.
+     */
+    private final Poly1305 polyMac;
+
+    /**
+     * The cachedBytes.
+     */
+    private final byte[] cachedBytes;
+
+    /**
+     * number of bytes in the cache.
+     */
+    private int cacheBytes;
+
+    /**
+     * Are we initialised?
+     */
+    private boolean initialised;
+
+    /**
+     * Are we encrypting?
+     */
+    private boolean encrypting;
+
+    /**
+     * The Initial AEAD Data.
+     */
+    private byte[] initialAEAD;
+
+    /**
+     * Have we completed AEAD?
+     */
+    private boolean aeadComplete;
+
+    /**
+     * The AEAD DataLength.
+     */
+    private long aeadLength;
+
+    /**
+     * The dataLength.
+     */
+    private long dataLength;
+
+    /**
+     * Constructor.
+     * @param pChaChaEngine the ChaCha engine.
+     */
+    public ChaChaPoly1305(final StreamCipher pChaChaEngine) {
+        theCipher = pChaChaEngine;
+        polyMac = new Poly1305();
+        cachedBytes = new byte[MACSIZE];
+    }
+
+    /**
+     * Obtain algorithm name.
+     * @return the algorithm name
+     */
+    @Override
+    public String getAlgorithmName() {
+        return theCipher.getAlgorithmName() + "Poly1305";
+    }
+
+    /**
+     * Initialise the cipher.
+     * @param forEncryption true/false
+     * @param params the parameters
+     */
+    public void init(final boolean forEncryption,
+                     final CipherParameters params) {
+        /* Access parameters */
+        CipherParameters parms = params;
+
+        /* Reset details */
+        initialised = false;
+        initialAEAD = null;
+
+        /* If we have AEAD parameters */
+        if (params instanceof AEADParameters) {
+            final AEADParameters param = (AEADParameters) params;
+            initialAEAD = param.getAssociatedText();
+            final byte[] nonce = param.getNonce();
+            final KeyParameter key = param.getKey();
+            parms = new ParametersWithIV(key, nonce);
+        }
+
+        /* Initialise the cipher */
+        theCipher.init(forEncryption, parms);
+
+        /* Reset the cipher and init the Mac */
+        reset();
+
+        /* Note that we are initialised */
+        encrypting = forEncryption;
+        initialised = true;
+    }
+
+    @Override
+    public void reset() {
+        /* Reset state */
+        dataLength = 0;
+        aeadLength = 0;
+        aeadComplete = false;
+        cacheBytes = 0;
+        theCipher.reset();
+
+        /* Run the cipher once to initialise the mac */
+        final byte[] firstBlock = new byte[64]; // ChaCha stateLength
+        theCipher.processBytes(firstBlock, 0, firstBlock.length, firstBlock, 0);
+        polyMac.init(new KeyParameter(firstBlock, 0, 32)); // Poly1305 KeyLength
+        Arrays.fill(firstBlock, (byte) 0);
+
+        /* If we have initial AEAD data */
+        if (initialAEAD != null) {
+            /* Reapply initial AEAD data */
+            aeadLength = initialAEAD.length;
+            polyMac.update(initialAEAD, 0, (int) aeadLength);
+        }
+    }
+
+    /**
+     * Process AAD byte.
+     * @param in the byte to process
+     */
+    public void processAADByte(final byte in) {
+        /* Check AAD is allowed */
+        checkAEADStatus();
+
+        /* Process the byte */
+        polyMac.update(in);
+        aeadLength++;
+    }
+
+    /**
+     * Process AAD bytes.
+     * @param in the bytes to process
+     * @param inOff the offset from which to start processing
+     * @param len the number of bytes to process
+     */
+    public void processAADBytes(final byte[] in,
+                                final int inOff,
+                                final int len) {
+        /* Check AAD is allowed */
+        checkAEADStatus();
+
+        /* Process the bytes */
+        polyMac.update(in, inOff, len);
+        aeadLength += len;
+    }
+
+    /**
+     * check AEAD status.
+     */
+    private void checkAEADStatus() {
+        /* Check we are initialised */
+        if (!initialised) {
+            throw new IllegalStateException("Cipher is not initialised");
+        }
+
+        /* Check AAD is allowed */
+        if (aeadComplete) {
+            throw new IllegalStateException("AEAD data cannot be processed after ordinary data");
+        }
+    }
+
+    /**
+     * check status.
+     */
+    private void checkStatus() {
+        /* Check we are initialised */
+        if (!initialised) {
+            throw new IllegalStateException("Cipher is not initialised");
+        }
+
+        /* Complete the AEAD section if this is the first data */
+        if (!aeadComplete) {
+            completeAEADMac();
+        }
+    }
+
+    /**
+     * Process single byte (not supported).
+     * @param in the input byte
+     * @return the output byte
+     */
+    public byte returnByte(final byte in) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Process bytes.
+     * @param in the input buffer
+     * @param inOff the starting offset in the input buffer
+     * @param len the length of data in the input buffer
+     * @param out the output buffer
+     * @param outOff the starting offset in the output buffer
+     * @return the number of bytes returned in the output buffer
+     */
+    public int processBytes(final byte[] in,
+                            final int inOff,
+                            final int len,
+                            final byte[] out,
+                            final int outOff) {
+        /* Check status */
+        checkStatus();
+
+        /* process the bytes */
+        return encrypting
+                  ? processEncryptionBytes(in, inOff, len, out, outOff)
+                  : processDecryptionBytes(in, inOff, len, out, outOff);
+    }
+
+    /**
+     * Obtain the maximum output length for a given input length.
+     * @param len the length of data to process
+     * @return the maximum output length
+     */
+    public int getOutputSize(final int len) {
+        if (encrypting) {
+            return len + MACSIZE;
+        }
+
+        /* Allow for cacheSpace */
+        final int cacheSpace = MACSIZE - cacheBytes;
+        return len < cacheSpace ? 0 : len - cacheSpace;
+    }
+
+    /**
+     * Obtain the maximum output length for an update.
+     * @param len the data length to update
+     * @return the maximum output length
+     */
+    public int getUpdateOutputSize(final int len) {
+         return len;
+    }
+
+    /**
+     * Finish processing.
+     * @param out the output buffer
+     * @param outOff the offset from which to start writing output
+     * @return the length of data written out
+     * @throws InvalidCipherTextException on mac misMatch
+     */
+    public int doFinal(final byte[] out,
+                       final int outOff) throws InvalidCipherTextException {
+        /* Check status */
+        checkStatus();
+
+        /* finish the mac */
+        final int outLen = encrypting
+                     ? finishEncryptionMac(out, outOff)
+                     : finishDecryptionMac();
+
+        /* Reset the cipher */
+        reset();
+
+        /* return the number of bytes processed */
+        return outLen;
+    }
+
+    /**
+     * Process encryption bytes.
+     * @param in the input buffer
+     * @param inOff the offset from which to start processing
+     * @param len the length of data to process
+     * @param out the output buffer
+     * @param outOff the offset from which to start writing output
+     * @return the length of data written out
+     */
+    private int processEncryptionBytes(final byte[] in,
+                                       final int inOff,
+                                       final int len,
+                                       final byte[] out,
+                                       final int outOff) {
+        /* Check that the buffers are sufficient */
+        if (in.length < (len + inOff)) {
+            throw new DataLengthException("Input buffer too short.");
+        }
+        if (out.length < (len + outOff)) {
+            throw new OutputLengthException("Output buffer too short.");
+        }
+
+        /* Process the bytes */
+        theCipher.processBytes(in, inOff, len, out, outOff);
+
+        /* Update the mac */
+        polyMac.update(out, outOff, len);
+        dataLength += len;
+
+        /* Return the number of bytes processed */
+        return len;
+    }
+
+    /**
+     * finish the encryption Mac.
+     * @param out the output buffer
+     * @param outOff the offset from which to start writing output
+     * @return the length of data written out
+     */
+    private int finishEncryptionMac(final byte[] out,
+                                    final int outOff) {
+        /* Check that the output buffer is sufficient */
+        if (out.length < (MACSIZE + outOff)) {
+            throw new OutputLengthException("Output buffer too short.");
+        }
+
+        /* complete the data portion of the Mac */
+        completeDataMac();
+
+        /* Update and return the mac in the output buffer */
+        return polyMac.doFinal(out, outOff);
+    }
+
+    /**
+     * Process decryption bytes.
+     * @param in the input buffer
+     * @param inOff the offset from which to start processing
+     * @param len the length of data to process
+     * @param out the output buffer
+     * @param outOff the offset from which to start writing output
+     * @return the length of data written out
+     */
+    private int processDecryptionBytes(final byte[] in,
+                                       final int inOff,
+                                       final int len,
+                                       final byte[] out,
+                                       final int outOff) {
+        /* Check that the buffers are sufficient */
+        if (in.length < (len + inOff)) {
+            throw new DataLengthException("Input buffer too short.");
+        }
+        if (out.length < (len + outOff + cacheBytes - MACSIZE)) {
+            throw new OutputLengthException("Output buffer too short.");
+        }
+
+        /* Count how much we have processed */
+        int processed = 0;
+
+        /* If we have at least MACSIZE data */
+        if (len >= MACSIZE) {
+            /* If we have cached mac bytes */
+            if (cacheBytes > 0) {
+                /* Process any existing cachedBytes */
+                polyMac.update(cachedBytes, 0, cacheBytes);
+                dataLength += cacheBytes;
+
+                /* Process the cached bytes */
+                processed = theCipher.processBytes(cachedBytes, 0, cacheBytes, out, outOff);
+            }
+
+            /* Determine how many bytes to process */
+            final int numBytes = len - MACSIZE;
+            if (numBytes > 0) {
+                /* Process the data */
+                polyMac.update(in, inOff, numBytes);
+                dataLength += numBytes;
+
+                /* Process the input */
+                processed += theCipher.processBytes(in, inOff, numBytes, out, outOff + processed);
+            }
+
+            /* Store the remaining input into the cache */
+            System.arraycopy(in, inOff + numBytes, cachedBytes, 0, MACSIZE);
+            cacheBytes = MACSIZE;
+
+            /* else all new data will be placed into the cache */
+        } else {
+            /* Calculate number of bytes in the cache to process */
+            final int numBytes = cacheBytes + len - MACSIZE;
+            if (numBytes > 0) {
+                /* Process the excess cachedBytes */
+                polyMac.update(cachedBytes, 0, numBytes);
+                dataLength += numBytes;
+
+                /* Process the cached bytes */
+                processed = theCipher.processBytes(cachedBytes, 0, numBytes, out, outOff);
+
+                /* Move remaining cached bytes down */
+                cacheBytes -= numBytes;
+                System.arraycopy(cachedBytes, numBytes, cachedBytes, 0, cacheBytes);
+            }
+
+            /* Store the data into the cache */
+            System.arraycopy(in, inOff, cachedBytes, cacheBytes, len);
+            cacheBytes += len;
+        }
+
+        /* Return the number of bytes processed */
+        return processed;
+    }
+
+    /**
+     * finish the decryption Mac.
+     * @return the length of data written out
+     * @throws InvalidCipherTextException on mac misMatch
+     */
+    private int finishDecryptionMac() throws InvalidCipherTextException {
+        /* If we do not have sufficient data */
+        if (cacheBytes < MACSIZE) {
+            throw new InvalidCipherTextException("data too short");
+        }
+
+        /* complete the data portion of the Mac */
+        completeDataMac();
+
+        /* Update and return the mac in the output buffer */
+        final byte[] mac = new byte[MACSIZE];
+        polyMac.doFinal(mac, 0);
+
+        /* Check that the buffers compare */
+        if (!Arrays.constantTimeAreEqual(mac, cachedBytes)) {
+            throw new InvalidCipherTextException("mac check failed");
+        }
+
+        /* No bytes returned */
+        return 0;
+    }
+
+    /**
+     * Complete AEAD Mac input.
+     */
+    private void completeAEADMac() {
+        /* Pad to boundary */
+        final int xtra = (int) aeadLength % MACSIZE;
+        if (xtra != 0) {
+            final int numPadding = MACSIZE - xtra;
+            polyMac.update(PADDING, 0, numPadding);
+        }
+        aeadComplete = true;
+    }
+
+    /**
+     * Complete Mac data input.
+     */
+    private void completeDataMac() {
+        /* Pad to boundary */
+        final int xtra = (int) dataLength % MACSIZE;
+        if (xtra != 0) {
+            final int numPadding = MACSIZE - xtra;
+            polyMac.update(PADDING, 0, numPadding);
+        }
+
+        /* Write the lengths */
+        final byte[] len = new byte[16]; // 2 * Long.BYTES
+        Pack.longToLittleEndian(aeadLength, len, 0);
+        Pack.longToLittleEndian(dataLength, len, 8); // Long.BYTES
+        polyMac.update(len, 0, len.length);
+    }
+}

--- a/core/src/test/java/org/bouncycastle/crypto/test/ChaCha20PolyTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/ChaCha20PolyTest.java
@@ -1,0 +1,208 @@
+package net.sourceforge.joceanus.jgordianknot.crypto.test;
+
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.engines.ChaCha7539Engine;
+import org.bouncycastle.crypto.modes.ChaChaPoly1305;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.encoders.Hex;
+import org.bouncycastle.util.test.SimpleTest;
+
+/**
+ * Test Cases for ChaCha20Poly1305.
+ * Test Vectors taken from RFC7539 https://tools.ietf.org/html/rfc7539
+ */
+public class ChaCha20PolyTest
+        extends SimpleTest {
+    public String getName() {
+        return "ChaCha20Poly1305";
+    }
+
+    public void performTest()
+            throws Exception {
+        new ChaChaPoly1305Test().testTheCipher();
+    }
+
+    /**
+     * The TestCase.
+     */
+    private static class TestCase {
+        /**
+         * The testCase.
+         */
+        private final String theKey;
+        private final String theIV;
+        private final String theAAD;
+        private final String thePlainText;
+        private final String theExpected;
+
+        /**
+         * Constructor.
+         * @param pKey the key
+         * @param pIV the IV
+         * @param pExpected the expected results.
+         */
+        TestCase(final String pKey,
+                 final String pIV,
+                 final String pExpected) {
+            this(pKey, pIV, null, null, pExpected);
+        }
+
+        /**
+         * Constructor.
+         * @param pKey the key
+         * @param pIV the IV
+         * @param pPlain the plainText
+         * @param pExpected the expected results.
+         */
+        TestCase(final String pKey,
+                 final String pIV,
+                 final String pPlain,
+                 final String pExpected) {
+            this(pKey, pIV, null, pPlain, pExpected);
+        }
+
+        /**
+         * Constructor.
+         * @param pKey the key
+         * @param pIV the IV
+         * @param pAAD the AAD
+         * @param pPlain the plainText
+         * @param pExpected the expected results.
+         */
+        TestCase(final String pKey,
+                 final String pIV,
+                 final String pAAD,
+                 final String pPlain,
+                 final String pExpected) {
+            theKey = pKey;
+            theIV = pIV;
+            theAAD = pAAD;
+            thePlainText = pPlain;
+            theExpected = pExpected;
+        }
+    }
+
+    /**
+     * ChaCha20Poly1305.
+     */
+    class ChaChaPoly1305Test {
+        /**
+         * TestCases.
+         */
+        private static final String KEY = "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f";
+        private static final String IV = "070000004041424344454647";
+        private static final String AAD = "50515253c0c1c2c3c4c5c6c7";
+        private static final String PLAIN = "4c616469657320616e642047656e746c" +
+                "656d656e206f662074686520636c6173" +
+                "73206f66202739393a20496620492063" +
+                "6f756c64206f6666657220796f75206f" +
+                "6e6c79206f6e652074697020666f7220" +
+                "746865206675747572652c2073756e73" +
+                "637265656e20776f756c642062652069" +
+                "742e";
+        private static final String EXPECTED =
+                "d31a8d34648e60db7b86afbc53ef7ec2" +
+                        "a4aded51296e08fea9e2b5a736ee62d6" +
+                        "3dbea45e8ca9671282fafb69da92728b" +
+                        "1a71de0a9e060b2905d6a5b67ecd3b36" +
+                        "92ddbd7f2d778b8c9803aee328091b58" +
+                        "fab324e4fad675945585808b4831d7bc" +
+                        "3ff4def08e4b7a9de576d26586cec64b" +
+                        "6116" +
+                        "1ae10b594f09e26a7e902ecbd0600691";
+        private final TestCase TEST = new TestCase(KEY, IV, AAD,
+                PLAIN, EXPECTED
+        );
+
+        /**
+         * Test Cipher.
+         */
+        void testTheCipher() {
+            final ChaChaPoly1305 myEngine = new ChaChaPoly1305(new ChaCha7539Engine());
+            testAADCipher(myEngine, TEST);
+        }
+    }
+
+    /**
+     * Test the Cipher against the results.
+     * @param pCipher the cipher to test.
+     * @param pTestCase the testCase
+     */
+    void testAADCipher(final ChaChaPoly1305 pCipher,
+                       final TestCase pTestCase) {
+        try {
+            /* Access the expected bytes */
+            final byte[] myExpected = Hex.decode(pTestCase.theExpected);
+
+            /* Access plainText */
+            final byte[] myData = Hex.decode(pTestCase.thePlainText);
+
+            /* Access AAD */
+            final byte[] myAAD = Hex.decode(pTestCase.theAAD);
+
+            /* Access the key and the iv */
+            final KeyParameter myKey = new KeyParameter(Hex.decode(pTestCase.theKey));
+            final byte[] myIV = Hex.decode(pTestCase.theIV);
+            final ParametersWithIV myIVParms = new ParametersWithIV(myKey, myIV);
+            final AEADParameters myAEADParms = new AEADParameters(myKey, 0, myIV, myAAD);
+
+            /* Initialise the cipher and encrypt the data */
+            pCipher.init(true, myAEADParms);
+            final byte[] myOutput = new byte[pCipher.getOutputSize(myData.length)];
+            int iProcessed = pCipher.processBytes(myData, 0, myData.length, myOutput, 0);
+            pCipher.doFinal(myOutput, iProcessed);
+
+            /* Check the encryption */
+            isTrue("Encryption mismatch", Arrays.areEqual(myExpected, myOutput));
+
+            /* Check that auto-reset worked */
+            iProcessed = pCipher.processBytes(myData, 0, myData.length, myOutput, 0);
+            pCipher.doFinal(myOutput, iProcessed);
+
+            /* Check the encryption */
+            isTrue("Encryption mismatch after reset", Arrays.areEqual(myExpected, myOutput));
+
+            /* Initialise the cipher and decrypt the data */
+            pCipher.init(false, myAEADParms);
+            final byte[] myResult = new byte[pCipher.getOutputSize(myExpected.length)];
+            iProcessed = pCipher.processBytes(myExpected, 0, myExpected.length, myResult, 0);
+            pCipher.doFinal(myResult, iProcessed);
+
+            /* Check the decryption */
+            isTrue("Decryption mismatch", Arrays.areEqual(myData, myResult));
+
+            /* Loop to process differing block sizes */
+            for (int blockSize = 1; blockSize <= 64; blockSize <<= 1) {
+                /* Process the decryption one block at a time */
+                iProcessed = 0;
+                int iRemaining = myExpected.length;
+                final byte[] myResult2 = new byte[pCipher.getOutputSize(myExpected.length)];
+                for (int i = 0; iRemaining > 0; i += blockSize, iRemaining -= blockSize) {
+                    int myLen = Math.min(blockSize, iRemaining);
+                    iProcessed += pCipher.processBytes(myExpected, i, myLen, myResult2, iProcessed);
+                }
+                pCipher.doFinal(myResult2, iProcessed);
+
+                /* Check the decryption */
+                isTrue("Block Decryption mismatch for size " + blockSize, Arrays.areEqual(myData, myResult));
+            }
+
+            /* Initialise the cipher and encrypt the data pass AAD explicitly */
+            pCipher.init(true, myIVParms);
+            pCipher.processAADBytes(myAAD, 0, myAAD.length);
+            final byte[] myOutput2 = new byte[pCipher.getOutputSize(myData.length)];
+            iProcessed = pCipher.processBytes(myData, 0, myData.length, myOutput2, 0);
+            pCipher.doFinal(myOutput2, iProcessed);
+
+            /* Check the encryption */
+            isTrue("Encryption mismatch", Arrays.areEqual(myExpected, myOutput2));
+
+            /* Catch exceptions */
+        } catch (InvalidCipherTextException e) {
+            fail("Failed to resolve mac", e);
+        }
+    }
+}


### PR DESCRIPTION
As requested in discussions, an alternative implementation of ChaCha20Poly1305 from that in the existing PullRequest #556 by kevinherron.

This implementation differs from the existing PullRequest in that data is processed in real time rather than being buffered and processed on doFinal(). 

This has the following advantages

1. It is faster and has a smaller memory footprint 
2. It can process 2^64 bytes of data rather than the 2^31 bytes of data that the buffered implementation allows.

It has the following disadvantages

1. All AEAD data must be processed prior to non-AEAD data.
2. Decrypted data is returned prior to the Mac being checked rather than only after the Mac is checked

It should be noted that the implementation is not restricted to the ChaCha20 algorithm and will in fact work on ANY stream cipher, by reserving the first 512 bits of the cipher stream to derive the 256 bit Poly1305 key.