### PR TITLE
Replaced direct CommandMap usage with mailcap file - fixes issue #704

### DIFF
--- a/ant/bc+-build.xml
+++ b/ant/bc+-build.xml
@@ -536,16 +536,25 @@
              <fileset dir="${src.dir}">
                  <include name="org/bouncycastle/mail/**/*.java" />
                  <include name="org/bouncycastle/mail/**/*.properties" />
+                 <include name="META-INF/mailcap" />
                  <exclude name="**/*Test.java" />
                  <exclude name="**/*Tests.java" />
                  <exclude name="**/test/*.java" />
              </fileset>
         </copy>
 
+        <mkdir dir="${build.dir}/${mail.target}/classes" />
+        <copy todir="${build.dir}/${mail.target}/classes">
+            <fileset dir="${src.dir}">
+                <include name="META-INF/mailcap" />
+            </fileset>
+        </copy>
+
         <compile target="${mail.target}">
             <jarFileSet>
                 <include name="**/*.class"/>
                 <include name="**/*.properties"/>
+                <include name="META-INF/mailcap" />
             </jarFileSet>
             <manifestElements>
                 <attribute name="Manifest-Version" value="1.0" />

--- a/ant/jdk15+.xml
+++ b/ant/jdk15+.xml
@@ -59,6 +59,7 @@
             <fileset dir="mail/src/main/java" includes="**/*.java" />
             <fileset dir="mail/src/main/javadoc" includes="**/*.html" />
             <fileset dir="mail/src/main/resources" includes="**/*.properties" />
+            <fileset dir="mail/src/main/resources" includes="META-INF/mailcap" />
             <fileset dir="mail/src/test/java" includes="**/*.java" />
             <fileset dir="mail/src/test/resources" includes="**/*.*" />
 

--- a/mail/src/main/java/org/bouncycastle/mail/smime/SMIMECompressedGenerator.java
+++ b/mail/src/main/java/org/bouncycastle/mail/smime/SMIMECompressedGenerator.java
@@ -5,8 +5,6 @@ import java.io.OutputStream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import javax.activation.CommandMap;
-import javax.activation.MailcapCommandMap;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
@@ -35,29 +33,6 @@ public class SMIMECompressedGenerator
     public static final String  ZLIB    = CMSCompressedDataGenerator.ZLIB;
 
     private static final String COMPRESSED_CONTENT_TYPE = "application/pkcs7-mime; name=\"smime.p7z\"; smime-type=compressed-data";
