### PR TITLE
Fix clearSignedFileProcessor header description.

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/examples/ClearSignedFileProcessor.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/examples/ClearSignedFileProcessor.java
@@ -40,7 +40,7 @@ import org.bouncycastle.util.Strings;
  * <p>
  * To sign a file: ClearSignedFileProcessor -s fileName secretKey passPhrase.<br>
  * <p>
- * To decrypt: ClearSignedFileProcessor -v fileName signatureFile publicKeyFile.
+ * To decrypt: ClearSignedFileProcessor -v signatureFile publicKeyFile.
  */
 public class ClearSignedFileProcessor
 {


### PR DESCRIPTION
The code is written as 'System.err.println("usage:ClearSignedFileProcessor [-s file keyfile passPhrase]|[-v sigFile keyFile]");'
So fix the description to conform to the code.