### PR TITLE
Added a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting a security issue
+
+If you would like to report something you believe to be a security issue
+then please use feedback-crypto@bouncycastle.org. 
+We can provide a PGP key if required.


### PR DESCRIPTION
The process of reporting security issues should be documented and easy to find.

I'd like to propose adding a security policy to the project that would be integrated with other GitHub features

https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository

It would make it a bit easier to find the docs that describe how security issues should be reported. Also, when someone creates an issue in the repository, they will see a link to the security policy.

The policy just contains content from the bottom of https://www.bouncycastle.org/