### PR TITLE
Use BigIntegers.intValueExact() for compatibility

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jce/provider/OcspCache.java
+++ b/prov/src/main/java/org/bouncycastle/jce/provider/OcspCache.java
@@ -38,6 +38,7 @@ import org.bouncycastle.asn1.ocsp.TBSRequest;
 import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.jcajce.PKIXCertRevocationCheckerParameters;
 import org.bouncycastle.jcajce.util.JcaJceHelper;
+import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.io.Streams;
 
 class OcspCache
@@ -173,7 +174,7 @@ class OcspCache
             }
             OCSPResponse response = OCSPResponse.getInstance(Streams.readAllLimited(reqIn, contentLength));
 
-            if (OCSPResponseStatus.SUCCESSFUL == response.getResponseStatus().getValue().intValueExact())
+            if (OCSPResponseStatus.SUCCESSFUL == BigIntegers.intValueExact(response.getResponseStatus().getValue()))
             {
                 boolean validated = false;
                 ResponseBytes respBytes = ResponseBytes.getInstance(response.getResponseBytes());


### PR DESCRIPTION
`BigInteger.intValueExact()` is only available since Java 8. This leads to run time errors on older JDKs (when using the 1.5on artifact) and on Android where this method is missing entirely.