### PR TITLE
BCRSAPrivateKey.java: Serialize algorithmIdentifier

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/BCRSAPrivateKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/BCRSAPrivateKey.java
@@ -144,7 +144,16 @@ public class BCRSAPrivateKey
         throws IOException, ClassNotFoundException
     {
         in.defaultReadObject();
-        
+
+        try
+        {
+            algorithmIdentifier = AlgorithmIdentifier.getInstance(in.readObject());
+        }
+        catch (Exception e)
+        {
+            algorithmIdentifier = BCRSAPublicKey.DEFAULT_ALGORITHM_IDENTIFIER;
+        }
+
         this.attrCarrier = new PKCS12BagAttributeCarrierImpl();
         this.rsaPrivateKey = new RSAKeyParameters(true, modulus, privateExponent);
     }
@@ -154,6 +163,11 @@ public class BCRSAPrivateKey
         throws IOException
     {
         out.defaultWriteObject();
+
+        if (!algorithmIdentifier.equals(BCRSAPublicKey.DEFAULT_ALGORITHM_IDENTIFIER))
+        {
+            out.writeObject(algorithmIdentifier.getEncoded());
+        }
     }
 
     public String toString()

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/RSATest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/RSATest.java
@@ -641,6 +641,11 @@ public class RSATest
             fail("private key hashCode check failed");
         }
 
+        if (!Arrays.areEqual(privKey.getEncoded(), crtKey.getEncoded()))
+        {
+            fail("encoding does not match");
+        }
+
         RSAPublicKey copyKey = (RSAPublicKey)keyFact.translateKey(pubKey);
         
         if (!pubKey.equals(copyKey))
@@ -752,6 +757,10 @@ public class RSATest
         privateKey = kFact.generatePrivate(new PKCS8EncodedKeySpec(kp.getPrivate().getEncoded()));
 
         isTrue("RSASSA-PSS".equals(privateKey.getAlgorithm()));
+
+        privateKey = (PrivateKey)serializeDeserialize(kp.getPrivate());
+
+        isTrue(Arrays.areEqual(kp.getPrivate().getEncoded(), privateKey.getEncoded()));
 
         SubjectPublicKeyInfo subKey = SubjectPublicKeyInfo.getInstance(publicKey.getEncoded());
 


### PR DESCRIPTION
Fixes #682 

Fixes regression introduced in a309b4f573eb4a1314649480541cecf2da11827a