### PR TITLE
KMAC algorithm gives incorrect output for digest length not in multip…

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/macs/KMAC.java
+++ b/core/src/main/java/org/bouncycastle/crypto/macs/KMAC.java
@@ -237,9 +237,9 @@ public class KMAC
 
         b[n] = n;
 
-        for (int i = 0; i < n; i++)
+        for (int i = 1; i <= n; i++)
         {
-            b[n - i - 1] = (byte)(strLen >> (8 * (n - i)));
+            b[i - 1] = (byte)(strLen >> (8 * (n - i)));
         }
 
         return b;


### PR DESCRIPTION
…les of 32 bytes due to wrong length encoding

**Algorithm: D= KMAC(K, X, L, S)**
Issue: Due to wrong length encoding, Bouncy Castle KMAC digest doesn't match with all other available KMAC implementations when digest size is not in multiples of 32 bytes.

**Example:**
Below values used for testing: 
X: "input message"
K: "password"
S: "custom"
L:  Set to different digest sizes in bytes

**Bouncy Castle KMAC Output**
L: 31
D=2C743AA2D98E42EAD49A0EB308D1F9DAA0E669D312765FB30FC46FA95AA9C0

L=32
D=A4B82A824E61A23ED603E38451386230D10CF75A98169243C4E1BA77172A1603

L=33
D=A4B82A824E61A23ED603E38451386230D10CF75A98169243C4E1BA77172A160342

**OpenSSL KMAC Output**
L=31
D=3435F61973F0C7C663F48F098CC49831C732980ADA7252D849139485BEF75D

L=32
D=A4B82A824E61A23ED603E38451386230D10CF75A98169243C4E1BA77172A1603

L=33
D=16893FC2901607BA6416685234485C8CADF8E9F15DC4F15EBD36966A09EE0DA03A