### PR TITLE
Keep root cause of KeyStoreException exception

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/keystore/bc/BcKeyStoreSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/keystore/bc/BcKeyStoreSpi.java
@@ -678,7 +678,7 @@ public class BcKeyStoreSpi
         }
         catch (Exception e)
         {
-            throw new KeyStoreException(e.toString());
+            throw new KeyStoreException(e.toString(), e);
         }
     }
 


### PR DESCRIPTION
Long term fix for debugging https://github.com/square/okhttp/issues/6116

This particular error has come up a couple of times and without the root NPE, it's difficult to debug.