### PR TITLE
char[] to byte[] conversion

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/OpenSSLPBKDF.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/OpenSSLPBKDF.java
@@ -60,7 +60,7 @@ public final class OpenSSLPBKDF
 
                 OpenSSLPBEParametersGenerator pGen = new OpenSSLPBEParametersGenerator();
 
-                pGen.init(Strings.toByteArray(pbeSpec.getPassword()), pbeSpec.getSalt());
+                pGen.init(Strings.toUTF8ByteArray(pbeSpec.getPassword()), pbeSpec.getSalt());
 
                 return new SecretKeySpec(((KeyParameter)pGen.generateDerivedParameters(pbeSpec.getKeyLength())).getKey(), "OpenSSLPBKDF");
             }


### PR DESCRIPTION
Conversion without specifying an encoding cause errors when using non-ascii symbols in passwords.