### PR TITLE
Prevent entropy gathering from blocking JVM shutdown

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/drbg/DRBG.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/drbg/DRBG.java
@@ -440,7 +440,9 @@ public class DRBG
 
                 if (!scheduled.getAndSet(true))
                 {
-                    new Thread(new EntropyGatherer(byteLength)).start();
+                    Thread gathererThread = new Thread(new EntropyGatherer(byteLength));
+                    gathererThread.setDaemon(true);
+                    gathererThread.start();
                 }
 
                 return seed;


### PR DESCRIPTION
Consider the following sample code:
```
import org.bouncycastle.jce.provider.BouncyCastleProvider;

import java.security.NoSuchAlgorithmException;
import java.security.SecureRandom;
import java.security.Security;

public class BCShutdownTest {
    public static void main(String[] args) throws NoSuchAlgorithmException {
        Security.addProvider(new BouncyCastleProvider());
        SecureRandom secureRandom = SecureRandom.getInstance("DEFAULT");
        System.out.println(secureRandom);
    }
}
```

On my Ubuntu 18.04.4 with openjdk version "11.0.6" It prints "Default" and hangs for around 20 seconds.
The ultimate cause for the hang is that after `main` exits there is still an entropy gatherer thread running in background trying to get enough data from /dev/random.
Seems like this thread can be safely stopped at this point, so make it a daemon.