### PR TITLE
Make BcKeyStoreSpi less predictable

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/keystore/bc/BcKeyStoreSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/keystore/bc/BcKeyStoreSpi.java
@@ -141,7 +141,6 @@ public class BcKeyStoreSpi
 
             byte[] salt = new byte[KEY_SALT_SIZE];
 
-            random.setSeed(System.currentTimeMillis());
             random.nextBytes(salt);
 
             int iterationCount = MIN_ITERATIONS + (random.nextInt() & 0x3ff);


### PR DESCRIPTION
`BcKeyStoreSpi` uses PBE to store entries. To do that, it generates a salt and iteration count by using `SecureRandom`. It uses `System.currentTimeMillis()` to initialize the random generator. If someones knows what time the code was run, they could predict the generated salt and iteration count which would make the PBE encryption a bit less secure.

This one-line patch updates `BcKeyStoreSpi` to use the default source of entropy when it generates a salt and an iteration count for PBE. The default source of entropy is defined by the `securerandom.source` security property that is normally set to `/dev/random` by default in the JRE. Although it's known that `/dev/random` may block, I think it would still be better to use it to make the random numbers less predictable by default. Furthermore, a used will be able to override `securerandom.source` with `/dev/urandom` if necessary. Right now a user can't control it at all.

I checked the history of the file on GitHub, and I didn't find a commit that introduced `System.currentTimeMillis()`. Unfortunately, http://git.bouncycastle.org/repositories/bc-java doesn't seem to work, so that I could not check exactly when it was introduced.

The issue was reported by LGTM:

https://lgtm.com/projects/g/bcgit/bc-java/snapshot/066687c2f112dc72f7be5e01a3c85582b33083a7/files/prov/src/main/java/org/bouncycastle/jcajce/provider/keystore/bc/BcKeyStoreSpi.java?sort=name&dir=ASC&mode=heatmap#x613c88fb22a011b9:1