-
-    static
-    {
-        CommandMap commandMap = CommandMap.getDefaultCommandMap();
-
-        if (commandMap instanceof MailcapCommandMap)
-        {
-            final MailcapCommandMap mc = (MailcapCommandMap)commandMap;
-
-            mc.addMailcap("application/pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_mime");
-            mc.addMailcap("application/x-pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_mime");
-
-            AccessController.doPrivileged(new PrivilegedAction()
-            {
-                public Object run()
-                {
-                    CommandMap.setDefaultCommandMap(mc);
-
-                    return null;
-                }
-            });
-        }
-    }
 
     /**
      * generate an compressed object that contains an SMIME Compressed

--- a/mail/src/main/java/org/bouncycastle/mail/smime/SMIMEEnvelopedGenerator.java
+++ b/mail/src/main/java/org/bouncycastle/mail/smime/SMIMEEnvelopedGenerator.java
@@ -7,8 +7,6 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.activation.CommandMap;
-import javax.activation.MailcapCommandMap;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
@@ -69,35 +67,6 @@ public class SMIMEEnvelopedGenerator
     
     private EnvelopedGenerator fact;
     private List               recipients = new ArrayList();
-
-    static
-    {
-        AccessController.doPrivileged(new PrivilegedAction()
-        {
-            public Object run()
-            {
-                CommandMap commandMap = CommandMap.getDefaultCommandMap();
-
-                if (commandMap instanceof MailcapCommandMap)
-                {
-                    CommandMap.setDefaultCommandMap(addCommands((MailcapCommandMap)commandMap));
-                }
-
-                return null;
-            }
-        });
-    }
-
-    private static MailcapCommandMap addCommands(MailcapCommandMap mc)
-    {
-        mc.addMailcap("application/pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_signature");
-        mc.addMailcap("application/pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_mime");
-        mc.addMailcap("application/x-pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_signature");
-        mc.addMailcap("application/x-pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_mime");
-        mc.addMailcap("multipart/signed;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.multipart_signed");
-
-        return mc;
-    }
 
     /**
      * base constructor
@@ -218,13 +187,6 @@ public class SMIMEEnvelopedGenerator
                 else
                 {
                     encrypted = fact.regenerate(out, _encryptor);
-                }
-
-                CommandMap commandMap = CommandMap.getDefaultCommandMap();
-
-                if (commandMap instanceof MailcapCommandMap)
-                {
-                    _content.getDataHandler().setCommandMap(addCommands((MailcapCommandMap)commandMap));
                 }
 
                 _content.writeTo(encrypted);

--- a/mail/src/main/java/org/bouncycastle/mail/smime/SMIMESigned.java
+++ b/mail/src/main/java/org/bouncycastle/mail/smime/SMIMESigned.java
@@ -7,8 +7,6 @@ import java.io.InputStream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import javax.activation.CommandMap;
-import javax.activation.MailcapCommandMap;
 import javax.mail.MessagingException;
 import javax.mail.Part;
 import javax.mail.Session;
@@ -80,27 +78,6 @@ public class SMIMESigned
         }
     }
 
-    static
-    {
-        final MailcapCommandMap mc = (MailcapCommandMap)CommandMap.getDefaultCommandMap();
-
-        mc.addMailcap("application/pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_signature");
-        mc.addMailcap("application/pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_mime");
-        mc.addMailcap("application/x-pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_signature");
-        mc.addMailcap("application/x-pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_mime");
-        mc.addMailcap("multipart/signed;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.multipart_signed");
-        
-        AccessController.doPrivileged(new PrivilegedAction()
-        {
-            public Object run()
-            {
-                CommandMap.setDefaultCommandMap(mc);
-
-                return null;
-            }
-        });
-    }
-    
     /**
      * base constructor using a defaultContentTransferEncoding of 7bit
      *

--- a/mail/src/main/java/org/bouncycastle/mail/smime/SMIMESignedGenerator.java
+++ b/mail/src/main/java/org/bouncycastle/mail/smime/SMIMESignedGenerator.java
@@ -613,13 +613,6 @@ public class SMIMESignedGenerator
                     }
                     else
                     {
-                        CommandMap commandMap = CommandMap.getDefaultCommandMap();
-
-                        if (commandMap instanceof MailcapCommandMap)
-                        {
-                            content.getDataHandler().setCommandMap(addCommands((MailcapCommandMap)commandMap));
-                        }
-
                         content.writeTo(signingStream);
                     }
                 }

--- a/mail/src/main/java/org/bouncycastle/mail/smime/SMIMESignedGenerator.java
+++ b/mail/src/main/java/org/bouncycastle/mail/smime/SMIMESignedGenerator.java
@@ -14,8 +14,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import javax.activation.CommandMap;
-import javax.activation.MailcapCommandMap;
 import javax.mail.MessagingException;
 import javax.mail.Multipart;
 import javax.mail.internet.ContentType;
@@ -107,34 +105,8 @@ public class SMIMESignedGenerator
     public static final Map RFC5751_MICALGS;
     public static final Map STANDARD_MICALGS;
 
-    private static MailcapCommandMap addCommands(MailcapCommandMap mc)
-    {
-        mc.addMailcap("application/pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_signature");
-        mc.addMailcap("application/pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_mime");
-        mc.addMailcap("application/x-pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_signature");
-        mc.addMailcap("application/x-pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_mime");
-        mc.addMailcap("multipart/signed;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.multipart_signed");
-
-        return mc;
-    }
-
     static
     {
-        AccessController.doPrivileged(new PrivilegedAction()
-        {
-            public Object run()
-            {
-                CommandMap commandMap = CommandMap.getDefaultCommandMap();
-
-                if (commandMap instanceof MailcapCommandMap)
-                {
-                    CommandMap.setDefaultCommandMap(addCommands((MailcapCommandMap)commandMap));
-                }
-
-                return null;
-            }
-        });
-
         Map stdMicAlgs = new HashMap();
 
         stdMicAlgs.put(CMSAlgorithm.MD5, "md5");

--- a/mail/src/main/java/org/bouncycastle/mail/smime/SMIMESignedParser.java
+++ b/mail/src/main/java/org/bouncycastle/mail/smime/SMIMESignedParser.java
@@ -12,8 +12,6 @@ import java.io.OutputStream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import javax.activation.CommandMap;
-import javax.activation.MailcapCommandMap;
 import javax.mail.BodyPart;
 import javax.mail.MessagingException;
 import javax.mail.Part;
@@ -120,32 +118,6 @@ public class SMIMESignedParser
         catch (IOException e)
         {
             throw new MessagingException("can't extract input stream: " + e);
-        }
-    }
-    
-    static
-    {
-        CommandMap commandMap = CommandMap.getDefaultCommandMap();
-
-        if (commandMap instanceof MailcapCommandMap)
-        {
-            final MailcapCommandMap mc = (MailcapCommandMap)commandMap;
-
-            mc.addMailcap("application/pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_signature");
-            mc.addMailcap("application/pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_mime");
-            mc.addMailcap("application/x-pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_signature");
-            mc.addMailcap("application/x-pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_mime");
-            mc.addMailcap("multipart/signed;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.multipart_signed");
-
-            AccessController.doPrivileged(new PrivilegedAction()
-            {
-                public Object run()
-                {
-                    CommandMap.setDefaultCommandMap(mc);
-
-                    return null;
-                }
-            });
         }
     }
 

--- a/mail/src/main/java/org/bouncycastle/mail/smime/examples/SendSignedAndEncryptedMail.java
+++ b/mail/src/main/java/org/bouncycastle/mail/smime/examples/SendSignedAndEncryptedMail.java
@@ -13,8 +13,6 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
 
-import javax.activation.CommandMap;
-import javax.activation.MailcapCommandMap;
 import javax.mail.Message;
 import javax.mail.Session;
 import javax.mail.Transport;
@@ -59,22 +57,6 @@ public class SendSignedAndEncryptedMail
 
         try
         {
-            MailcapCommandMap mailcap = (MailcapCommandMap)CommandMap
-                    .getDefaultCommandMap();
-
-            mailcap
-                    .addMailcap("application/pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_signature");
-            mailcap
-                    .addMailcap("application/pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_mime");
-            mailcap
-                    .addMailcap("application/x-pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_signature");
-            mailcap
-                    .addMailcap("application/x-pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_mime");
-            mailcap
-                    .addMailcap("multipart/signed;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.multipart_signed");
-
-            CommandMap.setDefaultCommandMap(mailcap);
-
             /* Add BC */
             Security.addProvider(new BouncyCastleProvider());
 

