### PR TITLE
Rejuvenate log levels

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/pkix/jcajce/X509RevocationChecker.java
+++ b/pkix/src/main/java/org/bouncycastle/pkix/jcajce/X509RevocationChecker.java
@@ -399,7 +399,7 @@ public class X509RevocationChecker
 
         if (issuerList.isEmpty())
         {
-            LOG.log(Level.INFO, "configured with 0 pre-loaded CRLs");
+            LOG.log(Level.FINEST, "configured with 0 pre-loaded CRLs");
         }
         else
         {
@@ -585,7 +585,7 @@ public class X509RevocationChecker
 
                             urlStream.close();
 
-                            LOG.log(Level.INFO, "downloaded CRL from CrlDP " + url + " for issuer \"" + issuer + "\"");
+                            LOG.log(Level.FINEST, "downloaded CRL from CrlDP " + url + " for issuer \"" + issuer + "\"");
 
                             crlCache.put(name, new WeakReference<X509CRL>(crl));
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/PropertyUtils.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/PropertyUtils.java
@@ -59,9 +59,9 @@ class PropertyUtils
                 LOG.log(Level.INFO, "Found boolean system property [" + propertyName + "]: " + false);
                 return false;
             }
-            LOG.log(Level.WARNING, "Unrecognized value for boolean system property [" + propertyName + "]: " + propertyValue);
+            LOG.log(Level.FINEST, "Unrecognized value for boolean system property [" + propertyName + "]: " + propertyValue);
         }
-        LOG.log(Level.FINE, "Boolean system property [" + propertyName + "] defaulted to: " + defaultValue);
+        LOG.log(Level.FINEST, "Boolean system property [" + propertyName + "] defaulted to: " + defaultValue);
         return defaultValue;
     }
 
@@ -89,7 +89,7 @@ class PropertyUtils
                 LOG.log(Level.WARNING, "Unrecognized value for integer system property [" + propertyName + "]: " + propertyValue);
             }
         }
-        LOG.log(Level.FINE, "Integer system property [" + propertyName + "] defaulted to: " + defaultValue);
+        LOG.log(Level.FINEST, "Integer system property [" + propertyName + "] defaulted to: " + defaultValue);
         return defaultValue;
     }
 
@@ -101,7 +101,7 @@ class PropertyUtils
             LOG.log(Level.INFO, "Found string security property [" + propertyName + "]: " + propertyValue);
             return propertyValue;
         }
-        LOG.log(Level.WARNING, "String security property [" + propertyName + "] defaulted to: " + defaultValue);
+        LOG.log(Level.FINEST, "String security property [" + propertyName + "] defaulted to: " + defaultValue);
         return defaultValue;
     }
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLContextSpi.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLContextSpi.java
@@ -311,7 +311,7 @@ class ProvSSLContextSpi
         {
             if (!SUPPORTED_PROTOCOL_MAP.containsKey(protocol))
             {
-                LOG.warning("'" + protocolsPropertyName + "' contains unsupported protocol: " + protocol);
+                LOG.fine("'" + protocolsPropertyName + "' contains unsupported protocol: " + protocol);
             }
             else if (!JsseUtils.contains(result, protocol))
             {

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/SupportedGroups.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/SupportedGroups.java
@@ -65,7 +65,7 @@ abstract class SupportedGroups
             int namedGroup = NamedGroup.getByName(Strings.toLowerCase(name));
             if (namedGroup < 0)
             {
-                LOG.warning("'" + PROPERTY_NAMED_GROUPS + "' contains unrecognised NamedGroup: " + name);
+                LOG.info("'" + PROPERTY_NAMED_GROUPS + "' contains unrecognised NamedGroup: " + name);
             }
             else if (provDisableChar2 && NamedGroup.isChar2Curve(namedGroup))
             {


### PR DESCRIPTION
Here's a reissue of https://github.com/bcgit/bc-java/pull/506 with a new version of our tool. The tool made many fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 6000.
The head at the time of analysis was: a66e904a431d992281c8378064fed4cbc4ab1d99