### PR TITLE
EdDSA: Add public constructors for key classes

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/edec/BCEdDSAPrivateKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/edec/BCEdDSAPrivateKey.java
@@ -29,7 +29,7 @@ public class BCEdDSAPrivateKey
     private final boolean hasPublicKey;
     private final byte[] attributes;
 
-    BCEdDSAPrivateKey(AsymmetricKeyParameter privKey)
+    public BCEdDSAPrivateKey(AsymmetricKeyParameter privKey)
     {
         this.hasPublicKey = true;
         this.attributes = null;

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/edec/BCEdDSAPublicKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/edec/BCEdDSAPublicKey.java
@@ -21,7 +21,7 @@ public class BCEdDSAPublicKey
 
     transient AsymmetricKeyParameter eddsaPublicKey;
 
-    BCEdDSAPublicKey(AsymmetricKeyParameter pubKey)
+    public BCEdDSAPublicKey(AsymmetricKeyParameter pubKey)
     {
         this.eddsaPublicKey = pubKey;
     }


### PR DESCRIPTION
Hello Lords of the Bouncy Castle,

Please consider this proposal to make these constructors public. We are relying on access to these constructors in the `buddy` library to generate EdDSA signatures and JSON web keys. It is important that we are able to construct an EdDSA key pair directly from its raw bytes.

https://github.com/funcool/buddy-core/pull/73