### PR TITLE
Rejuvenate log levels

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/pkix/jcajce/X509RevocationChecker.java
+++ b/pkix/src/main/java/org/bouncycastle/pkix/jcajce/X509RevocationChecker.java
@@ -399,7 +399,7 @@ public class X509RevocationChecker
 
         if (issuerList.isEmpty())
         {
-            LOG.log(Level.INFO, "configured with 0 pre-loaded CRLs");
+            LOG.log(Level.FINEST, "configured with 0 pre-loaded CRLs");
         }
         else
         {
@@ -585,7 +585,7 @@ public class X509RevocationChecker
 
                             urlStream.close();
 
-                            LOG.log(Level.INFO, "downloaded CRL from CrlDP " + url + " for issuer \"" + issuer + "\"");
+                            LOG.log(Level.FINEST, "downloaded CRL from CrlDP " + url + " for issuer \"" + issuer + "\"");
 
                             crlCache.put(name, new WeakReference<X509CRL>(crl));
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/PropertyUtils.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/PropertyUtils.java
@@ -61,7 +61,7 @@ class PropertyUtils
             }
             LOG.log(Level.WARNING, "Unrecognized value for boolean system property [" + propertyName + "]: " + propertyValue);
         }
-        LOG.log(Level.FINE, "Boolean system property [" + propertyName + "] defaulted to: " + defaultValue);
+        LOG.log(Level.FINEST, "Boolean system property [" + propertyName + "] defaulted to: " + defaultValue);
         return defaultValue;
     }
 
@@ -89,7 +89,7 @@ class PropertyUtils
                 LOG.log(Level.WARNING, "Unrecognized value for integer system property [" + propertyName + "]: " + propertyValue);
             }
         }
-        LOG.log(Level.FINE, "Integer system property [" + propertyName + "] defaulted to: " + defaultValue);
+        LOG.log(Level.FINEST, "Integer system property [" + propertyName + "] defaulted to: " + defaultValue);
         return defaultValue;
     }
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsClient.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsClient.java
@@ -402,17 +402,17 @@ class ProvTlsClient
 
         if (isResumed)
         {
-            LOG.fine("Server resumed session: " + Hex.toHexString(sessionID));
+            LOG.finer("Server resumed session: " + Hex.toHexString(sessionID));
         }
         else
         {
             if (sessionID == null || sessionID.length < 1)
             {
-                LOG.fine("Server did not specify a session ID");
+                LOG.finer("Server did not specify a session ID");
             }
             else
             {
-                LOG.fine("Server specified new session: " + Hex.toHexString(sessionID));
+                LOG.finer("Server specified new session: " + Hex.toHexString(sessionID));
             }
 
             if (!manager.getEnableSessionCreation())

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsServer.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvTlsServer.java
@@ -473,7 +473,7 @@ class ProvTlsServer
             Collection<BCSNIMatcher> sniMatchers = sslParameters.getSNIMatchers();
             if (null == sniMatchers || sniMatchers.isEmpty())
             {
-                LOG.fine("Server ignored SNI (no matchers specified)");
+                LOG.finer("Server ignored SNI (no matchers specified)");
             }
             else
             {
@@ -483,7 +483,7 @@ class ProvTlsServer
                     throw new TlsFatalAlert(AlertDescription.unrecognized_name);
                 }
 
-                LOG.fine("Server accepted SNI: " + matchedSNIServerName);
+                LOG.finer("Server accepted SNI: " + matchedSNIServerName);
             }
         }
     }


### PR DESCRIPTION
Here's a reissue of https://github.com/bcgit/bc-java/pull/507 with a new version of our tool. The tool made many fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG, WARNING, and SEVERE levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 6000.
The head at the time of analysis was: a66e904a431d992281c8378064fed4cbc4ab1d99