### PR TITLE
Suppress index-out-of-bound false-positives from LGTM

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/engines/BlowfishEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/BlowfishEngine.java
@@ -420,8 +420,9 @@ implements BlockCipher
 
             xr ^= P[ROUNDS + 1];
 
+            // suppress LGTM warnings index-out-of-bounds since the loop increments s by 2
             table[s] = xr;
-            table[s + 1] = xl;
+            table[s + 1] = xl;  // lgtm [java/index-out-of-bounds]
 
             xr = xl;            // end of cycle swap
             xl = table[s];

--- a/core/src/main/java/org/bouncycastle/crypto/generators/BCrypt.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/BCrypt.java
@@ -368,7 +368,7 @@ public final class BCrypt
             xr ^= P[ROUNDS + 1];
 
             table[s] = xr;
-            table[s + 1] = xl;
+            table[s + 1] = xl;  // lgtm [java/index-out-of-bounds]
 
             xr = xl;            // end of cycle swap
             xl = table[s];
@@ -489,8 +489,9 @@ public final class BCrypt
             }
             xr ^= P[ROUNDS + 1];
 
+            // suppress LGTM warnings index-out-of-bounds since the loop increments s by 4
             table[s] = xr;
-            table[s + 1] = xl;
+            table[s + 1] = xl;  // lgtm [java/index-out-of-bounds]
 
             yl = salt32Bit[2] ^ xr;
             yr = salt32Bit[3] ^ xl;
@@ -508,8 +509,8 @@ public final class BCrypt
             }
             yr ^= P[ROUNDS + 1];
 
-            table[s + 2] = yr;
-            table[s + 3] = yl;
+            table[s + 2] = yr;  // lgtm [java/index-out-of-bounds]
+            table[s + 3] = yl;  // lgtm [java/index-out-of-bounds]
 
             xl = salt32Bit[0] ^ yr;
             xr = salt32Bit[1] ^ yl;

--- a/core/src/main/java/org/bouncycastle/crypto/generators/OpenBSDBCrypt.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/OpenBSDBCrypt.java
@@ -383,8 +383,8 @@ public class OpenBSDBCrypt
         for (i = 0; i < len; i += 3)
         {
             a1 = data[i] & 0xff;
-            a2 = data[i + 1] & 0xff;
-            a3 = data[i + 2] & 0xff;
+            a2 = data[i + 1] & 0xff;    // lgtm [java/index-out-of-bounds]
+            a3 = data[i + 2] & 0xff;    // lgtm [java/index-out-of-bounds]
 
             sb.append((char)encodingTable[(a1 >>> 2) & 0x3f]);
             sb.append((char)encodingTable[((a1 << 4) | (a2 >>> 4)) & 0x3f]);
@@ -444,10 +444,11 @@ public class OpenBSDBCrypt
 
         for (int i = 0; i < len; i += 4)
         {
+            // suppress LGTM warnings index-out-of-bounds since the loop increments i by 4
             b1 = decodingTable[saltChars[i]];
-            b2 = decodingTable[saltChars[i + 1]];
-            b3 = decodingTable[saltChars[i + 2]];
-            b4 = decodingTable[saltChars[i + 3]];
+            b2 = decodingTable[saltChars[i + 1]];   // lgtm [java/index-out-of-bounds]
+            b3 = decodingTable[saltChars[i + 2]];   // lgtm [java/index-out-of-bounds]
+            b4 = decodingTable[saltChars[i + 3]];   // lgtm [java/index-out-of-bounds]
 
             out.write((b1 << 2) | (b2 >> 4));
             out.write((b2 << 4) | (b3 >> 2));


### PR DESCRIPTION
LGTM reports several findings about accessing an array with an index that is greater than or equal to the length of the array. Those are false-positives.

https://lgtm.com/projects/g/bcgit/bc-java/?mode=list&tag=&id=java%2Findex-out-of-bounds