### PR TITLE
Fix DTLS handshake infinite loop

### DIFF
--- a/tls/src/main/java/org/bouncycastle/tls/DTLSRecordLayer.java
+++ b/tls/src/main/java/org/bouncycastle/tls/DTLSRecordLayer.java
@@ -559,7 +559,20 @@ class DTLSRecordLayer
 
             if (!isClientHelloFragment)
             {
-                return -1;
+                boolean isServerHelloFragment =
+                        getReadEpoch () == 0
+                                &&  length > 0
+                                &&  ContentType.handshake == recordType
+                                &&  HandshakeType.server_hello == TlsUtils.readUint8(record, RECORD_HEADER_LENGTH);
+
+                if (isServerHelloFragment)
+                {
+                    setReadVersion(recordVersion);
+                }
+                else
+                {
+                    return -1;
+                }
             }
         }
 


### PR DESCRIPTION
Fix DTLS handshake infinite loop caused by the client dropping packets different from Client Hello kind of packets.

This happens when it receives the Hello Verify Request after its resend timeout (initially set to 1000ms) expires.

Fix #726 