--- a/mail/src/main/resources/META-INF/mailcap
+++ b/mail/src/main/resources/META-INF/mailcap
@@ -1,0 +1,6 @@
+# BouncyCastle Content Handlers
+application/pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_signature
+application/pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_mime
+application/x-pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_signature
+application/x-pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_mime
+multipart/signed;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.multipart_signed

--- a/mail/src/test/java/org/bouncycastle/mail/smime/test/SMIMETestSetup.java
+++ b/mail/src/test/java/org/bouncycastle/mail/smime/test/SMIMETestSetup.java
@@ -4,14 +4,10 @@ package org.bouncycastle.mail.smime.test;
 import junit.extensions.TestSetup;
 import junit.framework.Test;
 
-import javax.activation.CommandMap;
-import javax.activation.MailcapCommandMap;
 import java.security.Security;
 
 class SMIMETestSetup extends TestSetup 
 {
-    private CommandMap originalMap = null;
-
     public SMIMETestSetup(Test test)
     {
         super(test);
@@ -21,29 +17,10 @@ class SMIMETestSetup extends TestSetup
     {
         Security
                 .addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
-
-        MailcapCommandMap _mailcap = (MailcapCommandMap)CommandMap
-                .getDefaultCommandMap();
-
-        _mailcap
-                .addMailcap("application/pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_signature");
-        _mailcap
-                .addMailcap("application/pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.pkcs7_mime");
-        _mailcap
-                .addMailcap("application/x-pkcs7-signature;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_signature");
-        _mailcap
-                .addMailcap("application/x-pkcs7-mime;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.x_pkcs7_mime");
-        _mailcap
-                .addMailcap("multipart/signed;; x-java-content-handler=org.bouncycastle.mail.smime.handlers.multipart_signed");
-
-        originalMap = CommandMap.getDefaultCommandMap();
-        CommandMap.setDefaultCommandMap(_mailcap);
     }
 
     protected void tearDown()
     {
-        CommandMap.setDefaultCommandMap(originalMap);
-        originalMap = null;
         Security.removeProvider("BC");
     }
 


### PR DESCRIPTION
Instead of directly updating the javax.activation CommandMap via code this change uses a mailcap file in the META-INF. This file is automatically processed by the javax.activation's standard MailcapCommandMap, and it is also processed by the special CommandMap implementation used by ServiceMix/Karaf.

This fixes all problems as described in #704

