### PR TITLE
Update hashCodeValue before setting isHashCodeCalculated

### DIFF
--- a/core/src/main/j2me/org/bouncycastle/asn1/x500/X500Name.java
+++ b/core/src/main/j2me/org/bouncycastle/asn1/x500/X500Name.java
@@ -245,9 +245,9 @@ public class X500Name
             return hashCodeValue;
         }
 
-        isHashCodeCalculated = true;
-
         hashCodeValue = style.calculateHashCode(this);
+
+        isHashCodeCalculated = true;
 
         return hashCodeValue;
     }


### PR DESCRIPTION
This essentially make the hashCode calculation thread safe. There might be multiple threads calling hashCode. This allows each thread gets the same hashCode value.