### PR TITLE
Use GOST 34.11-2012-256 digest for VKO with 34.10-2012-512 keys

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost12/KeyAgreementSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ecgost12/KeyAgreementSpi.java
@@ -163,7 +163,7 @@ public class KeyAgreementSpi
     {
         public ECVKO512()
         {
-            super("ECGOST3410-2012-512", new ECVKOAgreement(new GOST3411_2012_512Digest()), null);
+            super("ECGOST3410-2012-512", new ECVKOAgreement(new GOST3411_2012_256Digest()), null);
         }
     }
 }


### PR DESCRIPTION
For now only GOST R 28147-89 is used in enveloped CMS with GOST R 34.10-* key pairs  and it requires VKO GOST R 34.10-2012-256 to be used for key agreement with GOST R 3410-2012-256 and GOST R 3410-2012-512 keys