### PR TITLE
Fix padding error in CSHAKEDigest,java

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/digests/CSHAKEDigest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/CSHAKEDigest.java
@@ -40,6 +40,8 @@ public class CSHAKEDigest
 
         int required = blockSize - (diff.length % blockSize);
 
+        required %= blockSize;  //  otherwise diffPadAndAbsorb will add one entire blockSize of ZEROs,
+                                //  which contradicts the specification of bytepad(X,w) in NIST SP 800-185
         while (required > padding.length)
         {
             absorb(padding, 0, padding.length);


### PR DESCRIPTION
The current implementation og diffPadAndAbsorb contradicts the specification of bytepad in NIST SP 800-38.

Letting bit-padding aside, SP 800-185 specifies that...
3. while (len(z)/8) mod w ≠ 0:
z = z || 00000000

* z in SP800-185 is named diff in BCs implementation
* len(z) is the BITlength of z - len(z) /8 matches diff.length in BC implementation
* w is the padding width (in bytes) - this matches blockSize in the BC implementation.

When by chance z / diff has a length of blockSize, the current implementation will append an entire block (w) of ZEROs.
This contradicts the specification cited above.

Thanks for your work on BC!