### PR TITLE
Enable nohttp check during the build

### DIFF
--- a/CONTRIBUTORS.html
+++ b/CONTRIBUTORS.html
@@ -78,18 +78,18 @@ Organisations
 </p>
 <ul>
 <li>Holders of <a href="https://www.cryptoworkshop.com">Crypto Workshop Support Contracts</a>. Without the consulting time left over from support contracts being contributed back to working on the Bouncy Castle APIs, progress would be impossible. You know who you are!</li>
-<li><a href="http://www.atlassian.com/">Atlassian Software Systems</a> donation of Confluence and JIRA licences.</li>
-<li><a href="http://www.grierforensics.com/">Grier Forensics</a>, for collaborating in the development of the S/MIME Toolkit and DANE SMIMEA functionality.</li>
+<li><a href="https://www.atlassian.com/">Atlassian Software Systems</a> donation of Confluence and JIRA licences.</li>
+<li><a href="https://www.grierforensics.com/">Grier Forensics</a>, for collaborating in the development of the S/MIME Toolkit and DANE SMIMEA functionality.</li>
 <li>TU-Darmstadt, Computer Science Department, RBG, for the initial
 lightweight client side TLS implementation, which is based on MicroTLS and for help with qTESLA implementation. MicroTLS was developed by Erik Tews under the supervision of Dipl.-Ing. Henning Baer and Prof. Max Muehlhaeuser. qTESLA assistance was provided by Nina Bindel and Yinhua Xu.
 </li>
 <li>TU-Darmstadt, Computer Science Department, RBG, for the initial
 Post Quantum provider, which was based on the FlexiProvider. The FlexiProvider was developed
 by the Theoretical Computer Science Research Group at TU-Darmstadt, Computer Science Department, RBG under the supervision of Prof. Dr. Johannes Buchmann. More information on the history of FlexiProvider can be found at:
-<a href="http://www.flexiprovider.de/">http://www.flexiprovider.de/</a>
+<a href="https://www.flexiprovider.de/">https://www.flexiprovider.de/</a>
 </li>
 <li>Voxeo Labs - sponsorship of the initial development of APIs for DTLS 1.0 (RFC 4347), DTLS-SRTP key negotiation (RFC 5764),
-and server side TLS 1.1 (RFC 4346) and tested WebRTC compatibility. More information on Voxeo Labs can be found at <a href="http://voxeolabs.com">http://voxeolabs.com</a></li>
+and server side TLS 1.1 (RFC 4346) and tested WebRTC compatibility. More information on Voxeo Labs can be found at <a href="https://voxeolabs.com">https://voxeolabs.com</a></li>
 <li><a href="https://www.coreinfrastructure.org/">Core Infrastructure Initiative</a> - financial support towards developing the TLS API and JSSE provider that appeared in 1.56.</li>
 <li>Additional CertPath testing and validation data from the CertPath testing tool developed by <a href="https://www.cryptosource.de">cryptosource GmbH</a> and <a href="https://www.mtg.de">media Transfer AG</a> both located in Darmstadt, Germany.</li>
 <li><a href="https://www.microfocus.com/">Micro Focus</a> - additional support towards further developing the TLS/DTLS API and the BCJSSE provider.</li>
@@ -128,7 +128,7 @@ support, bug fixes in CertPath API.</li>
 addition of ISO 9796-1 padding.</li>
 <li>Stefan K&ouml;psell &lt;sk13&#064;mail.inf.tu-dresden.de&gt; - making the jdk 1.1
 version of the collections API available. For further details see
-<a href="http://sourceforge.net/projects/jcf/">http://sourceforge.net/projects/jcf/</a></li>
+<a href="https://sourceforge.net/projects/jcf/">https://sourceforge.net/projects/jcf/</a></li>
 <li>Carmen Bastiaans &lt;cbastiaa&#064;microbits.com.au&gt; - fixing the improper
 null pointer problem in the setting of certificates in the PKCS12 key store.</li>
 <li>Tomas Gustavsson &lt;tomasg&#064;primekey.se&gt; - initial implementation of the AuthorityInformationAccess, SubjectKeyIdentifier, AuthorityKeyIdentifier, CRLNumber, CRLReason, CertificatePolicies, V2TBSCertListGenerator, and X509V2CRLGenerator classes in the ASN.1 library. Additions to GeneralName class, other bug fixes in the X.509 package. Initial implementation of the CertificationRequest classes. getRevocationReason() patch for OCSP. Patch to SemanticsInformation to prevent ClassCastException.</li>
@@ -246,7 +246,7 @@ SecureRandom.</li>
 <li>Albert Moliner &lt;amoliner&#064evintia.com&gt; - initial TSP implementation.</li>
 <li>Carlos Lozano &lt;carlos&#064evintia.com&gt; - initial TSP implementation, patch to SignerInformation for supporting repeated signers, initial updates for supporting repeated attributes in CMS.</li>
 <li>Javier Delgadillo &lt;javi&#064javi.codewarp.org&gt; - initial Mozilla PublicKeyAndChallenge classes.</li>
-<li>Joni Hahkala &lt;joni.hahkala&#064cern.ch&gt; - initial implementations of VOMS Attribute Certificate Validation, IetfAttrSyntax, and ObjectDigestInfo. We also wish to thank the <a href="http://www.eu-egee.org">EGEE project</a> for making the work available.</li>
+<li>Joni Hahkala &lt;joni.hahkala&#064cern.ch&gt; - initial implementations of VOMS Attribute Certificate Validation, IetfAttrSyntax, and ObjectDigestInfo. We also wish to thank the <a href="https://www.eu-egee.org">EGEE project</a> for making the work available.</li>
 <li>Rolf Schillinger&lt;rolf&#064sir-wum.de&gt; - initial implementation of Attribute Certificate generation.</li>
 <li>Sergey Bahtin &lt;Sergey_Bahtin&#064yahoo.com&gt; - fix for recovering certificate aliases in BKS and UBER key stores. Initial implementations of GOST-28147, GOST-3410, EC GOST-3410, GOST OFB mode (GOFB) and GOST-3411.</li>
 <li>Franck Leroy &lt;Franck.Leroy&#064keynectis.com&gt; - ANS.1 set sorting. Contributions to TSP implementation. Test vectors for Bleichenbacher's forgery attack.</li>
@@ -281,7 +281,7 @@ Optimisation to avoid redundant verification in path validator. Suggestion to us
 <li>Kishimoto Kazuhiko &lt;kazu-k&#064hi-ho.ne.jp&gt; - RFC 3280 updates to policy processing in the CertPath validator. Additional test data not covered by NIST.</li>
 <li>Lawrence Tan &lt;lwrnctan&#064gmail.com&gt - Large field OID sample test data. Missing key types in JDKKeyFactory.</li>
 <li>Carlos Valiente &lt;superdupont&#064gmail.com&gt; - Addition of CRL writing to the PEMWriter class.</li>
-<li>Keyon AG, Martin Christinat, <a href="http://www.keyon.ch">http://www.keyon.ch</a> - fixing incorrect 
+<li>Keyon AG, Martin Christinat, <a href="https://www.keyon.ch">https://www.keyon.ch</a> - fixing incorrect
 ASN.1 encoding of field elements in X9FieldElement class.</li>
 <li>Olaf Keller, &lt;olaf.keller.bc&#064bluewin.ch&gt; - initial implementation of the elliptic curves over binary fields F2m. Additional tests and modifications to elliptic curve support for both F2m and Fp. Performance improvements to F2m multiplication. Initial implementation of WNAF/WTNAF point multiplication. Improvement to k value generation in ECDSA.</li>
 <li>J&ouml;rg Eichhorn &lt;eichhorn&#064ponton-consulting.de&gt; - patch to fix EOF read on SharedFileInputStream, support for F2m compression.</li>

--- a/LICENSE.html
+++ b/LICENSE.html
@@ -1,7 +1,7 @@
 <html>
 <body bgcolor=#ffffff>
 
-Copyright (c) 2000-2020 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
+Copyright (c) 2000-2020 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
 <p>
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
 and associated documentation files (the "Software"), to deal in the Software without restriction, 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Legion also gratefully acknowledges the contributions made to this package b
 
 The package is organised so that it contains a light-weight API suitable for use in any environment (including the newly released J2ME) with the additional infrastructure to conform the algorithms to the JCE framework.
 
-Except where otherwise stated, this software is distributed under a license based on the MIT X Consortium license. To view the license, [see here](https://www.bouncycastle.org/licence.html). The OpenPGP library also includes a modified BZIP2 library which is licensed under the [Apache Software License, Version 2.0](http://www.apache.org/licenses/). 
+Except where otherwise stated, this software is distributed under a license based on the MIT X Consortium license. To view the license, [see here](https://www.bouncycastle.org/licence.html). The OpenPGP library also includes a modified BZIP2 library which is licensed under the [Apache Software License, Version 2.0](https://www.apache.org/licenses/). 
 
 **Note**: this source tree is not the FIPS version of the APIs - if you are interested in our FIPS version please contact us directly at  [office@bouncycastle.org](mailto:office@bouncycastle.org).
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,9 @@ buildscript {
       url "https://plugins.gradle.org/m2/"
     }
   }
+  dependencies {
+    classpath "io.spring.nohttp:nohttp-gradle:0.0.5.RELEASE"
+  }
 }
 
 if (JavaVersion.current().isJava8Compatible())
@@ -18,6 +21,7 @@ if (JavaVersion.current().isJava8Compatible())
 allprojects {
   apply plugin: 'java'
   apply plugin: 'idea'
+  apply plugin: 'io.spring.nohttp'
 
   repositories {
     mavenCentral()

--- a/config/nohttp/checkstyle.xml
+++ b/config/nohttp/checkstyle.xml
@@ -1,0 +1,17 @@
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+  "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <property name="charset" value="UTF-8"/>
+  <property name="fileExtensions" value=""/>
+
+  <module name="io.spring.nohttp.checkstyle.check.NoHttpCheck">
+    <property name="allowlistFileName" value="${nohttp.checkstyle.allowlistFileName}" default=""/>
+  </module>
+
+  <module name="SuppressionFilter">
+    <property name="file" value="${config_loc}/suppressions.xml" default=""/>
+    <property name="optional" value="true"/>
+  </module>
+
+  <module name="SuppressWithPlainTextCommentFilter"/>
+</module>

--- a/config/nohttp/suppressions.xml
+++ b/config/nohttp/suppressions.xml
@@ -1,0 +1,19 @@
+<!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+
+  <!-- Suppress warnings in certificates, signatures, configs and emails for testing -->
+  <suppress files=".+\.(pem|crt|cer|eml|cnf|sig|message)" checks="NoHttp"/>
+
+  <!-- This tests server doesn't seem to support HTTPS -->
+  <suppress message="http://testrfc7030.com/" checks="NoHttp"/>
+
+  <!-- Suppress warnings for strings that are used in tests -->
+  <suppress message="http://test" files=".+Test.java" checks="NoHttp"/>
+  <suppress message="http://img2.thejournal.ie" files=".+Test.java" checks="NoHttp"/>
+  <suppress message="http://gpgtools.org" files=".+Test.java" checks="NoHttp"/>
+  <suppress message="http://www.tbs-certificats.com" files=".+Test.java" checks="NoHttp"/>
+
+  <!-- Suppress warnings in this file -->
+  <suppress files="config/nohttp/suppressions.xml" checks="NoHttp"/>
+</suppressions>

--- a/core/src/main/java/org/bouncycastle/LICENSE.java
+++ b/core/src/main/java/org/bouncycastle/LICENSE.java
@@ -5,7 +5,7 @@ import org.bouncycastle.util.Strings;
 /**
  * The Bouncy Castle License
  *
- * Copyright (c) 2000-2019 The Legion Of The Bouncy Castle Inc. (http://www.bouncycastle.org)
+ * Copyright (c) 2000-2019 The Legion Of The Bouncy Castle Inc. (https://www.bouncycastle.org)
  * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
  * and associated documentation files (the "Software"), to deal in the Software without restriction, 
@@ -26,7 +26,7 @@ import org.bouncycastle.util.Strings;
 public class LICENSE
 {
     public static final String licenseText =
-      "Copyright (c) 2000-2019 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org) "
+      "Copyright (c) 2000-2019 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org) "
       + Strings.lineSeparator()
       + Strings.lineSeparator()
       + "Permission is hereby granted, free of charge, to any person obtaining a copy of this software "

--- a/core/src/main/java/org/bouncycastle/asn1/cms/Attribute.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/Attribute.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.ASN1Set;
 import org.bouncycastle.asn1.DERSequence;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#page-14">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#page-14">RFC 5652</a>:
  * Attribute is a pair of OID (as type identifier) + set of values.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/Attributes.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/Attributes.java
@@ -8,7 +8,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DLSet;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652">RFC 5652</a> defines
+ * <a href="https://tools.ietf.org/html/rfc5652">RFC 5652</a> defines
  * 5 "SET OF Attribute" entities with 5 different names.
  * This is common implementation for them all:
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/AuthEnvelopedData.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/AuthEnvelopedData.java
@@ -12,7 +12,7 @@ import org.bouncycastle.asn1.BERSequence;
 import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5083">RFC 5083</a>:
+ * <a href="https://tools.ietf.org/html/rfc5083">RFC 5083</a>:
  *
  * CMS AuthEnveloped Data object.
  * <p>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/AuthenticatedData.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/AuthenticatedData.java
@@ -15,7 +15,7 @@ import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-9.1">RFC 5652</a> section 9.1:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-9.1">RFC 5652</a> section 9.1:
  * The AuthenticatedData carries AuthAttributes and other data
  * which define what really is being signed.
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/CCMParameters.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/CCMParameters.java
@@ -11,7 +11,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.util.Arrays;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5084">RFC 5084</a>: CCMParameters object.
+ * <a href="https://tools.ietf.org/html/rfc5084">RFC 5084</a>: CCMParameters object.
  * <p>
  * <pre>
  CCMParameters ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/CMSAttributes.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/CMSAttributes.java
@@ -5,8 +5,8 @@ import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652">RFC 5652</a> CMS attribute OID constants.
- * and <a href="http://tools.ietf.org/html/rfc6211">RFC 6211</a> Algorithm Identifier Protection Attribute.
+ * <a href="https://tools.ietf.org/html/rfc5652">RFC 5652</a> CMS attribute OID constants.
+ * and <a href="https://tools.ietf.org/html/rfc6211">RFC 6211</a> Algorithm Identifier Protection Attribute.
  * <pre>
  * contentType      ::= 1.2.840.113549.1.9.3
  * messageDigest    ::= 1.2.840.113549.1.9.4
@@ -28,7 +28,7 @@ public interface CMSAttributes
     ASN1ObjectIdentifier  signingTime = PKCSObjectIdentifiers.pkcs_9_at_signingTime;
     /** PKCS#9: 1.2.840.113549.1.9.6 */
     ASN1ObjectIdentifier  counterSignature = PKCSObjectIdentifiers.pkcs_9_at_counterSignature;
-    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.4 - See <a href="http://tools.ietf.org/html/rfc2634">RFC 2634</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.4 - See <a href="https://tools.ietf.org/html/rfc2634">RFC 2634</a> */
     ASN1ObjectIdentifier  contentHint = PKCSObjectIdentifiers.id_aa_contentHint;
 
     ASN1ObjectIdentifier  cmsAlgorithmProtect = PKCSObjectIdentifiers.id_aa_cmsAlgorithmProtect;

--- a/core/src/main/java/org/bouncycastle/asn1/cms/CompressedData.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/CompressedData.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.BERSequence;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /** 
- * <a href="http://tools.ietf.org/html/rfc3274">RFC 3274</a>: CMS Compressed Data.
+ * <a href="https://tools.ietf.org/html/rfc3274">RFC 3274</a>: CMS Compressed Data.
  * 
  * <pre>
  * CompressedData ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/CompressedDataParser.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/CompressedDataParser.java
@@ -7,7 +7,7 @@ import org.bouncycastle.asn1.ASN1SequenceParser;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /**
- * Parser of <a href="http://tools.ietf.org/html/rfc3274">RFC 3274</a> {@link CompressedData} object.
+ * Parser of <a href="https://tools.ietf.org/html/rfc3274">RFC 3274</a> {@link CompressedData} object.
  * <p>
  * <pre>
  * CompressedData ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/ContentInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/ContentInfo.java
@@ -11,8 +11,8 @@ import org.bouncycastle.asn1.BERSequence;
 import org.bouncycastle.asn1.BERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-3">RFC 5652</a> ContentInfo, and 
- * <a href="http://tools.ietf.org/html/rfc5652#section-5.2">RFC 5652</a> EncapsulatedContentInfo objects.
+ * <a href="https://tools.ietf.org/html/rfc5652#section-3">RFC 5652</a> ContentInfo, and
+ * <a href="https://tools.ietf.org/html/rfc5652#section-5.2">RFC 5652</a> EncapsulatedContentInfo objects.
  *
  * <pre>
  * ContentInfo ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/ContentInfoParser.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/ContentInfoParser.java
@@ -8,7 +8,7 @@ import org.bouncycastle.asn1.ASN1SequenceParser;
 import org.bouncycastle.asn1.ASN1TaggedObjectParser;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-3">RFC 5652</a> {@link ContentInfo} object parser.
+ * <a href="https://tools.ietf.org/html/rfc5652#section-3">RFC 5652</a> {@link ContentInfo} object parser.
  *
  * <pre>
  * ContentInfo ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/DigestedData.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/DigestedData.java
@@ -12,7 +12,7 @@ import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /** 
- * <a href="http://tools.ietf.org/html/rfc5652#section-7">RFC 5652</a> DigestedData object.
+ * <a href="https://tools.ietf.org/html/rfc5652#section-7">RFC 5652</a> DigestedData object.
  * <pre>
  * DigestedData ::= SEQUENCE {
  *       version CMSVersion,

--- a/core/src/main/java/org/bouncycastle/asn1/cms/EncryptedContentInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/EncryptedContentInfo.java
@@ -12,7 +12,7 @@ import org.bouncycastle.asn1.BERTaggedObject;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.1">RFC 5652</a> EncryptedContentInfo object.
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.1">RFC 5652</a> EncryptedContentInfo object.
  *
  * <pre>
  * EncryptedContentInfo ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/EncryptedContentInfoParser.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/EncryptedContentInfoParser.java
@@ -9,7 +9,7 @@ import org.bouncycastle.asn1.ASN1TaggedObjectParser;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /**
- * Parser for <a href="http://tools.ietf.org/html/rfc5652#section-6.1">RFC 5652</a> EncryptedContentInfo object.
+ * Parser for <a href="https://tools.ietf.org/html/rfc5652#section-6.1">RFC 5652</a> EncryptedContentInfo object.
  * <p>
  * <pre>
  * EncryptedContentInfo ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/EncryptedData.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/EncryptedData.java
@@ -11,7 +11,7 @@ import org.bouncycastle.asn1.BERSequence;
 import org.bouncycastle.asn1.BERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-8">RFC 5652</a> EncryptedData object.
+ * <a href="https://tools.ietf.org/html/rfc5652#section-8">RFC 5652</a> EncryptedData object.
  * <p>
  * <pre>
  * EncryptedData ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/EnvelopedData.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/EnvelopedData.java
@@ -13,7 +13,7 @@ import org.bouncycastle.asn1.BERSequence;
 import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.1">RFC 5652</a> EnvelopedData object.
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.1">RFC 5652</a> EnvelopedData object.
  * <pre>
  * EnvelopedData ::= SEQUENCE {
  *     version CMSVersion,

--- a/core/src/main/java/org/bouncycastle/asn1/cms/EnvelopedDataParser.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/EnvelopedDataParser.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.ASN1TaggedObjectParser;
 import org.bouncycastle.asn1.BERTags;
 
 /** 
- * Parser of <a href="http://tools.ietf.org/html/rfc5652#section-6.1">RFC 5652</a> {@link EnvelopedData} object.
+ * Parser of <a href="https://tools.ietf.org/html/rfc5652#section-6.1">RFC 5652</a> {@link EnvelopedData} object.
  * <p>
  * <pre>
  * EnvelopedData ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/Evidence.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/Evidence.java
@@ -9,7 +9,7 @@ import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.tsp.EvidenceRecord;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5544">RFC 5544</a>:
+ * <a href="https://tools.ietf.org/html/rfc5544">RFC 5544</a>:
  * Binding Documents with Time-Stamps; Evidence object.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/GCMParameters.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/GCMParameters.java
@@ -11,7 +11,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.util.Arrays;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5084">RFC 5084</a>: GCMParameters object.
+ * <a href="https://tools.ietf.org/html/rfc5084">RFC 5084</a>: GCMParameters object.
  * <p>
  * <pre>
  GCMParameters ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/IssuerAndSerialNumber.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/IssuerAndSerialNumber.java
@@ -14,7 +14,7 @@ import org.bouncycastle.asn1.x509.X509CertificateStructure;
 import org.bouncycastle.asn1.x509.X509Name;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-10.2.4">RFC 5652</a>: IssuerAndSerialNumber object.
+ * <a href="https://tools.ietf.org/html/rfc5652#section-10.2.4">RFC 5652</a>: IssuerAndSerialNumber object.
  * <p>
  * <pre>
  * IssuerAndSerialNumber ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/KEKIdentifier.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/KEKIdentifier.java
@@ -11,7 +11,7 @@ import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.3">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.3">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/KEKRecipientInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/KEKRecipientInfo.java
@@ -11,7 +11,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.3">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.3">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/KeyAgreeRecipientIdentifier.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/KeyAgreeRecipientIdentifier.java
@@ -8,7 +8,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/KeyAgreeRecipientInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/KeyAgreeRecipientInfo.java
@@ -12,7 +12,7 @@ import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/KeyTransRecipientInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/KeyTransRecipientInfo.java
@@ -11,7 +11,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.1">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.1">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <pre>
  * KeyTransRecipientInfo ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/MetaData.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/MetaData.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERUTF8String;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5544">RFC 5544</a>:
+ * <a href="https://tools.ietf.org/html/rfc5544">RFC 5544</a>:
  * Binding Documents with Time-Stamps; MetaData object.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/OriginatorIdentifierOrKey.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/OriginatorIdentifierOrKey.java
@@ -11,7 +11,7 @@ import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <pre>
  * OriginatorIdentifierOrKey ::= CHOICE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/OriginatorInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/OriginatorInfo.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.1">RFC 5652</a>: OriginatorInfo object.
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.1">RFC 5652</a>: OriginatorInfo object.
  * <pre>
  * RFC 3369:
  *

--- a/core/src/main/java/org/bouncycastle/asn1/cms/OriginatorPublicKey.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/OriginatorPublicKey.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/OtherKeyAttribute.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/OtherKeyAttribute.java
@@ -9,7 +9,7 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERSequence;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-10.2.7">RFC 5652</a>: OtherKeyAttribute object.
+ * <a href="https://tools.ietf.org/html/rfc5652#section-10.2.7">RFC 5652</a>: OtherKeyAttribute object.
  * <p>
  * <pre>
  * OtherKeyAttribute ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/OtherRecipientInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/OtherRecipientInfo.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERSequence;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.5">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.5">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <pre>
  * OtherRecipientInfo ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/OtherRevocationInfoFormat.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/OtherRevocationInfoFormat.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERSequence;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-10.2.1">RFC 5652</a>: OtherRevocationInfoFormat object.
+ * <a href="https://tools.ietf.org/html/rfc5652#section-10.2.1">RFC 5652</a>: OtherRevocationInfoFormat object.
  * <p>
  * <pre>
  * OtherRevocationInfoFormat ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/PasswordRecipientInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/PasswordRecipientInfo.java
@@ -12,7 +12,7 @@ import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-10.2.7">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-10.2.7">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <pre>
  * PasswordRecipientInfo ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/RecipientEncryptedKey.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/RecipientEncryptedKey.java
@@ -9,7 +9,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERSequence;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <pre>
  * RecipientEncryptedKey ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/RecipientIdentifier.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/RecipientIdentifier.java
@@ -9,7 +9,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.1">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.1">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <pre>
  * RecipientIdentifier ::= CHOICE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/RecipientInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/RecipientInfo.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/RecipientKeyIdentifier.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/RecipientKeyIdentifier.java
@@ -11,7 +11,7 @@ import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-6.2.2">RFC 5652</a>:
  * Content encryption key delivery mechanisms.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/SCVPReqRes.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/SCVPReqRes.java
@@ -9,7 +9,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5940">RFC 5940</a>:
+ * <a href="https://tools.ietf.org/html/rfc5940">RFC 5940</a>:
  * Additional Cryptographic Message Syntax (CMS) Revocation Information Choices.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/SignedData.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/SignedData.java
@@ -16,7 +16,7 @@ import org.bouncycastle.asn1.BERTaggedObject;
 import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-5.1">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-5.1">RFC 5652</a>:
  * <p>
  * A signed data object containing multitude of {@link SignerInfo}s.
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/SignedDataParser.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/SignedDataParser.java
@@ -11,7 +11,7 @@ import org.bouncycastle.asn1.ASN1TaggedObjectParser;
 import org.bouncycastle.asn1.BERTags;
 
 /**
- * Parser for <a href="http://tools.ietf.org/html/rfc5652#section-5.1">RFC 5652</a>: {@link SignedData} object.
+ * Parser for <a href="https://tools.ietf.org/html/rfc5652#section-5.1">RFC 5652</a>: {@link SignedData} object.
  * <p>
  * <pre>
  * SignedData ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/SignerIdentifier.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/SignerIdentifier.java
@@ -9,7 +9,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERTaggedObject;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-5.3">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-5.3">RFC 5652</a>:
  * Identify who signed the containing {@link SignerInfo} object.
  * <p>
  * The certificates referred to by this are at containing {@link SignedData} structure.

--- a/core/src/main/java/org/bouncycastle/asn1/cms/SignerInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/SignerInfo.java
@@ -16,7 +16,7 @@ import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-5.3">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-5.3">RFC 5652</a>:
  * Signature container per Signer, see {@link SignerIdentifier}.
  * <pre>
  * PKCS#7:

--- a/core/src/main/java/org/bouncycastle/asn1/cms/Time.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/Time.java
@@ -16,7 +16,7 @@ import org.bouncycastle.asn1.DERGeneralizedTime;
 import org.bouncycastle.asn1.DERUTCTime;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5652#section-11.3">RFC 5652</a>:
+ * <a href="https://tools.ietf.org/html/rfc5652#section-11.3">RFC 5652</a>:
  * Dual-mode timestamp format producing either UTCTIme or GeneralizedTime.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/TimeStampAndCRL.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/TimeStampAndCRL.java
@@ -8,7 +8,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.CertificateList;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5544">RFC 5544</a>
+ * <a href="https://tools.ietf.org/html/rfc5544">RFC 5544</a>
  * Binding Documents with Time-Stamps; TimeStampAndCRL object.
  * <pre>
  * TimeStampAndCRL ::= SEQUENCE {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/TimeStampTokenEvidence.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/TimeStampTokenEvidence.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERSequence;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5544">RFC 5544</a>
+ * <a href="https://tools.ietf.org/html/rfc5544">RFC 5544</a>
  * Binding Documents with Time-Stamps; TimeStampTokenEvidence object.
  * <pre>
  * TimeStampTokenEvidence ::=

--- a/core/src/main/java/org/bouncycastle/asn1/cms/TimeStampedData.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/TimeStampedData.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.BERSequence;
 import org.bouncycastle.asn1.DERIA5String;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5544">RFC 5544</a>:
+ * <a href="https://tools.ietf.org/html/rfc5544">RFC 5544</a>:
  * Binding Documents with Time-Stamps; TimeStampedData object.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/TimeStampedDataParser.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/TimeStampedDataParser.java
@@ -10,7 +10,7 @@ import org.bouncycastle.asn1.ASN1SequenceParser;
 import org.bouncycastle.asn1.DERIA5String;
 
 /**
- * Parser for <a href="http://tools.ietf.org/html/rfc5544">RFC 5544</a>:
+ * Parser for <a href="https://tools.ietf.org/html/rfc5544">RFC 5544</a>:
  * {@link TimeStampedData} object.
  * <p>
  * <pre>

--- a/core/src/main/java/org/bouncycastle/asn1/cms/ecc/MQVuserKeyingMaterial.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/ecc/MQVuserKeyingMaterial.java
@@ -11,7 +11,7 @@ import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.cms.OriginatorPublicKey;
 
 /**
- * <a href="http://tools.ietf.org/html/rfc5753">RFC 5753/3278</a>: MQVuserKeyingMaterial object.
+ * <a href="https://tools.ietf.org/html/rfc5753">RFC 5753/3278</a>: MQVuserKeyingMaterial object.
  * <pre>
  * MQVuserKeyingMaterial ::= SEQUENCE {
  *   ephemeralPublicKey OriginatorPublicKey,

--- a/core/src/main/java/org/bouncycastle/asn1/dvcs/DVCSObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/dvcs/DVCSObjectIdentifiers.java
@@ -3,7 +3,7 @@ package org.bouncycastle.asn1.dvcs;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
 /**
- * OIDs for <a href="http://tools.ietf.org/html/rfc3029">RFC 3029</a>
+ * OIDs for <a href="https://tools.ietf.org/html/rfc3029">RFC 3029</a>
  * Data Validation and Certification Server Protocols
  */
 public interface DVCSObjectIdentifiers

--- a/core/src/main/java/org/bouncycastle/asn1/eac/EACObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/eac/EACObjectIdentifiers.java
@@ -5,7 +5,7 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 /**
  * German Federal Office for Information Security
  * (Bundesamt f&uuml;r Sicherheit in der Informationstechnik)
- * <a href="http://www.bsi.bund.de/">http://www.bsi.bund.de/</a>
+ * <a href="https://www.bsi.bund.de/">https://www.bsi.bund.de/</a>
  * <p>
  * <a href="https://www.bsi.bund.de/EN/Publications/TechnicalGuidelines/TR03110/BSITR03110.html">BSI TR-03110</a>
  * Technical Guideline Advanced Security Mechanisms for Machine Readable Travel Documents

--- a/core/src/main/java/org/bouncycastle/asn1/isismtt/x509/AdmissionSyntax.java
+++ b/core/src/main/java/org/bouncycastle/asn1/isismtt/x509/AdmissionSyntax.java
@@ -67,8 +67,8 @@ import org.bouncycastle.asn1.x509.GeneralName;
  * component namingAuthorityId are grouped under the OID-branch
  * id-isis-at-namingAuthorities and must be applied for.
  * <li>See
- * http://www.teletrust.de/anwend.asp?Id=30200&amp;Sprache=E_&amp;HomePG=0 for
- * an application form and http://www.teletrust.de/links.asp?id=30220,11
+ * https://www.teletrust.de/anwend.asp?Id=30200&amp;Sprache=E_&amp;HomePG=0 for
+ * an application form and https://www.teletrust.de/links.asp?id=30220,11
  * for an overview of registered naming authorities.
  * <li> By means of the data type ProfessionInfo certain professions,
  * specializations, disciplines, fields of activity, etc. are identified. A

--- a/core/src/main/java/org/bouncycastle/asn1/kisa/KISAObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/kisa/KISAObjectIdentifiers.java
@@ -6,10 +6,10 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
  * Korea Information Security Agency (KISA)
  * ({iso(1) member-body(2) kr(410) kisa(200004)})
  * <p>
- * See <a href="http://tools.ietf.org/html/rfc4010">RFC 4010</a>
+ * See <a href="https://tools.ietf.org/html/rfc4010">RFC 4010</a>
  * Use of the SEED Encryption Algorithm
  * in Cryptographic Message Syntax (CMS),
- * and <a href="http://tools.ietf.org/html/rfc4269">RFC 4269</a>
+ * and <a href="https://tools.ietf.org/html/rfc4269">RFC 4269</a>
  * The SEED Encryption Algorithm
  */
 public interface KISAObjectIdentifiers

--- a/core/src/main/java/org/bouncycastle/asn1/ntt/NTTObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ntt/NTTObjectIdentifiers.java
@@ -3,7 +3,7 @@ package org.bouncycastle.asn1.ntt;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
 /**
- * From <a href="http://tools.ietf.org/html/rfc3657">RFC 3657</a>
+ * From <a href="https://tools.ietf.org/html/rfc3657">RFC 3657</a>
  * Use of the Camellia Encryption Algorithm
  * in Cryptographic Message Syntax (CMS)
  */

--- a/core/src/main/java/org/bouncycastle/asn1/ocsp/OCSPObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ocsp/OCSPObjectIdentifiers.java
@@ -3,7 +3,7 @@ package org.bouncycastle.asn1.ocsp;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
 /**
- * OIDs for <a href="http://tools.ietf.org/html/rfc2560">RFC 2560</a> and <a href="http://tools.ietf.org/html/rfc6960">RFC 6960</a>
+ * OIDs for <a href="https://tools.ietf.org/html/rfc2560">RFC 2560</a> and <a href="https://tools.ietf.org/html/rfc6960">RFC 6960</a>
  * Online Certificate Status Protocol - OCSP.
  */
 public interface OCSPObjectIdentifiers

--- a/core/src/main/java/org/bouncycastle/asn1/pkcs/PKCSObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/pkcs/PKCSObjectIdentifiers.java
@@ -327,7 +327,7 @@ public interface PKCSObjectIdentifiers
     /** PKCS#9: 1.2.840.113549.1.9.16.2.1 -- smime attribute receiptRequest */
     ASN1ObjectIdentifier id_aa_receiptRequest = id_aa.branch("1");
     
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.4 - See <a href="http://tools.ietf.org/html/rfc2634">RFC 2634</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.4 - See <a href="https://tools.ietf.org/html/rfc2634">RFC 2634</a> */
     ASN1ObjectIdentifier id_aa_contentHint      = id_aa.branch("4"); // See RFC 2634
     /** PKCS#9: 1.2.840.113549.1.9.16.2.5 */
     ASN1ObjectIdentifier id_aa_msgSigDigest     = id_aa.branch("5");
@@ -344,40 +344,40 @@ public interface PKCSObjectIdentifiers
     /** PKCS#9: 1.2.840.113549.1.9.16.2.47 */
     ASN1ObjectIdentifier id_aa_signingCertificateV2 = id_aa.branch("47");
 
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.7 - See <a href="http://tools.ietf.org/html/rfc2634">RFC 2634</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.7 - See <a href="https://tools.ietf.org/html/rfc2634">RFC 2634</a> */
     ASN1ObjectIdentifier id_aa_contentIdentifier = id_aa.branch("7"); // See RFC 2634
 
     /*
      * RFC 3126
      */
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.14 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.14 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_signatureTimeStampToken = id_aa.branch("14");
     
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.15 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.15 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_sigPolicyId = id_aa.branch("15");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.16 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.16 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_commitmentType = id_aa.branch("16");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.17 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.17 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_signerLocation = id_aa.branch("17");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.18 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.18 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_signerAttr = id_aa.branch("18");
-    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.19 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.6.2.19 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_otherSigCert = id_aa.branch("19");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.20 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.20 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_contentTimestamp = id_aa.branch("20");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.21 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.21 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_certificateRefs = id_aa.branch("21");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.22 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.22 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_revocationRefs = id_aa.branch("22");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.23 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.23 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_certValues = id_aa.branch("23");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.24 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.24 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_revocationValues = id_aa.branch("24");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.25 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.25 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_escTimeStamp = id_aa.branch("25");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.26 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.26 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_certCRLTimestamp = id_aa.branch("26");
-    /** PKCS#9: 1.2.840.113549.1.9.16.2.27 - <a href="http://tools.ietf.org/html/rfc3126">RFC 3126</a> */
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.27 - <a href="https://tools.ietf.org/html/rfc3126">RFC 3126</a> */
     ASN1ObjectIdentifier id_aa_ets_archiveTimestamp = id_aa.branch("27");
 
     /** PKCS#9: 1.2.840.113549.1.9.16.2.37 - <a href="https://tools.ietf.org/html/rfc4108#section-2.2.5">RFC 4108</a> */

--- a/core/src/main/java/org/bouncycastle/asn1/teletrust/TeleTrusTNamedCurves.java
+++ b/core/src/main/java/org/bouncycastle/asn1/teletrust/TeleTrusTNamedCurves.java
@@ -15,7 +15,7 @@ import org.bouncycastle.util.encoders.Hex;
 
 /**
  * Elliptic curves defined in "ECC Brainpool Standard Curves and Curve Generation"
- * http://www.ecc-brainpool.org/download/draft_pkix_additional_ecc_dp.txt
+ * https://www.ecc-brainpool.org/download/draft_pkix_additional_ecc_dp.txt
  */
 public class TeleTrusTNamedCurves
 {

--- a/core/src/main/java/org/bouncycastle/asn1/x509/KeyPurposeId.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/KeyPurposeId.java
@@ -123,12 +123,12 @@ public class KeyPurposeId
 
 
     /**
-     * Microsoft Server Gated Crypto (msSGC) see http://www.alvestrand.no/objectid/1.3.6.1.4.1.311.10.3.3.html
+     * Microsoft Server Gated Crypto (msSGC) see https://www.alvestrand.no/objectid/1.3.6.1.4.1.311.10.3.3.html
      */
     public static final KeyPurposeId id_kp_msSGC = new KeyPurposeId(new ASN1ObjectIdentifier("1.3.6.1.4.1.311.10.3.3"));
 
     /**
-     * Netscape Server Gated Crypto (nsSGC) see http://www.alvestrand.no/objectid/2.16.840.1.113730.4.1.html
+     * Netscape Server Gated Crypto (nsSGC) see https://www.alvestrand.no/objectid/2.16.840.1.113730.4.1.html
      */
     public static final KeyPurposeId id_kp_nsSGC = new KeyPurposeId(new ASN1ObjectIdentifier("2.16.840.1.113730.4.1"));
 

--- a/core/src/main/java/org/bouncycastle/asn1/x509/PKIXNameConstraintValidator.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/PKIXNameConstraintValidator.java
@@ -1824,20 +1824,20 @@ public class PKIXNameConstraintValidator
         // see RFC 1738
         // remove ':' after protocol, e.g. http:
         String sub = url.substring(url.indexOf(':') + 1);
-        // extract host from Common Internet Scheme Syntax, e.g. http://
+        // extract host from Common Internet Scheme Syntax, e.g. https://
         if (sub.indexOf("//") != -1)
         {
             sub = sub.substring(sub.indexOf("//") + 2);
         }
-        // first remove port, e.g. http://test.com:21
+        // first remove port, e.g. https://test.com:21
         if (sub.lastIndexOf(':') != -1)
         {
             sub = sub.substring(0, sub.lastIndexOf(':'));
         }
-        // remove user and password, e.g. http://john:password@test.com
+        // remove user and password, e.g. https://john:password@test.com
         sub = sub.substring(sub.indexOf(':') + 1);
         sub = sub.substring(sub.indexOf('@') + 1);
-        // remove local parts, e.g. http://test.com/bla
+        // remove local parts, e.g. https://test.com/bla
         if (sub.indexOf('/') != -1)
         {
             sub = sub.substring(0, sub.indexOf('/'));

--- a/core/src/main/java/org/bouncycastle/asn1/x509/PolicyMappings.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/PolicyMappings.java
@@ -18,7 +18,7 @@ import org.bouncycastle.asn1.DERSequence;
  *      subjectDomainPolicy     CertPolicyId }
  * </pre>
  *
- * @see <a href="http://www.faqs.org/rfc/rfc3280.txt">RFC 3280, section 4.2.1.6</a>
+ * @see <a href="https://www.faqs.org/rfc/rfc3280.txt">RFC 3280, section 4.2.1.6</a>
  */
 public class PolicyMappings
     extends ASN1Object

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/jpake/JPAKEParticipant.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/jpake/JPAKEParticipant.java
@@ -13,7 +13,7 @@ import org.bouncycastle.util.Arrays;
  * A participant in a Password Authenticated Key Exchange by Juggling (J-PAKE) exchange.
  * <p>
  * The J-PAKE exchange is defined by Feng Hao and Peter Ryan in the paper
- * <a href="http://grouper.ieee.org/groups/1363/Research/contributions/hao-ryan-2008.pdf">
+ * <a href="https://grouper.ieee.org/groups/1363/Research/contributions/hao-ryan-2008.pdf">
  * "Password Authenticated Key Exchange by Juggling, 2008."</a>
  * <p>
  * The J-PAKE protocol is symmetric.
@@ -49,7 +49,7 @@ import org.bouncycastle.util.Arrays;
  * These are the trivial techniques to optimize the communication.
  * <p>
  * The key confirmation process is implemented as specified in
- * <a href="http://csrc.nist.gov/publications/nistpubs/800-56A/SP800-56A_Revision1_Mar08-2007.pdf">NIST SP 800-56A Revision 1</a>,
+ * <a href="https://csrc.nist.gov/publications/nistpubs/800-56A/SP800-56A_Revision1_Mar08-2007.pdf">NIST SP 800-56A Revision 1</a>,
  * Section 8.2 Unilateral Key Confirmation for Key Agreement Schemes.
  * <p>
  * This class is stateful and NOT threadsafe.

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/jpake/JPAKEPrimeOrderGroup.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/jpake/JPAKEPrimeOrderGroup.java
@@ -10,7 +10,7 @@ import java.math.BigInteger;
  * <p>
  * See {@link JPAKEPrimeOrderGroups} for convenient standard groups.
  * <p>
- * NIST <a href="http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/DSA2_All.pdf">publishes</a>
+ * NIST <a href="https://csrc.nist.gov/groups/ST/toolkit/documents/Examples/DSA2_All.pdf">publishes</a>
  * many groups that can be used for the desired level of security.
  */
 public class JPAKEPrimeOrderGroup

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/jpake/JPAKEPrimeOrderGroups.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/jpake/JPAKEPrimeOrderGroups.java
@@ -11,7 +11,7 @@ import java.math.BigInteger;
  * <p>
  * The prime order groups below are taken from Sun's JDK JavaDoc (docs/guide/security/CryptoSpec.html#AppB),
  * and from the prime order groups
- * <a href="http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/DSA2_All.pdf">published by NIST</a>.
+ * <a href="https://csrc.nist.gov/groups/ST/toolkit/documents/Examples/DSA2_All.pdf">published by NIST</a>.
  */
 public class JPAKEPrimeOrderGroups
 {

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/jpake/JPAKEUtil.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/jpake/JPAKEUtil.java
@@ -317,7 +317,7 @@ public class JPAKEUtil
 
     /**
      * Calculates the MacTag (to be used for key confirmation), as defined by
-     * <a href="http://csrc.nist.gov/publications/nistpubs/800-56A/SP800-56A_Revision1_Mar08-2007.pdf">NIST SP 800-56A Revision 1</a>,
+     * <a href="https://csrc.nist.gov/publications/nistpubs/800-56A/SP800-56A_Revision1_Mar08-2007.pdf">NIST SP 800-56A Revision 1</a>,
      * Section 8.2 Unilateral Key Confirmation for Key Agreement Schemes.
      * <pre>
      * MacTag = HMAC(MacKey, MacLen, MacData)

--- a/core/src/main/java/org/bouncycastle/crypto/digests/KeccakDigest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/KeccakDigest.java
@@ -5,7 +5,7 @@ import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.Pack;
 
 /**
- * implementation of Keccak based on following KeccakNISTInterface.c from http://keccak.noekeon.org/
+ * implementation of Keccak based on following KeccakNISTInterface.c from https://keccak.noekeon.org/
  * <p>
  * Following the naming conventions used in the C source code to enable easy review of the implementation.
  */

--- a/core/src/main/java/org/bouncycastle/crypto/digests/RIPEMD160Digest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/RIPEMD160Digest.java
@@ -5,7 +5,7 @@ import org.bouncycastle.util.Memoable;
 
 /**
  * implementation of RIPEMD see,
- * http://www.esat.kuleuven.ac.be/~bosselae/ripemd160.html
+ * https://www.esat.kuleuven.ac.be/~bosselae/ripemd160.html
  */
 public class RIPEMD160Digest
     extends GeneralDigest

--- a/core/src/main/java/org/bouncycastle/crypto/digests/SHA3Digest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/SHA3Digest.java
@@ -2,7 +2,7 @@ package org.bouncycastle.crypto.digests;
 
 
 /**
- * implementation of SHA-3 based on following KeccakNISTInterface.c from http://keccak.noekeon.org/
+ * implementation of SHA-3 based on following KeccakNISTInterface.c from https://keccak.noekeon.org/
  * <p>
  * Following the naming conventions used in the C source code to enable easy review of the implementation.
  */

--- a/core/src/main/java/org/bouncycastle/crypto/digests/SHAKEDigest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/SHAKEDigest.java
@@ -4,7 +4,7 @@ import org.bouncycastle.crypto.Xof;
 
 
 /**
- * implementation of SHAKE based on following KeccakNISTInterface.c from http://keccak.noekeon.org/
+ * implementation of SHAKE based on following KeccakNISTInterface.c from https://keccak.noekeon.org/
  * <p>
  * Following the naming conventions used in the C source code to enable easy review of the implementation.
  */

--- a/core/src/main/java/org/bouncycastle/crypto/digests/SM3Digest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/SM3Digest.java
@@ -5,7 +5,7 @@ import org.bouncycastle.util.Pack;
 
 /**
  * Implementation of Chinese SM3 digest as described at
- * http://tools.ietf.org/html/draft-shen-sm3-hash-01
+ * https://tools.ietf.org/html/draft-shen-sm3-hash-01
  * and at .... ( Chinese PDF )
  * <p>
  * The specification says "process a bit stream",

--- a/core/src/main/java/org/bouncycastle/crypto/digests/TigerDigest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/TigerDigest.java
@@ -5,8 +5,8 @@ import org.bouncycastle.util.Memoable;
 
 /**
  * implementation of Tiger based on:
- * <a href="http://www.cs.technion.ac.il/~biham/Reports/Tiger">
- *  http://www.cs.technion.ac.il/~biham/Reports/Tiger</a>
+ * <a href="https://www.cs.technion.ac.il/~biham/Reports/Tiger">
+ *  https://www.cs.technion.ac.il/~biham/Reports/Tiger</a>
  */
 public class TigerDigest
     implements ExtendedDigest, Memoable

--- a/core/src/main/java/org/bouncycastle/crypto/engines/AESEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/AESEngine.java
@@ -11,10 +11,10 @@ import org.bouncycastle.util.Pack;
 /**
  * an implementation of the AES (Rijndael), from FIPS-197.
  * <p>
- * For further details see: <a href="http://csrc.nist.gov/encryption/aes/">http://csrc.nist.gov/encryption/aes/</a>.
+ * For further details see: <a href="https://csrc.nist.gov/encryption/aes/">https://csrc.nist.gov/encryption/aes/</a>.
  *
  * This implementation is based on optimizations from Dr. Brian Gladman's paper and C code at
- * <a href="http://fp.gladman.plus.com/cryptography_technology/rijndael/">http://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
+ * <a href="https://fp.gladman.plus.com/cryptography_technology/rijndael/">https://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
  *
  * There are three levels of tradeoff of speed vs memory
  * Because java has no preprocessor, they are written as three separate classes from which to choose

--- a/core/src/main/java/org/bouncycastle/crypto/engines/AESFastEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/AESFastEngine.java
@@ -10,10 +10,10 @@ import org.bouncycastle.util.Pack;
 /**
  * an implementation of the AES (Rijndael), from FIPS-197.
  * <p>
- * For further details see: <a href="http://csrc.nist.gov/encryption/aes/">http://csrc.nist.gov/encryption/aes/</a>.
+ * For further details see: <a href="https://csrc.nist.gov/encryption/aes/">https://csrc.nist.gov/encryption/aes/</a>.
  *
  * This implementation is based on optimizations from Dr. Brian Gladman's paper and C code at
- * <a href="http://fp.gladman.plus.com/cryptography_technology/rijndael/">http://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
+ * <a href="https://fp.gladman.plus.com/cryptography_technology/rijndael/">https://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
  *
  * There are three levels of tradeoff of speed vs memory
  * Because java has no preprocessor, they are written as three separate classes from which to choose

--- a/core/src/main/java/org/bouncycastle/crypto/engines/AESLightEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/AESLightEngine.java
@@ -10,10 +10,10 @@ import org.bouncycastle.util.Pack;
 /**
  * an implementation of the AES (Rijndael), from FIPS-197.
  * <p>
- * For further details see: <a href="http://csrc.nist.gov/encryption/aes/">http://csrc.nist.gov/encryption/aes/</a>.
+ * For further details see: <a href="https://csrc.nist.gov/encryption/aes/">https://csrc.nist.gov/encryption/aes/</a>.
  *
  * This implementation is based on optimizations from Dr. Brian Gladman's paper and C code at
- * <a href="http://fp.gladman.plus.com/cryptography_technology/rijndael/">http://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
+ * <a href="https://fp.gladman.plus.com/cryptography_technology/rijndael/">https://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
  *
  * There are three levels of tradeoff of speed vs memory
  * Because java has no preprocessor, they are written as three separate classes from which to choose

--- a/core/src/main/java/org/bouncycastle/crypto/engines/AESWrapEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/AESWrapEngine.java
@@ -4,7 +4,7 @@ package org.bouncycastle.crypto.engines;
  * an implementation of the AES Key Wrapper from the NIST Key Wrap
  * Specification.
  * <p>
- * For further details see: <a href="http://csrc.nist.gov/encryption/kms/key-wrap.pdf">http://csrc.nist.gov/encryption/kms/key-wrap.pdf</a>.
+ * For further details see: <a href="https://csrc.nist.gov/encryption/kms/key-wrap.pdf">https://csrc.nist.gov/encryption/kms/key-wrap.pdf</a>.
  */
 public class AESWrapEngine
     extends RFC3394WrapEngine

--- a/core/src/main/java/org/bouncycastle/crypto/engines/ARIAWrapEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/ARIAWrapEngine.java
@@ -4,7 +4,7 @@ package org.bouncycastle.crypto.engines;
  * an implementation of the ARIA Key Wrapper from the NIST Key Wrap
  * Specification.
  * <p>
- * For further details see: <a href="http://csrc.nist.gov/encryption/kms/key-wrap.pdf">http://csrc.nist.gov/encryption/kms/key-wrap.pdf</a>.
+ * For further details see: <a href="https://csrc.nist.gov/encryption/kms/key-wrap.pdf">https://csrc.nist.gov/encryption/kms/key-wrap.pdf</a>.
  */
 public class ARIAWrapEngine
     extends RFC3394WrapEngine

--- a/core/src/main/java/org/bouncycastle/crypto/engines/CamelliaWrapEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/CamelliaWrapEngine.java
@@ -3,7 +3,7 @@ package org.bouncycastle.crypto.engines;
 /**
  * An implementation of the Camellia key wrapper based on RFC 3657/RFC 3394.
  * <p>
- * For further details see: <a href="http://www.ietf.org/rfc/rfc3657.txt">http://www.ietf.org/rfc/rfc3657.txt</a>.
+ * For further details see: <a href="https://www.ietf.org/rfc/rfc3657.txt">https://www.ietf.org/rfc/rfc3657.txt</a>.
  */
 public class CamelliaWrapEngine
     extends RFC3394WrapEngine

--- a/core/src/main/java/org/bouncycastle/crypto/engines/DESedeWrapEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/DESedeWrapEngine.java
@@ -305,7 +305,7 @@ public class DESedeWrapEngine
      * - Compute the 20 octet SHA-1 hash on the key being wrapped.
      * - Use the first 8 octets of this hash as the checksum value.
      *
-     * For details see http://www.w3.org/TR/xmlenc-core/#sec-CMSKeyChecksum.
+     * For details see https://www.w3.org/TR/xmlenc-core/#sec-CMSKeyChecksum.
      *
      * @param key the key to check,
      * @return the CMS checksum.
@@ -325,7 +325,7 @@ public class DESedeWrapEngine
     }
 
     /**
-     * For details see http://www.w3.org/TR/xmlenc-core/#sec-CMSKeyChecksum
+     * For details see https://www.w3.org/TR/xmlenc-core/#sec-CMSKeyChecksum
      *
      * @param key key to be validated.
      * @param checksum the checksum.

--- a/core/src/main/java/org/bouncycastle/crypto/engines/GOST28147Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/GOST28147Engine.java
@@ -39,8 +39,8 @@ public class GOST28147Engine
     
     /*
      * class content S-box parameters for encrypting
-     * getting from, see: http://tools.ietf.org/id/draft-popov-cryptopro-cpalgs-01.txt
-     *                    http://tools.ietf.org/id/draft-popov-cryptopro-cpalgs-02.txt
+     * getting from, see: https://tools.ietf.org/id/draft-popov-cryptopro-cpalgs-01.txt
+     *                    https://tools.ietf.org/id/draft-popov-cryptopro-cpalgs-02.txt
      */
     private static byte[] ESbox_Test = {
          0x4,0x2,0xF,0x5,0x9,0x1,0x0,0x8,0xE,0x3,0xB,0xC,0xD,0x7,0xA,0x6,

--- a/core/src/main/java/org/bouncycastle/crypto/engines/HC128Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/HC128Engine.java
@@ -12,12 +12,12 @@ import org.bouncycastle.crypto.params.ParametersWithIV;
  * generates keystream from a 128-bit secret key and a 128-bit initialization
  * vector.
  * <p>
- * http://www.ecrypt.eu.org/stream/p3ciphers/hc/hc128_p3.pdf
+ * https://www.ecrypt.eu.org/stream/p3ciphers/hc/hc128_p3.pdf
  * </p><p>
  * It is a third phase candidate in the eStream contest, and is patent-free.
  * No attacks are known as of today (April 2007). See
  *
- * http://www.ecrypt.eu.org/stream/hcp3.html
+ * https://www.ecrypt.eu.org/stream/hcp3.html
  * </p>
  */
 public class HC128Engine

--- a/core/src/main/java/org/bouncycastle/crypto/engines/HC256Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/HC256Engine.java
@@ -12,13 +12,13 @@ import org.bouncycastle.crypto.params.ParametersWithIV;
  * generates keystream from a 256-bit secret key and a 256-bit initialization 
  * vector.
  * <p>
- * http://www.ecrypt.eu.org/stream/p3ciphers/hc/hc256_p3.pdf
+ * https://www.ecrypt.eu.org/stream/p3ciphers/hc/hc256_p3.pdf
  * </p><p>
  * Its brother, HC-128, is a third phase candidate in the eStream contest.
  * The algorithm is patent-free. No attacks are known as of today (April 2007). 
  * See
  * 
- * http://www.ecrypt.eu.org/stream/hcp3.html
+ * https://www.ecrypt.eu.org/stream/hcp3.html
  * </p>
  */
 public class HC256Engine

--- a/core/src/main/java/org/bouncycastle/crypto/engines/ISAACEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/ISAACEngine.java
@@ -9,7 +9,7 @@ import org.bouncycastle.util.Pack;
 
 /**
  * Implementation of Bob Jenkin's ISAAC (Indirection Shift Accumulate Add and Count).
- * see: http://www.burtleburtle.net/bob/rand/isaacafa.html
+ * see: https://www.burtleburtle.net/bob/rand/isaacafa.html
 */
 public class ISAACEngine
     implements StreamCipher

--- a/core/src/main/java/org/bouncycastle/crypto/engines/NaccacheSternEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/NaccacheSternEngine.java
@@ -14,7 +14,7 @@ import org.bouncycastle.crypto.params.ParametersWithRandom;
 
 /**
  * NaccacheStern Engine. For details on this cipher, please see
- * http://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
+ * https://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
  */
 public class NaccacheSternEngine
     implements AsymmetricBlockCipher

--- a/core/src/main/java/org/bouncycastle/crypto/engines/RC2WrapEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/RC2WrapEngine.java
@@ -351,7 +351,7 @@ public class RC2WrapEngine
      * - Compute the 20 octet SHA-1 hash on the key being wrapped.
      * - Use the first 8 octets of this hash as the checksum value.
      *
-     * For details see  http://www.w3.org/TR/xmlenc-core/#sec-CMSKeyChecksum
+     * For details see  https://www.w3.org/TR/xmlenc-core/#sec-CMSKeyChecksum
      */
     private byte[] calculateCMSKeyChecksum(
         byte[] key)
@@ -367,7 +367,7 @@ public class RC2WrapEngine
     }
 
     /*
-     * For details see  http://www.w3.org/TR/xmlenc-core/#sec-CMSKeyChecksum
+     * For details see  https://www.w3.org/TR/xmlenc-core/#sec-CMSKeyChecksum
      */
     private boolean checkCMSKeyChecksum(
         byte[] key,

--- a/core/src/main/java/org/bouncycastle/crypto/engines/RC532Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/RC532Engine.java
@@ -8,7 +8,7 @@ import org.bouncycastle.crypto.params.RC5Parameters;
 /**
  * The specification for RC5 came from the <code>RC5 Encryption Algorithm</code>
  * publication in RSA CryptoBytes, Spring of 1995. 
- * <em>http://www.rsasecurity.com/rsalabs/cryptobytes</em>.
+ * <em>https://www.rsasecurity.com/rsalabs/cryptobytes</em>.
  * <p>
  * This implementation has a word size of 32 bits.
  * <p>

--- a/core/src/main/java/org/bouncycastle/crypto/engines/RC564Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/RC564Engine.java
@@ -7,7 +7,7 @@ import org.bouncycastle.crypto.params.RC5Parameters;
 /**
  * The specification for RC5 came from the <code>RC5 Encryption Algorithm</code>
  * publication in RSA CryptoBytes, Spring of 1995. 
- * <em>http://www.rsasecurity.com/rsalabs/cryptobytes</em>.
+ * <em>https://www.rsasecurity.com/rsalabs/cryptobytes</em>.
  * <p>
  * This implementation is set to work with a 64 bit word size.
  * <p>

--- a/core/src/main/java/org/bouncycastle/crypto/engines/RFC3394WrapEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/RFC3394WrapEngine.java
@@ -14,8 +14,8 @@ import org.bouncycastle.util.Arrays;
  * an implementation of the AES Key Wrapper from the NIST Key Wrap
  * Specification as described in RFC 3394.
  * <p>
- * For further details see: <a href="http://www.ietf.org/rfc/rfc3394.txt">http://www.ietf.org/rfc/rfc3394.txt</a>
- * and  <a href="http://csrc.nist.gov/encryption/kms/key-wrap.pdf">http://csrc.nist.gov/encryption/kms/key-wrap.pdf</a>.
+ * For further details see: <a href="https://www.ietf.org/rfc/rfc3394.txt">https://www.ietf.org/rfc/rfc3394.txt</a>
+ * and  <a href="https://csrc.nist.gov/encryption/kms/key-wrap.pdf">https://csrc.nist.gov/encryption/kms/key-wrap.pdf</a>.
  */
 public class RFC3394WrapEngine
     implements Wrapper

--- a/core/src/main/java/org/bouncycastle/crypto/engines/SEEDWrapEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/SEEDWrapEngine.java
@@ -3,7 +3,7 @@ package org.bouncycastle.crypto.engines;
 /**
  * An implementation of the SEED key wrapper based on RFC 4010/RFC 3394.
  * <p>
- * For further details see: <a href="http://www.ietf.org/rfc/rfc4010.txt">http://www.ietf.org/rfc/rfc4010.txt</a>.
+ * For further details see: <a href="https://www.ietf.org/rfc/rfc4010.txt">https://www.ietf.org/rfc/rfc4010.txt</a>.
  */
 public class SEEDWrapEngine
     extends RFC3394WrapEngine

--- a/core/src/main/java/org/bouncycastle/crypto/engines/SM4Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/SM4Engine.java
@@ -10,7 +10,7 @@ import org.bouncycastle.util.Pack;
 /**
  * SM4 Block Cipher - SM4 is a 128 bit block cipher with a 128 bit key.
  * <p>
- *     The implementation here is based on the document <a href="http://eprint.iacr.org/2008/329.pdf">http://eprint.iacr.org/2008/329.pdf</a>
+ *     The implementation here is based on the document <a href="https://eprint.iacr.org/2008/329.pdf">https://eprint.iacr.org/2008/329.pdf</a>
  *     by Whitfield Diffie and George Ledin, which is a translation of Prof. LU Shu-wang's original standard.
  * </p>
  */

--- a/core/src/main/java/org/bouncycastle/crypto/engines/SerpentEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/SerpentEngine.java
@@ -10,7 +10,7 @@ import org.bouncycastle.util.Pack;
  * Serpent was designed by Ross Anderson, Eli Biham and Lars Knudsen as a
  * candidate algorithm for the NIST AES Quest.
  * <p>
- * For full details see <a href="http://www.cl.cam.ac.uk/~rja14/serpent.html">The Serpent home page</a>
+ * For full details see <a href="https://www.cl.cam.ac.uk/~rja14/serpent.html">The Serpent home page</a>
  */
 public final class SerpentEngine
     extends SerpentEngineBase

--- a/core/src/main/java/org/bouncycastle/crypto/engines/SerpentEngineBase.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/SerpentEngineBase.java
@@ -125,7 +125,7 @@ public abstract class SerpentEngineBase
      * Sam Simpson, whose original notice appears below.
      * <p>
      * For further details see:
-     *      http://fp.gladman.plus.com/cryptography_technology/serpent/
+     *      https://fp.gladman.plus.com/cryptography_technology/serpent/
      */
 
     /* Partially optimised Serpent S Box boolean functions derived  */

--- a/core/src/main/java/org/bouncycastle/crypto/engines/Shacal2Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/Shacal2Engine.java
@@ -13,7 +13,7 @@ import org.bouncycastle.util.encoders.Hex;
  * using SHA-256-Initialization-Values as data and SHA-256-Data as key.
  * <p>
  * A description of Shacal can be found at:
- *    http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.3.4066
+ *    https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.3.4066
  * Best known cryptanalytic (Wikipedia 11.2013):
  *    Related-key rectangle attack on 44-rounds (Jiqiang Lu, Jongsung Kim).
  * Comments are related to SHA-256-Naming as described in FIPS PUB 180-2

--- a/core/src/main/java/org/bouncycastle/crypto/engines/TnepresEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/TnepresEngine.java
@@ -12,7 +12,7 @@ import org.bouncycastle.util.Pack;
  * with test vectors in the AES submission and the resulting confusion lead to the Tnepres cipher
  * as well, which is a byte swapped version of Serpent.
  * <p>
- * For full details see <a href="http://www.cl.cam.ac.uk/~rja14/serpent.html">The Serpent home page</a>
+ * For full details see <a href="https://www.cl.cam.ac.uk/~rja14/serpent.html">The Serpent home page</a>
  */
 public final class TnepresEngine
     extends SerpentEngineBase

--- a/core/src/main/java/org/bouncycastle/crypto/engines/Zuc128Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/Zuc128Engine.java
@@ -4,7 +4,7 @@ import org.bouncycastle.util.Memoable;
 
 /**
  * Zuc256 implementation.
- * Based on http://www.is.cas.cn/ztzl2016/zouchongzhi/201801/W020180126529970733243.pdf
+ * Based on https://www.is.cas.cn/ztzl2016/zouchongzhi/201801/W020180126529970733243.pdf
  */
 public final class Zuc128Engine
     extends Zuc128CoreEngine

--- a/core/src/main/java/org/bouncycastle/crypto/engines/Zuc256CoreEngine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/Zuc256CoreEngine.java
@@ -4,7 +4,7 @@ import org.bouncycastle.util.Memoable;
 
 /**
  * Zuc256 implementation.
- * Based on http://www.is.cas.cn/ztzl2016/zouchongzhi/201801/W020180126529970733243.pdf
+ * Based on https://www.is.cas.cn/ztzl2016/zouchongzhi/201801/W020180126529970733243.pdf
  */
 public class Zuc256CoreEngine
     extends Zuc128CoreEngine

--- a/core/src/main/java/org/bouncycastle/crypto/engines/Zuc256Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/engines/Zuc256Engine.java
@@ -4,7 +4,7 @@ import org.bouncycastle.util.Memoable;
 
 /**
  * Zuc256 implementation.
- * Based on http://www.is.cas.cn/ztzl2016/zouchongzhi/201801/W020180126529970733243.pdf
+ * Based on https://www.is.cas.cn/ztzl2016/zouchongzhi/201801/W020180126529970733243.pdf
  */
 public final class Zuc256Engine
     extends Zuc256CoreEngine

--- a/core/src/main/java/org/bouncycastle/crypto/generators/NaccacheSternKeyPairGenerator.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/NaccacheSternKeyPairGenerator.java
@@ -15,7 +15,7 @@ import org.bouncycastle.util.BigIntegers;
 /**
  * Key generation parameters for NaccacheStern cipher. For details on this cipher, please see
  * 
- * http://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
+ * https://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
  */
 public class NaccacheSternKeyPairGenerator 
     implements AsymmetricCipherKeyPairGenerator 

--- a/core/src/main/java/org/bouncycastle/crypto/generators/PKCS12ParametersGenerator.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/PKCS12ParametersGenerator.java
@@ -11,7 +11,7 @@ import org.bouncycastle.crypto.params.ParametersWithIV;
  * Generator for PBE derived keys and ivs as defined by PKCS 12 V1.0.
  * <p>
  * The document this implementation is based on can be found at
- * <a href=http://www.rsasecurity.com/rsalabs/pkcs/pkcs-12/index.html>
+ * <a href=https://www.rsasecurity.com/rsalabs/pkcs/pkcs-12/index.html>
  * RSA's PKCS12 Page</a>
  */
 public class PKCS12ParametersGenerator

--- a/core/src/main/java/org/bouncycastle/crypto/generators/PKCS5S1ParametersGenerator.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/PKCS5S1ParametersGenerator.java
@@ -12,7 +12,7 @@ import org.bouncycastle.crypto.params.ParametersWithIV;
  * digest used to drive it.
  * <p>
  * The document this implementation is based on can be found at
- * <a href=http://www.rsasecurity.com/rsalabs/pkcs/pkcs-5/index.html>
+ * <a href=https://www.rsasecurity.com/rsalabs/pkcs/pkcs-5/index.html>
  * RSA's PKCS5 Page</a>
  */
 public class PKCS5S1ParametersGenerator

--- a/core/src/main/java/org/bouncycastle/crypto/generators/PKCS5S2ParametersGenerator.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/PKCS5S2ParametersGenerator.java
@@ -14,7 +14,7 @@ import org.bouncycastle.crypto.util.DigestFactory;
  * This generator uses a SHA-1 HMac as the calculation function.
  * <p>
  * The document this implementation is based on can be found at
- * <a href=http://www.rsasecurity.com/rsalabs/pkcs/pkcs-5/index.html>
+ * <a href=https://www.rsasecurity.com/rsalabs/pkcs/pkcs-5/index.html>
  * RSA's PKCS5 Page</a>
  */
 public class PKCS5S2ParametersGenerator

--- a/core/src/main/java/org/bouncycastle/crypto/macs/Zuc128Mac.java
+++ b/core/src/main/java/org/bouncycastle/crypto/macs/Zuc128Mac.java
@@ -6,7 +6,7 @@ import org.bouncycastle.crypto.engines.Zuc128CoreEngine;
 
 /**
  * Zuc128 Mac implementation.
- * Based on http://www.qtc.jp/3GPP/Specs/eea3eia3specificationv16.pdf
+ * Based on https://www.qtc.jp/3GPP/Specs/eea3eia3specificationv16.pdf
  */
 public final class Zuc128Mac
     implements Mac

--- a/core/src/main/java/org/bouncycastle/crypto/macs/Zuc256Mac.java
+++ b/core/src/main/java/org/bouncycastle/crypto/macs/Zuc256Mac.java
@@ -6,7 +6,7 @@ import org.bouncycastle.crypto.engines.Zuc256CoreEngine;
 
 /**
  * Zuc256 Mac implementation.
- * Based on http://www.is.cas.cn/ztzl2016/zouchongzhi/201801/W020180126529970733243.pdf
+ * Based on https://www.is.cas.cn/ztzl2016/zouchongzhi/201801/W020180126529970733243.pdf
  */
 public final class Zuc256Mac
     implements Mac

--- a/core/src/main/java/org/bouncycastle/crypto/modes/EAXBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/EAXBlockCipher.java
@@ -15,7 +15,7 @@ import org.bouncycastle.util.Arrays;
  * A Two-Pass Authenticated-Encryption Scheme Optimized for Simplicity and
  * Efficiency - by M. Bellare, P. Rogaway, D. Wagner.
  *
- * http://www.cs.ucdavis.edu/~rogaway/papers/eax.pdf
+ * https://www.cs.ucdavis.edu/~rogaway/papers/eax.pdf
  *
  * EAX is an AEAD scheme based on CTR and OMAC1/CMAC, that uses a single block
  * cipher to encrypt and authenticate data. It's on-line (the length of a

--- a/core/src/main/java/org/bouncycastle/crypto/modes/G3413CBCBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/G3413CBCBlockCipher.java
@@ -8,7 +8,7 @@ import org.bouncycastle.util.Arrays;
 
 /**
  * An implementation of the CBC mode for GOST 3412 2015 cipher.
- * See  <a href="http://www.tc26.ru/standard/gost/GOST_R_3413-2015.pdf">GOST R 3413 2015</a>
+ * See  <a href="https://www.tc26.ru/standard/gost/GOST_R_3413-2015.pdf">GOST R 3413 2015</a>
  */
 public class G3413CBCBlockCipher
     implements BlockCipher

--- a/core/src/main/java/org/bouncycastle/crypto/modes/G3413CFBBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/G3413CFBBlockCipher.java
@@ -9,7 +9,7 @@ import org.bouncycastle.util.Arrays;
 
 /**
  * An implementation of the CFB mode for GOST 3412 2015 cipher.
- * See  <a href="http://www.tc26.ru/standard/gost/GOST_R_3413-2015.pdf">GOST R 3413 2015</a>
+ * See  <a href="https://www.tc26.ru/standard/gost/GOST_R_3413-2015.pdf">GOST R 3413 2015</a>
  */
 public class G3413CFBBlockCipher
     extends StreamBlockCipher

--- a/core/src/main/java/org/bouncycastle/crypto/modes/G3413OFBBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/G3413OFBBlockCipher.java
@@ -9,7 +9,7 @@ import org.bouncycastle.util.Arrays;
 
 /**
  * An implementation of the OFB mode for GOST 3412 2015 cipher.
- * See  <a href="http://www.tc26.ru/standard/gost/GOST_R_3413-2015.pdf">GOST R 3413 2015</a>
+ * See  <a href="https://www.tc26.ru/standard/gost/GOST_R_3413-2015.pdf">GOST R 3413 2015</a>
  */
 public class G3413OFBBlockCipher
     extends StreamBlockCipher

--- a/core/src/main/java/org/bouncycastle/crypto/modes/OCBBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/OCBBlockCipher.java
@@ -13,10 +13,10 @@ import org.bouncycastle.crypto.params.ParametersWithIV;
 import org.bouncycastle.util.Arrays;
 
 /**
- * An implementation of <a href="http://tools.ietf.org/html/rfc7253">RFC 7253 on The OCB
+ * An implementation of <a href="https://tools.ietf.org/html/rfc7253">RFC 7253 on The OCB
  * Authenticated-Encryption Algorithm</a>, licensed per:
  * <p>
- * <blockquote> <a href="http://www.cs.ucdavis.edu/~rogaway/ocb/license1.pdf">License for
+ * <blockquote> <a href="https://www.cs.ucdavis.edu/~rogaway/ocb/license1.pdf">License for
  * Open-Source Software Implementations of OCB</a> (Jan 9, 2013) &mdash; &ldquo;License 1&rdquo; <br>
  * Under this license, you are authorized to make, use, and distribute open-source software
  * implementations of OCB. This license terminates for you if you sue someone over their open-source

--- a/core/src/main/java/org/bouncycastle/crypto/modes/OpenPGPCFBBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/OpenPGPCFBBlockCipher.java
@@ -11,7 +11,7 @@ import org.bouncycastle.crypto.OutputLengthException;
  * to the data stream already, and just accomodates the reset after
  * (blockSize + 2) bytes have been read.
  * <p>
- * For further info see <a href="http://www.ietf.org/rfc/rfc2440.html">RFC 2440</a>.
+ * For further info see <a href="https://www.ietf.org/rfc/rfc2440.html">RFC 2440</a>.
  */
 public class OpenPGPCFBBlockCipher
     implements BlockCipher

--- a/core/src/main/java/org/bouncycastle/crypto/modes/PGPCFBBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/PGPCFBBlockCipher.java
@@ -7,7 +7,7 @@ import org.bouncycastle.crypto.OutputLengthException;
 import org.bouncycastle.crypto.params.ParametersWithIV;
 
 /**
- * Implements OpenPGP's rather strange version of Cipher-FeedBack (CFB) mode on top of a simple cipher. For further info see <a href="http://www.ietf.org/rfc/rfc2440.html">RFC 2440</a>.
+ * Implements OpenPGP's rather strange version of Cipher-FeedBack (CFB) mode on top of a simple cipher. For further info see <a href="https://www.ietf.org/rfc/rfc2440.html">RFC 2440</a>.
  */
 public class PGPCFBBlockCipher
     implements BlockCipher

--- a/core/src/main/java/org/bouncycastle/crypto/params/DESParameters.java
+++ b/core/src/main/java/org/bouncycastle/crypto/params/DESParameters.java
@@ -52,7 +52,7 @@ public class DESParameters
      * if the given DES key material is weak or semi-weak.
      * Key material that is too short is regarded as weak.
      * <p>
-     * See <a href="http://www.counterpane.com/applied.html">"Applied
+     * See <a href="https://www.counterpane.com/applied.html">"Applied
      * Cryptography"</a> by Bruce Schneier for more information.
      *
      * @return true if the given DES key material is weak or semi-weak,

--- a/core/src/main/java/org/bouncycastle/crypto/params/NaccacheSternKeyGenerationParameters.java
+++ b/core/src/main/java/org/bouncycastle/crypto/params/NaccacheSternKeyGenerationParameters.java
@@ -8,7 +8,7 @@ import org.bouncycastle.crypto.KeyGenerationParameters;
  * Parameters for NaccacheStern public private key generation. For details on
  * this cipher, please see
  * 
- * http://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
+ * https://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
  */
 public class NaccacheSternKeyGenerationParameters extends KeyGenerationParameters
 {

--- a/core/src/main/java/org/bouncycastle/crypto/params/NaccacheSternKeyParameters.java
+++ b/core/src/main/java/org/bouncycastle/crypto/params/NaccacheSternKeyParameters.java
@@ -6,7 +6,7 @@ import java.math.BigInteger;
  * Public key parameters for NaccacheStern cipher. For details on this cipher,
  * please see
  * 
- * http://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
+ * https://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
  */
 public class NaccacheSternKeyParameters extends AsymmetricKeyParameter
 {

--- a/core/src/main/java/org/bouncycastle/crypto/params/NaccacheSternPrivateKeyParameters.java
+++ b/core/src/main/java/org/bouncycastle/crypto/params/NaccacheSternPrivateKeyParameters.java
@@ -7,7 +7,7 @@ import java.util.Vector;
  * Private key parameters for NaccacheStern cipher. For details on this cipher,
  * please see
  * 
- * http://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
+ * https://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
  */
 public class NaccacheSternPrivateKeyParameters extends NaccacheSternKeyParameters 
 {

--- a/core/src/main/java/org/bouncycastle/pqc/crypto/ntru/NTRUSigner.java
+++ b/core/src/main/java/org/bouncycastle/pqc/crypto/ntru/NTRUSigner.java
@@ -10,8 +10,8 @@ import org.bouncycastle.pqc.math.ntru.polynomial.Polynomial;
 /**
 * Signs, verifies data and generates key pairs.
 * @deprecated the NTRUSigner algorithm was broken in 2012 by Ducas and Nguyen. See
-* <a href="http://www.di.ens.fr/~ducas/NTRUSign_Cryptanalysis/DucasNguyen_Learning.pdf">
-* http://www.di.ens.fr/~ducas/NTRUSign_Cryptanalysis/DucasNguyen_Learning.pdf</a>
+* <a href="https://www.di.ens.fr/~ducas/NTRUSign_Cryptanalysis/DucasNguyen_Learning.pdf">
+* https://www.di.ens.fr/~ducas/NTRUSign_Cryptanalysis/DucasNguyen_Learning.pdf</a>
 * for details.
 */
 public class NTRUSigner

--- a/core/src/main/java/org/bouncycastle/pqc/crypto/rainbow/Layer.java
+++ b/core/src/main/java/org/bouncycastle/pqc/crypto/rainbow/Layer.java
@@ -20,7 +20,7 @@ import org.bouncycastle.util.Arrays;
  * <p>
  * More information about the layer can be found in the paper of Jintai Ding,
  * Dieter Schmidt: Rainbow, a New Multivariable Polynomial Signature Scheme.
- * ACNS 2005: 164-175 (http://dx.doi.org/10.1007/11496137_12)
+ * ACNS 2005: 164-175 (https://dx.doi.org/10.1007/11496137_12)
  */
 public class Layer
 {

--- a/core/src/main/java/org/bouncycastle/pqc/crypto/rainbow/RainbowKeyPairGenerator.java
+++ b/core/src/main/java/org/bouncycastle/pqc/crypto/rainbow/RainbowKeyPairGenerator.java
@@ -16,7 +16,7 @@ import org.bouncycastle.pqc.crypto.rainbow.util.GF2Field;
  * <p>
  * Detailed information about the key generation is to be found in the paper of
  * Jintai Ding, Dieter Schmidt: Rainbow, a New Multivariable Polynomial
- * Signature Scheme. ACNS 2005: 164-175 (http://dx.doi.org/10.1007/11496137_12)
+ * Signature Scheme. ACNS 2005: 164-175 (https://dx.doi.org/10.1007/11496137_12)
  */
 public class RainbowKeyPairGenerator
     implements AsymmetricCipherKeyPairGenerator

--- a/core/src/main/java/org/bouncycastle/pqc/crypto/rainbow/RainbowSigner.java
+++ b/core/src/main/java/org/bouncycastle/pqc/crypto/rainbow/RainbowSigner.java
@@ -17,7 +17,7 @@ import org.bouncycastle.pqc.crypto.rainbow.util.GF2Field;
  * Detailed information about the signature and the verify-method is to be found
  * in the paper of Jintai Ding, Dieter Schmidt: Rainbow, a New Multivariable
  * Polynomial Signature Scheme. ACNS 2005: 164-175
- * (http://dx.doi.org/10.1007/11496137_12)
+ * (https://dx.doi.org/10.1007/11496137_12)
  */
 public class RainbowSigner
     implements MessageSigner

--- a/core/src/main/java/org/bouncycastle/pqc/math/linearalgebra/GF2nONBElement.java
+++ b/core/src/main/java/org/bouncycastle/pqc/math/linearalgebra/GF2nONBElement.java
@@ -1116,7 +1116,7 @@ public class GF2nONBElement
 
     /**
      * Returns this element as FlexiBigInt. The conversion is <a href =
-     * "http://grouper.ieee.org/groups/1363/">P1363</a>-conform.
+     * "https://grouper.ieee.org/groups/1363/">P1363</a>-conform.
      *
      * @return this element as BigInteger
      */
@@ -1129,7 +1129,7 @@ public class GF2nONBElement
 
     /**
      * Returns this element as byte array. The conversion is <a href =
-     * "http://grouper.ieee.org/groups/1363/">P1363</a>-conform.
+     * "https://grouper.ieee.org/groups/1363/">P1363</a>-conform.
      *
      * @return this element as byte array
      */

--- a/core/src/main/java/org/bouncycastle/pqc/math/linearalgebra/GF2nONBField.java
+++ b/core/src/main/java/org/bouncycastle/pqc/math/linearalgebra/GF2nONBField.java
@@ -10,7 +10,7 @@ import java.util.Vector;
  * This class implements the abstract class <tt>GF2nField</tt> for ONB
  * representation. It computes the fieldpolynomial, multiplication matrix and
  * one of its roots mONBRoot, (see for example <a
- * href=http://www2.certicom.com/ecc/intro.htm>Certicoms Whitepapers</a>).
+ * href=https://www2.certicom.com/ecc/intro.htm>Certicoms Whitepapers</a>).
  * GF2nField is used by GF2nONBElement which implements the elements of this
  * field.
  *

--- a/core/src/main/java/org/bouncycastle/pqc/math/linearalgebra/GF2nPolynomialElement.java
+++ b/core/src/main/java/org/bouncycastle/pqc/math/linearalgebra/GF2nPolynomialElement.java
@@ -9,7 +9,7 @@ import java.util.Random;
  * This class implements elements of finite binary fields <i>GF(2<sup>n</sup>)</i>
  * using polynomial representation. For more information on the arithmetic see
  * for example IEEE Standard 1363 or <a
- * href=http://www.certicom.com/research/online.html> Certicom online-tutorial</a>.
+ * href=https://www.certicom.com/research/online.html> Certicom online-tutorial</a>.
  *
  * @see "GF2nField"
  * @see GF2nPolynomialField

--- a/core/src/main/java/org/bouncycastle/pqc/math/linearalgebra/GFElement.java
+++ b/core/src/main/java/org/bouncycastle/pqc/math/linearalgebra/GFElement.java
@@ -118,7 +118,7 @@ public interface GFElement
 
     /**
      * Returns this element as FlexiBigInt. The conversion is <a
-     * href="http://grouper.ieee.org/groups/1363/">P1363</a>-conform.
+     * href="https://grouper.ieee.org/groups/1363/">P1363</a>-conform.
      *
      * @return this element as BigInt
      */
@@ -126,7 +126,7 @@ public interface GFElement
 
     /**
      * Returns this element as byte array. The conversion is <a href =
-     * "http://grouper.ieee.org/groups/1363/">P1363</a>-conform.
+     * "https://grouper.ieee.org/groups/1363/">P1363</a>-conform.
      *
      * @return this element as byte array
      */

--- a/core/src/main/java/org/bouncycastle/pqc/math/ntru/euclid/BigIntEuclidean.java
+++ b/core/src/main/java/org/bouncycastle/pqc/math/ntru/euclid/BigIntEuclidean.java
@@ -15,7 +15,7 @@ public class BigIntEuclidean
 
     /**
      * Runs the EEA on two <code>BigInteger</code>s<br>
-     * Implemented from pseudocode on <a href="http://en.wikipedia.org/wiki/Extended_Euclidean_algorithm">Wikipedia</a>.
+     * Implemented from pseudocode on <a href="https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm">Wikipedia</a>.
      *
      * @param a
      * @param b

--- a/core/src/main/java/org/bouncycastle/pqc/math/ntru/euclid/IntEuclidean.java
+++ b/core/src/main/java/org/bouncycastle/pqc/math/ntru/euclid/IntEuclidean.java
@@ -13,7 +13,7 @@ public class IntEuclidean
 
     /**
      * Runs the EEA on two <code>int</code>s<br>
-     * Implemented from pseudocode on <a href="http://en.wikipedia.org/wiki/Extended_Euclidean_algorithm">Wikipedia</a>.
+     * Implemented from pseudocode on <a href="https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm">Wikipedia</a>.
      *
      * @param a
      * @param b

--- a/core/src/main/java/org/bouncycastle/pqc/math/ntru/polynomial/IntegerPolynomial.java
+++ b/core/src/main/java/org/bouncycastle/pqc/math/ntru/polynomial/IntegerPolynomial.java
@@ -684,7 +684,7 @@ public class IntegerPolynomial
         int N = coeffs.length;
 
         // upper bound for resultant(f, g) = ||f, 2||^deg(g) * ||g, 2||^deg(f) = squaresum(f)^(N/2) * 2^(deg(f)/2) because g(x)=x^N-1
-        // see http://jondalon.mathematik.uni-osnabrueck.de/staff/phpages/brunsw/CompAlg.pdf chapter 3
+        // see https://jondalon.mathematik.uni-osnabrueck.de/staff/phpages/brunsw/CompAlg.pdf chapter 3
         BigInteger max = squareSum().pow((N + 1) / 2);
         max = max.multiply(BigInteger.valueOf(2).pow((degree() + 1) / 2));
         BigInteger max2 = max.multiply(BigInteger.valueOf(2));

--- a/core/src/main/java/org/bouncycastle/pqc/math/ntru/util/ArrayEncoder.java
+++ b/core/src/main/java/org/bouncycastle/pqc/math/ntru/util/ArrayEncoder.java
@@ -13,7 +13,7 @@ public class ArrayEncoder
 {
     /**
      * Bit string to coefficient conversion table from P1363.1. Also found at
-     * {@link http://stackoverflow.com/questions/1562548/how-to-make-a-message-into-a-polynomial}
+     * {@link https://stackoverflow.com/questions/1562548/how-to-make-a-message-into-a-polynomial}
      * <p>
      * Convert each three-bit quantity to two ternary coefficients as follows, and concatenate the resulting
      * ternary quantities to obtain [the output].
@@ -34,7 +34,7 @@ public class ArrayEncoder
     private static final int[] COEFF2_TABLE = {0, 1, -1, 0, 1, -1, 0, 1};
     /**
      * Coefficient to bit string conversion table from P1363.1. Also found at
-     * {@link http://stackoverflow.com/questions/1562548/how-to-make-a-message-into-a-polynomial}
+     * {@link https://stackoverflow.com/questions/1562548/how-to-make-a-message-into-a-polynomial}
      * <p>
      * Convert each set of two ternary coefficients to three bits as follows, and concatenate the resulting bit
      * quantities to obtain [the output]:

--- a/core/src/main/jdk1.1/org/bouncycastle/crypto/agreement/jpake/JPAKEParticipant.java
+++ b/core/src/main/jdk1.1/org/bouncycastle/crypto/agreement/jpake/JPAKEParticipant.java
@@ -13,7 +13,7 @@ import org.bouncycastle.util.Arrays;
  * A participant in a Password Authenticated Key Exchange by Juggling (J-PAKE) exchange.
  * <p>
  * The J-PAKE exchange is defined by Feng Hao and Peter Ryan in the paper
- * <a href="http://grouper.ieee.org/groups/1363/Research/contributions/hao-ryan-2008.pdf">
+ * <a href="https://grouper.ieee.org/groups/1363/Research/contributions/hao-ryan-2008.pdf">
  * "Password Authenticated Key Exchange by Juggling, 2008."</a>
  * </p>
  * <p>
@@ -54,7 +54,7 @@ import org.bouncycastle.util.Arrays;
  * </p>
  * <p>
  * The key confirmation process is implemented as specified in
- * <a href="http://csrc.nist.gov/publications/nistpubs/800-56A/SP800-56A_Revision1_Mar08-2007.pdf">NIST SP 800-56A Revision 1</a>,
+ * <a href="https://csrc.nist.gov/publications/nistpubs/800-56A/SP800-56A_Revision1_Mar08-2007.pdf">NIST SP 800-56A Revision 1</a>,
  * Section 8.2 Unilateral Key Confirmation for Key Agreement Schemes.
  * </p>
  * <p>

--- a/core/src/main/jdk1.1/org/bouncycastle/crypto/agreement/jpake/JPAKEPrimeOrderGroup.java
+++ b/core/src/main/jdk1.1/org/bouncycastle/crypto/agreement/jpake/JPAKEPrimeOrderGroup.java
@@ -12,7 +12,7 @@ import java.math.BigInteger;
  * See {@link JPAKEPrimeOrderGroups} for convenient standard groups.
  * </p>
  * <p>
- * NIST <a href="http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/DSA2_All.pdf">publishes</a>
+ * NIST <a href="https://csrc.nist.gov/groups/ST/toolkit/documents/Examples/DSA2_All.pdf">publishes</a>
  * many groups that can be used for the desired level of security.
  * </p>
  */

--- a/core/src/main/jdk1.4/org/bouncycastle/asn1/x509/PKIXNameConstraintValidator.java
+++ b/core/src/main/jdk1.4/org/bouncycastle/asn1/x509/PKIXNameConstraintValidator.java
@@ -1807,20 +1807,20 @@ public class PKIXNameConstraintValidator
         // see RFC 1738
         // remove ':' after protocol, e.g. http:
         String sub = url.substring(url.indexOf(':') + 1);
-        // extract host from Common Internet Scheme Syntax, e.g. http://
+        // extract host from Common Internet Scheme Syntax, e.g. https://
         if (sub.indexOf("//") != -1)
         {
             sub = sub.substring(sub.indexOf("//") + 2);
         }
-        // first remove port, e.g. http://test.com:21
+        // first remove port, e.g. https://test.com:21
         if (sub.lastIndexOf(':') != -1)
         {
             sub = sub.substring(0, sub.lastIndexOf(':'));
         }
-        // remove user and password, e.g. http://john:password@test.com
+        // remove user and password, e.g. https://john:password@test.com
         sub = sub.substring(sub.indexOf(':') + 1);
         sub = sub.substring(sub.indexOf('@') + 1);
-        // remove local parts, e.g. http://test.com/bla
+        // remove local parts, e.g. https://test.com/bla
         if (sub.indexOf('/') != -1)
         {
             sub = sub.substring(0, sub.indexOf('/'));

--- a/core/src/test/data/PKITS/README
+++ b/core/src/test/data/PKITS/README
@@ -1,3 +1,3 @@
-PKITS test data from http://csrc.nist.gov/pki/testing/x509paths.html
+PKITS test data from https://csrc.nist.gov/pki/testing/x509paths.html
 
 For more details please check the website above.

--- a/core/src/test/data/rfc4134/rfc4134.txt
+++ b/core/src/test/data/rfc4134/rfc4134.txt
@@ -7596,7 +7596,7 @@ Intellectual Property
    attempt made to obtain a general license or permission for the use of
    such proprietary rights by implementers or users of this
    specification can be obtained from the IETF on-line IPR repository at
-   http://www.ietf.org/ipr.
+   https://www.ietf.org/ipr.
 
    The IETF invites any interested party to bring to its attention any
    copyrights, patents or patent applications, or other proprietary

--- a/core/src/test/java/org/bouncycastle/asn1/test/EncryptedPrivateKeyInfoTest.java
+++ b/core/src/test/java/org/bouncycastle/asn1/test/EncryptedPrivateKeyInfoTest.java
@@ -14,7 +14,7 @@ import org.bouncycastle.util.test.SimpleTest;
 /**
  * Test the reading and writing of EncryptedPrivateKeyInfo objects using
  * the test vectors provided at
- * <a href=http://www.rsasecurity.com/rsalabs/pkcs/pkcs-5/index.html>
+ * <a href=https://www.rsasecurity.com/rsalabs/pkcs/pkcs-5/index.html>
  * RSA's PKCS5 Page</a>.
  * <br>
  * The vectors are Base 64 encoded and encrypted using the password "password"

--- a/core/src/test/java/org/bouncycastle/crypto/prng/test/DualECDRBGTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/prng/test/DualECDRBGTest.java
@@ -258,7 +258,7 @@ public class DualECDRBGTest
                             "815B6D34E29F2603526CE186576F4CCA3FEDF7F8ACDB37C9" +
                             "9D762706ABE4967D44739C8CFCFCC76C58B1ED243AC394C0"
                         }),
-                // From http://csrc.nist.gov/groups/STM/cavp/documents/drbg/drbgtestvectors.zip
+                // From https://csrc.nist.gov/groups/STM/cavp/documents/drbg/drbgtestvectors.zip
                 // modified to test partial block processing.
                 new DRBGTestVector(
                     new SHA256Digest(),

--- a/core/src/test/java/org/bouncycastle/crypto/test/AESFastTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/AESFastTest.java
@@ -9,8 +9,8 @@ import org.bouncycastle.util.test.SimpleTest;
 
 /**
  * Test vectors from the NIST standard tests and Brian Gladman's vector set
- * <a href="http://fp.gladman.plus.com/cryptography_technology/rijndael/">
- * http://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
+ * <a href="https://fp.gladman.plus.com/cryptography_technology/rijndael/">
+ * https://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
  */
 public class AESFastTest
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/AESLightTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/AESLightTest.java
@@ -9,8 +9,8 @@ import org.bouncycastle.util.test.SimpleTest;
 
 /**
  * Test vectors from the NIST standard tests and Brian Gladman's vector set
- * <a href="http://fp.gladman.plus.com/cryptography_technology/rijndael/">
- * http://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
+ * <a href="https://fp.gladman.plus.com/cryptography_technology/rijndael/">
+ * https://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
  */
 public class AESLightTest
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/AESTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/AESTest.java
@@ -18,8 +18,8 @@ import org.bouncycastle.util.test.SimpleTest;
 
 /**
  * Test vectors from the NIST standard tests and Brian Gladman's vector set
- * <a href="http://fp.gladman.plus.com/cryptography_technology/rijndael/">
- * http://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
+ * <a href="https://fp.gladman.plus.com/cryptography_technology/rijndael/">
+ * https://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
  */
 public class AESTest
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/AESVectorFileTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/AESVectorFileTest.java
@@ -23,8 +23,8 @@ import org.bouncycastle.util.test.TestResult;
 
 /**
  * Test vectors from the NIST standard tests and Brian Gladman's vector set
- * <a href="http://fp.gladman.plus.com/cryptography_technology/rijndael/">
- * http://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
+ * <a href="https://fp.gladman.plus.com/cryptography_technology/rijndael/">
+ * https://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
  */
 public class AESVectorFileTest
     implements Test

--- a/core/src/test/java/org/bouncycastle/crypto/test/Blake2bDigestTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/Blake2bDigestTest.java
@@ -48,7 +48,7 @@ public class Blake2bDigestTest
                 "142709d62e28fcccd0af97fad0f8465b971e82201dc51070faa0372aa43e92484be1c1e73ba10906d5d1853db6a4106e0a7bf9800d373d6dee2d46d62ef2a461"}};
 
     private final static String[][] unkeyedTestVectors =
-        { // from: http://fossies.org/linux/john/src/rawBLAKE2_512_fmt_plug.c
+        { // from: https://fossies.org/linux/john/src/rawBLAKE2_512_fmt_plug.c
             // hash, input/message
             // digests without leading $BLAKE2$
             {

--- a/core/src/test/java/org/bouncycastle/crypto/test/BlowfishTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/BlowfishTest.java
@@ -6,7 +6,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * blowfish tester - vectors from http://www.counterpane.com/vectors.txt
+ * blowfish tester - vectors from https://www.counterpane.com/vectors.txt
  */
 public class BlowfishTest
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/CAST5Test.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/CAST5Test.java
@@ -6,7 +6,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * cast tester - vectors from http://www.ietf.org/rfc/rfc2144.txt
+ * cast tester - vectors from https://www.ietf.org/rfc/rfc2144.txt
  */
 public class CAST5Test
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/CAST6Test.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/CAST6Test.java
@@ -6,7 +6,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * cast6 tester - vectors from http://www.ietf.org/rfc/rfc2612.txt
+ * cast6 tester - vectors from https://www.ietf.org/rfc/rfc2612.txt
  */
 public class CAST6Test
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/CMacTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/CMacTest.java
@@ -18,7 +18,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * CMAC tester - <a href="http://www.nuee.nagoya-u.ac.jp/labs/tiwata/omac/tv/omac1-tv.txt">Official Test Vectors</a>.
+ * CMAC tester - <a href="https://www.nuee.nagoya-u.ac.jp/labs/tiwata/omac/tv/omac1-tv.txt">Official Test Vectors</a>.
  */
 public class CMacTest
     extends SimpleTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/DESTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/DESTest.java
@@ -151,7 +151,7 @@ class DESParametersTest
 }
 
 /**
- * DES tester - vectors from <a href=http://www.itl.nist.gov/fipspubs/fip81.htm>FIPS 81</a>
+ * DES tester - vectors from <a href=https://www.itl.nist.gov/fipspubs/fip81.htm>FIPS 81</a>
  */
 public class DESTest
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/ECGOST3410Test.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/ECGOST3410Test.java
@@ -100,7 +100,7 @@ public class ECGOST3410Test
 
     /**
      * Test Sign & Verify with test parameters
-     * see: http://www.ietf.org/internet-drafts/draft-popov-cryptopro-cpalgs-01.txt
+     * see: https://www.ietf.org/internet-drafts/draft-popov-cryptopro-cpalgs-01.txt
      * gostR3410-2001-TestParamSet  P.46
      */
     private void ecGOST3410_TestParam()
@@ -157,7 +157,7 @@ public class ECGOST3410Test
 
     /**
      * Test Sign & Verify with A parameters
-     * see: http://www.ietf.org/internet-drafts/draft-popov-cryptopro-cpalgs-01.txt
+     * see: https://www.ietf.org/internet-drafts/draft-popov-cryptopro-cpalgs-01.txt
      * gostR3410-2001-CryptoPro-A-ParamSet  P.47
      */
     public void ecGOST3410_AParam()
@@ -207,7 +207,7 @@ public class ECGOST3410Test
 
     /**
      * Test Sign & Verify with B parameters
-     * see: http://www.ietf.org/internet-drafts/draft-popov-cryptopro-cpalgs-01.txt
+     * see: https://www.ietf.org/internet-drafts/draft-popov-cryptopro-cpalgs-01.txt
      * gostR3410-2001-CryptoPro-B-ParamSet  P.47-48
      */
     private void ecGOST3410_BParam()
@@ -257,7 +257,7 @@ public class ECGOST3410Test
 
     /**
      * Test Sign & Verify with C parameters
-     * see: http://www.ietf.org/internet-drafts/draft-popov-cryptopro-cpalgs-01.txt
+     * see: https://www.ietf.org/internet-drafts/draft-popov-cryptopro-cpalgs-01.txt
      * gostR3410-2001-CryptoPro-C-ParamSet  P.48
      */
     private void ecGOST3410_CParam()

--- a/core/src/test/java/org/bouncycastle/crypto/test/GMacTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/GMacTest.java
@@ -12,7 +12,7 @@ import org.bouncycastle.util.test.SimpleTest;
 
 /**
  * Test vectors for AES-GMAC, extracted from <a
- * href="http://csrc.nist.gov/groups/STM/cavp/documents/mac/gcmtestvectors.zip">NIST CAVP GCM test
+ * href="https://csrc.nist.gov/groups/STM/cavp/documents/mac/gcmtestvectors.zip">NIST CAVP GCM test
  * vectors</a>.
  *
  */

--- a/core/src/test/java/org/bouncycastle/crypto/test/HCFamilyTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/HCFamilyTest.java
@@ -12,8 +12,8 @@ import org.bouncycastle.util.test.SimpleTest;
  * HC-128 and HC-256 Tests. Based on the test vectors in the official reference
  * papers, respectively:
  * <pre>
- * http://www.ecrypt.eu.org/stream/p3ciphers/hc/hc128_p3.pdf
- * http://www.ecrypt.eu.org/stream/p3ciphers/hc/hc256_p3.pdf
+ * https://www.ecrypt.eu.org/stream/p3ciphers/hc/hc128_p3.pdf
+ * https://www.ecrypt.eu.org/stream/p3ciphers/hc/hc256_p3.pdf
  * </pre>
  * See HCFamilyVecTest for a more exhaustive test based on the ecrypt vectors.
  */

--- a/core/src/test/java/org/bouncycastle/crypto/test/HCFamilyVecTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/HCFamilyVecTest.java
@@ -19,8 +19,8 @@ import org.bouncycastle.util.test.SimpleTest;
  * HC-128 and HC-256 Tests. Based on the test vectors in the official reference
  * papers, respectively:
  * 
- * http://www.ecrypt.eu.org/stream/p3ciphers/hc/hc128_p3.pdf
- * http://www.ecrypt.eu.org/stream/p3ciphers/hc/hc256_p3.pdf
+ * https://www.ecrypt.eu.org/stream/p3ciphers/hc/hc128_p3.pdf
+ * https://www.ecrypt.eu.org/stream/p3ciphers/hc/hc256_p3.pdf
  */
 public class HCFamilyVecTest
     extends SimpleTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/ISAACTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/ISAACTest.java
@@ -6,7 +6,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * ISAAC Test - see http://www.burtleburtle.net/bob/rand/isaacafa.html
+ * ISAAC Test - see https://www.burtleburtle.net/bob/rand/isaacafa.html
  */
 public class ISAACTest
     extends SimpleTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/KeccakDigestTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/KeccakDigestTest.java
@@ -66,7 +66,7 @@ public class KeccakDigestTest
         "3e122edaf37398231cfaca4c7c216c9d66d5b899ec1d7ac617c40c7261906a45fc01617a021e5da3bd8d4182695b5cb785a28237cbb167590e34718e56d8aab8"
     };
 
-    // test vectors from  http://www.di-mgt.com.au/hmac_sha3_testvectors.html
+    // test vectors from  https://www.di-mgt.com.au/hmac_sha3_testvectors.html
     final static byte[][] macKeys =
     {
         Hex.decode("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),

--- a/core/src/test/java/org/bouncycastle/crypto/test/MacTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/MacTest.java
@@ -13,8 +13,8 @@ import org.bouncycastle.util.test.SimpleTest;
 
 /**
  * MAC tester - vectors from 
- * <a href=http://www.itl.nist.gov/fipspubs/fip81.htm>FIP 81</a> and 
- * <a href=http://www.itl.nist.gov/fipspubs/fip113.htm>FIP 113</a>.
+ * <a href=https://www.itl.nist.gov/fipspubs/fip81.htm>FIP 81</a> and
+ * <a href=https://www.itl.nist.gov/fipspubs/fip113.htm>FIP 113</a>.
  */
 public class MacTest
     extends SimpleTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/NaccacheSternTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/NaccacheSternTest.java
@@ -17,7 +17,7 @@ import org.bouncycastle.util.test.SimpleTest;
 /**
  * Test case for NaccacheStern cipher. For details on this cipher, please see
  * 
- * http://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
+ * https://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf
  *
  * Performs the following tests: 
  *  <ul>
@@ -91,7 +91,7 @@ public class NaccacheSternTest
         decryptEng.setDebug(debug);
 
         // First the Parameters from the NaccacheStern Paper
-        // (see http://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf )
+        // (see https://www.gemplus.com/smart/rd/publications/pdf/NS98pkcs.pdf )
 
         smallPrimes.addElement(u1);
         smallPrimes.addElement(u2);

--- a/core/src/test/java/org/bouncycastle/crypto/test/OCBTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/OCBTest.java
@@ -16,7 +16,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * Test vectors from <a href="http://tools.ietf.org/html/rfc7253">RFC 7253 on The OCB
+ * Test vectors from <a href="https://tools.ietf.org/html/rfc7253">RFC 7253 on The OCB
  * Authenticated-Encryption Algorithm</a>
  */
 public class OCBTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/OpenBSDBCryptTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/OpenBSDBCryptTest.java
@@ -8,7 +8,7 @@ public class OpenBSDBCryptTest
     extends SimpleTest
 {
 
-    private final static String[][] bcryptTest1 = // vectors from http://cvsweb.openwall.com/cgi/cvsweb.cgi/Owl/packages/glibc/crypt_blowfish/wrapper.c?rev=HEAD
+    private final static String[][] bcryptTest1 = // vectors from https://cvsweb.openwall.com/cgi/cvsweb.cgi/Owl/packages/glibc/crypt_blowfish/wrapper.c?rev=HEAD
         {
             {"$2a$05$CCCCCCCCCCCCCCCCCCCCC.E5YPO9kmyuRGyh0XouQYb4YMJKvyOeW",
                 "U*U"},
@@ -24,11 +24,11 @@ public class OpenBSDBCryptTest
                     + "chars after 72 are ignored"},
         };
 
-    private final static String[] bcryptTest2 = { // from: http://openwall.info/wiki/john/sample-hashes
+    private final static String[] bcryptTest2 = { // from: https://openwall.info/wiki/john/sample-hashes
         "$2a$05$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe", "password"
     };
 
-    private final static String[] bcryptTest2b = { // from: http://stackoverflow.com/questions/11654684/verifying-a-bcrypt-hash
+    private final static String[] bcryptTest2b = { // from: https://stackoverflow.com/questions/11654684/verifying-a-bcrypt-hash
         "$2a$10$.TtQJ4Jr6isd4Hp.mVfZeuh6Gws4rOQ/vdBczhDx.19NFK0Y84Dle", "\u03c0\u03c0\u03c0\u03c0\u03c0\u03c0\u03c0\u03c0"
     };
 

--- a/core/src/test/java/org/bouncycastle/crypto/test/PKCS12Test.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/PKCS12Test.java
@@ -13,8 +13,8 @@ import org.bouncycastle.util.test.TestResult;
 
 /**
  * test for PKCS12 key generation - vectors from 
- * <a href=http://www.drh-consultancy.demon.co.uk/test.txt>
- * http://www.drh-consultancy.demon.co.uk/test.txt</a>
+ * <a href=https://www.drh-consultancy.demon.co.uk/test.txt>
+ * https://www.drh-consultancy.demon.co.uk/test.txt</a>
  */
 public class PKCS12Test
     implements Test

--- a/core/src/test/java/org/bouncycastle/crypto/test/PKCS5Test.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/PKCS5Test.java
@@ -29,7 +29,7 @@ import org.bouncycastle.util.test.SimpleTest;
 /**
  * A test class for PKCS5 PBES2 with PBKDF2 (PKCS5 v2.0) using
  * test vectors provider at 
- * <a href=http://www.rsasecurity.com/rsalabs/pkcs/pkcs-5/index.html>
+ * <a href=https://www.rsasecurity.com/rsalabs/pkcs/pkcs-5/index.html>
  * RSA's PKCS5 Page</a>
  * <br>
  * The vectors are Base 64 encoded and encrypted using the password "password"

--- a/core/src/test/java/org/bouncycastle/crypto/test/RijndaelTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/RijndaelTest.java
@@ -7,8 +7,8 @@ import org.bouncycastle.util.test.SimpleTest;
 
 /**
  * Test vectors from the NIST standard tests and Brian Gladman's vector set
- * <a href="http://fp.gladman.plus.com/cryptography_technology/rijndael/">
- * http://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
+ * <a href="https://fp.gladman.plus.com/cryptography_technology/rijndael/">
+ * https://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
  */
 public class RijndaelTest
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/SCryptTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/SCryptTest.java
@@ -10,7 +10,7 @@ import org.bouncycastle.util.test.SimpleTest;
 
 /*
  * scrypt test vectors from "Stronger Key Derivation Via Sequential Memory-hard Functions" Appendix B.
- * (http://www.tarsnap.com/scrypt/scrypt.pdf)
+ * (https://www.tarsnap.com/scrypt/scrypt.pdf)
  */
 public class SCryptTest
     extends SimpleTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/SEEDTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/SEEDTest.java
@@ -6,7 +6,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * SEED tester - vectors http://www.ietf.org/rfc/rfc4009.txt
+ * SEED tester - vectors https://www.ietf.org/rfc/rfc4009.txt
  */
 public class SEEDTest
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/SM4Test.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/SM4Test.java
@@ -12,7 +12,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * SM4 tester, vectors from <a href="http://eprint.iacr.org/2008/329.pdf">http://eprint.iacr.org/2008/329.pdf</a>
+ * SM4 tester, vectors from <a href="https://eprint.iacr.org/2008/329.pdf">https://eprint.iacr.org/2008/329.pdf</a>
  */
 public class SM4Test
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/TEATest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/TEATest.java
@@ -6,7 +6,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * TEA tester - based on C implementation results from http://www.simonshepherd.supanet.com/tea.htm
+ * TEA tester - based on C implementation results from https://www.simonshepherd.supanet.com/tea.htm
  */
 public class TEATest
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/XTEATest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/XTEATest.java
@@ -6,7 +6,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * TEA tester - based on C implementation results from http://www.simonshepherd.supanet.com/tea.htm
+ * TEA tester - based on C implementation results from https://www.simonshepherd.supanet.com/tea.htm
  */
 public class XTEATest
     extends CipherTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/ZucTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/ZucTest.java
@@ -17,7 +17,7 @@ import org.bouncycastle.util.test.SimpleTest;
 /**
  * Test Cases for Zuc128 and Zuc256.
  * Test Vectors taken from https://www.gsma.com/aboutus/wp-content/uploads/2014/12/eea3eia3zucv16.pdf for Zuc128
- * and http://www.is.cas.cn/ztzl2016/zouchongzhi/201801/W020180126529970733243.pdf for Zuc256.
+ * and https://www.is.cas.cn/ztzl2016/zouchongzhi/201801/W020180126529970733243.pdf for Zuc256.
  */
 public class ZucTest
     extends SimpleTest

--- a/core/src/test/java/org/bouncycastle/crypto/test/speedy/Poly1305Reference.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/speedy/Poly1305Reference.java
@@ -16,7 +16,7 @@ import org.bouncycastle.crypto.params.ParametersWithIV;
  * consisting of a 128 bit key applied to an underlying cipher, and a 128 bit key (with 106
  * effective key bits) used in the authenticator.
  * <p>
- * This implementation is adapted from the public domain <a href="http://nacl.cr.yp.to/">nacl</a>
+ * This implementation is adapted from the public domain <a href="https://nacl.cr.yp.to/">nacl</a>
  * <code>ref</code> implementation, and is probably too slow for real usage.
  * 
  * @see Poly1305KeyGenerator

--- a/core/src/test/resources/org/bouncycastle/crypto/test/SHA3TestVectors.txt
+++ b/core/src/test/resources/org/bouncycastle/crypto/test/SHA3TestVectors.txt
@@ -1,6 +1,6 @@
 # Test vectors for FIPS 202 - SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions
 #
-# Downloaded 6th August, 2015 from http://csrc.nist.gov/groups/ST/toolkit/examples.html#aHashing
+# Downloaded 6th August, 2015 from https://csrc.nist.gov/groups/ST/toolkit/examples.html#aHashing
 #
 # NOTE: The 1605-bit test vectors were initially wrong. Corrections were published on 14th August, 2015
 #       (SHA3-512 corrected on 3rd September, 2015).

--- a/core/src/test/resources/org/bouncycastle/crypto/test/SHAKETestVectors.txt
+++ b/core/src/test/resources/org/bouncycastle/crypto/test/SHAKETestVectors.txt
@@ -1,6 +1,6 @@
 # Test vectors for FIPS 202 - SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions
 #
-# Downloaded 6th August, 2015 from http://csrc.nist.gov/groups/ST/toolkit/examples.html#aHashing
+# Downloaded 6th August, 2015 from https://csrc.nist.gov/groups/ST/toolkit/examples.html#aHashing
 
 SHAKE-128 sample of 0-bit message
 

--- a/docs/releasenotes.html
+++ b/docs/releasenotes.html
@@ -438,7 +438,7 @@ Date:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2017, May 11
 <li>SM2 signatures, key exchange, and public key encryption has been added to the lightweight API.</li>
 <li>XMSS has been added to the lightweight PQ API. Note: this should be treated as beta code.</li>
 <li>API support for client side EST (RFC 7030), as well as some CMC (RFC 5273) has been added to the PKIX API. A full set of ASN.1 classes for both protocols has been added as well.</li>
-<li>A test client for EST which will interop with the 7030 test server at http://testrfc7030.com/ has been added to the general test module in the current source tree.</li>
+<li>A test client for EST which will interop with the 7030 test server at https://testrfc7030.com/ has been added to the general test module in the current source tree.</li>
 <li>The BCJSSE provider now supports SSLContext.getDefault(), with very similar behaviour to the SunJSSE provider, including checks of the relevant javax.net.ssl.* system properties and auto-loading of jssecacerts or cacerts as the default trust store.</li>
 </ul>
 <h3>2.11.4 Security Related Changes</h3>
@@ -1939,7 +1939,7 @@ Date:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2002, February 8
 <h3>2.56.3 Additional Functionality and Features</h3>
 <ul>
     <li>The AESWrap ciphers will now take IV's.
-    <li>The DES-EDEWrap algorithm described in http://www.ietf.org/internet-drafts/draft-ietf-smime-key-wrap-01.txt is now supported.
+    <li>The DES-EDEWrap algorithm described in https://www.ietf.org/internet-drafts/draft-ietf-smime-key-wrap-01.txt is now supported.
     <li>Support for the ExtendedKeyUsageExtension and the KeyPurposeId has been added.
     <li>The OID based alias for DSA has been added to the JCE provider.
     <li>BC key stores now implement the BCKeyStore interface so you can provide your own source of randomness to a key store.

--- a/docs/specifications.html
+++ b/docs/specifications.html
@@ -23,7 +23,7 @@ Except where otherwise stated, this software is distributed under a license
 based on the MIT X 
 Consortium license.  To view the license, see <a href="./LICENSE.html">here</a>.
 The OpenPGP library also includes a modified BZIP2 library which
-is licensed under the <a href="http://www.apache.org/licenses/">Apache Software License, Version 2.0</a>.
+is licensed under the <a href="https://www.apache.org/licenses/">Apache Software License, Version 2.0</a>.
 
 <p>
 If you have the full package you will have six jar files, bcprov*.jar
@@ -58,7 +58,7 @@ the request of the patent holder.
 <p>
 The BC distribution contains implementations of EC MQV as described in RFC 5753, "Use of ECC Algorithms in CMS". In line with the conditions in:
 <pre>
-<a href="http://www.ietf.org/ietf-ftp/IPR/certicom-ipr-rfc-5753.pdf">http://www.ietf.org/ietf-ftp/IPR/certicom-ipr-rfc-5753.pdf</a>
+<a href="https://www.ietf.org/ietf-ftp/IPR/certicom-ipr-rfc-5753.pdf">https://www.ietf.org/ietf-ftp/IPR/certicom-ipr-rfc-5753.pdf</a>
 </pre>
 We state, where EC MQV has not otherwise been disabled or removed:</br />
 
@@ -1066,9 +1066,9 @@ To be able to fully compile and utilise the BouncyCastle S/MIME
 package (including the test classes) you need the jar files for
 the following APIs.
 <ul>
-<li>Junit - <a href="http://www.junit.org">http://www.junit.org</a></li>
-<li>JavaMail - <a href="http://java.sun.com/products/javamail/index.html">http://java.sun.com/products/javamail/index.html</a></li>
-<li>The Java Activation Framework - <a href="http://java.sun.com/products/javabeans/glasgow/jaf.html">http://java.sun.com/products/javabeans/glasgow/jaf.html</a></li>
+<li>Junit - <a href="https://www.junit.org">https://www.junit.org</a></li>
+<li>JavaMail - <a href="https://java.sun.com/products/javamail/index.html">https://java.sun.com/products/javamail/index.html</a></li>
+<li>The Java Activation Framework - <a href="https://java.sun.com/products/javabeans/glasgow/jaf.html">https://java.sun.com/products/javabeans/glasgow/jaf.html</a></li>
 </ul>
 
 <h3>7.1 Setting up BouncyCastle S/MIME in JavaMail</h3>

--- a/index.html
+++ b/index.html
@@ -16,11 +16,11 @@ The Bouncy Castle Crypto package is a Java implementation of
 cryptographic algorithms, it was developed by the Legion of the
 Bouncy Castle, a registered Australian Charity, with a little help! The Legion, and the latest
 goings on with this package, can be found at
-<a href=http://www.bouncycastle.org>http://www.bouncycastle.org</a>. 
+<a href=https://www.bouncycastle.org>https://www.bouncycastle.org</a>.
 <p>
 The Legion also gratefully acknowledges the contributions made to this
 package by others (see <a href=CONTRIBUTORS.html>here</a>
-for the current list). If you would like to contribute to our efforts please feel free to get in touch with us or visit our <a href="https://www.bouncycastle.org/donate">donations page</a>, sponsor some specific work, or purchase a support contract through <a href="http://www.cryptoworkshop.com">Crypto Workshop</a>.
+for the current list). If you would like to contribute to our efforts please feel free to get in touch with us or visit our <a href="https://www.bouncycastle.org/donate">donations page</a>, sponsor some specific work, or purchase a support contract through <a href="https://www.cryptoworkshop.com">Crypto Workshop</a>.
 </p>
 <p>
 The package is organised so that it 
@@ -29,7 +29,7 @@ contains a light-weight API suitable for use in any environment
 to conform the algorithms to the JCE framework.
 </p>
 <p>
-Except where otherwise stated, this software is distributed under a license based on the MIT X Consortium license.  To view the license, <a href="./LICENSE.html">see here</a>. The OpenPGP library also includes a modified BZIP2 library which is licensed under the <a href="http://www.apache.org/licenses/">Apache Software License, Version 2.0</a>.
+Except where otherwise stated, this software is distributed under a license based on the MIT X Consortium license.  To view the license, <a href="./LICENSE.html">see here</a>. The OpenPGP library also includes a modified BZIP2 library which is licensed under the <a href="https://www.apache.org/licenses/">Apache Software License, Version 2.0</a>.
 </p>
 <p>
 The current release notes for this package are
@@ -68,7 +68,7 @@ Additional documentation on use of the classes can also be found in the <a href=
 			<li><p><b>org.bouncycastle.x509.examples</b>
 		</ul>
 
-		<p>Finally there are also code <a href="http://www.wiley.com/WileyCDA/WileyAncillary/productCd-0764596330.html">examples</a> from <a href="http://www.amazon.com/exec/obidos/redirect?path=ASIN/0764596330&amp;link_code=as2&amp;camp=1789&amp;tag=bouncycastleo-20&amp;creative=9325">Beginning Cryptography with Java</a> which demonstrate both the use of the JCE/JCA and also some of the Bouncy Castle APIs.</p>
+		<p>Finally there are also code <a href="https://www.wiley.com/WileyCDA/WileyAncillary/productCd-0764596330.html">examples</a> from <a href="https://www.amazon.com/exec/obidos/redirect?path=ASIN/0764596330&amp;link_code=as2&amp;camp=1789&amp;tag=bouncycastleo-20&amp;creative=9325">Beginning Cryptography with Java</a> which demonstrate both the use of the JCE/JCA and also some of the Bouncy Castle APIs.</p>
 <p>
 <b>Note 1:</b>The JCE classes are only distributed with the JDK 1.1, JDK 1.2, and JDK 1.3 JCE releases. The
 JDK 1.0, J2ME, and the JDK 1.1, JDK 1.2, JDK 1.3, JDK 1.4, and JDK 1.5 lightweight releases only include the
@@ -103,7 +103,7 @@ use or operation.
 <b>NOTE:</b>You need to be subscribed to send mail to the above
 mailing list.
 <p>
-If you want to provide feedback, directly to the members of <b>The Legion</b> then please use <a href="mailto:feedback-crypto@bouncycastle.org">feedback-crypto@bouncycastle.org</a>, if you want to help this project survive please consider <a href="https://www.bouncycastle.org/donate">donating</a> or getting a <a href="http://www.cryptoworkshop.com">support contract</a>.
+If you want to provide feedback, directly to the members of <b>The Legion</b> then please use <a href="mailto:feedback-crypto@bouncycastle.org">feedback-crypto@bouncycastle.org</a>, if you want to help this project survive please consider <a href="https://www.bouncycastle.org/donate">donating</a> or getting a <a href="https://www.cryptoworkshop.com">support contract</a>.
 <p>
 Enjoy!
 </body>

--- a/jce/src/main/java/javax/crypto/Cipher.java
+++ b/jce/src/main/java/javax/crypto/Cipher.java
@@ -409,7 +409,7 @@ public class Cipher
      * <p>
      * If this cipher (including its underlying feedback or padding scheme)
      * requires any random bytes (e.g., for parameter generation), it will get
-     * them using the <a href="http://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
+     * them using the <a href="https://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
      * <code>SecureRandom</code></a> implementation of the highest-priority
      * installed provider as the source of randomness.
      * (If none of the installed providers supply an implementation of
@@ -511,7 +511,7 @@ public class Cipher
      * If this cipher (including its underlying feedback or padding scheme)
      * requires any random bytes (e.g., for parameter generation), it will get
      * them using the
-     * <a href="http://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
+     * <a href="https://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
      * <code>SecureRandom</code></a> implementation of the highest-priority
      * installed provider as the source of randomness.
      * (If none of the installed providers supply an implementation of
@@ -626,7 +626,7 @@ public class Cipher
      * If this cipher (including its underlying feedback or padding scheme)
      * requires any random bytes (e.g., for parameter generation), it will get
      * them using the
-     * <a href="http://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
+     * <a href="https://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
      * <code>SecureRandom</code></a> implementation of the highest-priority
      * installed provider as the source of randomness.
      * (If none of the installed providers supply an implementation of
@@ -752,7 +752,7 @@ public class Cipher
      * If this cipher (including its underlying feedback or padding scheme)
      * requires any random bytes (e.g., for parameter generation), it will get
      * them using the
-     * <a href="http://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
+     * <a href="https://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
      * <code>SecureRandom</code></a>
      * implementation of the highest-priority installed provider as the source of randomness.
      * (If none of the installed providers supply an implementation of

--- a/jce/src/main/java/javax/crypto/KeyAgreement.java
+++ b/jce/src/main/java/javax/crypto/KeyAgreement.java
@@ -193,7 +193,7 @@ public class KeyAgreement
      * contain all the algorithm parameters required for this key agreement.
      * <p>
      * If this key agreement requires any random bytes, it will get
-     * them using the <a href="http://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
+     * them using the <a href="https://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
      * <code>SecureRandom</code></a> implementation of the highest-priority
      * installed provider as the source of randomness.
      * (If none of the installed providers supply an implementation of
@@ -245,7 +245,7 @@ public class KeyAgreement
      * algorithm parameters.
      * <p>
      * If this key agreement requires any random bytes, it will get
-     * them using the <a href="http://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
+     * them using the <a href="https://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
      * <code>SecureRandom</code></a> implementation of the highest-priority
      * installed provider as the source of randomness.
      * (If none of the installed providers supply an implementation of

--- a/jce/src/main/java/javax/crypto/KeyGenerator.java
+++ b/jce/src/main/java/javax/crypto/KeyGenerator.java
@@ -226,7 +226,7 @@ public class KeyGenerator
      * Initializes this key generator with the specified parameter set.
      * <p>
      * If this key generator requires any random bytes, it will get them
-     * using the * <a href="http://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
+     * using the * <a href="https://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
      * <code>SecureRandom</code></a> implementation of the highest-priority installed
      * provider as the source of randomness.
      * (If none of the installed providers supply an implementation of
@@ -262,7 +262,7 @@ public class KeyGenerator
      * Initializes this key generator for a certain keysize.
      * <p>
      * If this key generator requires any random bytes, it will get them using the
-     * <a href="http://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
+     * <a href="https://java.sun.com/products/jdk/1.2/docs/api/java.security.SecureRandom.html">
      * <code>SecureRandom</code></a> implementation of the highest-priority installed provider as
      * the source of randomness. (If none of the installed providers supply an implementation of
      * SecureRandom, a system-provided source of randomness will be used.)

--- a/jce/src/main/java/javax/crypto/spec/DHGenParameterSpec.java
+++ b/jce/src/main/java/javax/crypto/spec/DHGenParameterSpec.java
@@ -20,7 +20,7 @@ public class DHGenParameterSpec
     /**
      * Constructs a parameter set for the generation of Diffie-Hellman
      * (system) parameters. The constructed parameter set can be used to
-     * initialize an <a href="http://java.sun.com/products/jdk/1.2/docs/api/java.security.AlgorithmParameterGenerator.html"><code>AlgorithmParameterGenerator</code></a>
+     * initialize an <a href="https://java.sun.com/products/jdk/1.2/docs/api/java.security.AlgorithmParameterGenerator.html"><code>AlgorithmParameterGenerator</code></a>
      * object for the generation of Diffie-Hellman parameters.
      *
      * @param primeSize the size (in bits) of the prime modulus.

--- a/jce/src/main/java/javax/crypto/spec/PBEParameterSpec.java
+++ b/jce/src/main/java/javax/crypto/spec/PBEParameterSpec.java
@@ -4,7 +4,7 @@ import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * This class specifies the set of parameters used with password-based encryption (PBE), as defined in the
- * <a href="http://www.rsa.com/rsalabs/pubs/PKCS/html/pkcs-5.html">PKCS #5</a> standard.
+ * <a href="https://www.rsa.com/rsalabs/pubs/PKCS/html/pkcs-5.html">PKCS #5</a> standard.
  */
 public class PBEParameterSpec
     implements AlgorithmParameterSpec

--- a/jce/src/main/java/javax/crypto/spec/PSource.java
+++ b/jce/src/main/java/javax/crypto/spec/PSource.java
@@ -2,7 +2,7 @@ package javax.crypto.spec;
 
 /**
  * This class specifies the source for encoding input P in OAEP Padding, as
- * defined in the {@link http://www.ietf.org/rfc/rfc3447.txt PKCS #1} standard.
+ * defined in the {@link https://www.ietf.org/rfc/rfc3447.txt PKCS #1} standard.
  * 
  * <pre>
  *  

--- a/jce/src/main/java/javax/crypto/spec/RC2ParameterSpec.java
+++ b/jce/src/main/java/javax/crypto/spec/RC2ParameterSpec.java
@@ -4,7 +4,7 @@ import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * This class specifies the parameters used with the
- * <a href="http://www.rsa.com/rsalabs/newfaq/q75.html"><i>RC2</i></a>
+ * <a href="https://www.rsa.com/rsalabs/newfaq/q75.html"><i>RC2</i></a>
  * algorithm.
  * <p>
  * The parameters consist of an effective key size and optionally

--- a/jce/src/main/java/javax/crypto/spec/RC5ParameterSpec.java
+++ b/jce/src/main/java/javax/crypto/spec/RC5ParameterSpec.java
@@ -4,7 +4,7 @@ import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * This class specifies the parameters used with the
- *  <a href="http://www.rsa.com/rsalabs/newfaq/q76.html"><i>RC5</i></a>
+ *  <a href="https://www.rsa.com/rsalabs/newfaq/q76.html"><i>RC5</i></a>
  *  algorithm.
  *  <p>
  *  The parameters consist of a version number, a rounds count, a word
@@ -12,7 +12,7 @@ import java.security.spec.AlgorithmParameterSpec;
  *  <p>
  *  This class can be used to initialize a <code>Cipher</code> object that
  *  implements the <i>RC5</i> algorithm as supplied by
- *  <a href="http://www.rsa.com">RSA Data Security, Inc.</a> (RSA DSI),
+ *  <a href="https://www.rsa.com">RSA Data Security, Inc.</a> (RSA DSI),
  *  or any parties authorized by RSA DSI.
  */
 public class RC5ParameterSpec

--- a/mail/src/test/java/org/bouncycastle/mail/smime/test/SMIMETestSetup.java
+++ b/mail/src/test/java/org/bouncycastle/mail/smime/test/SMIMETestSetup.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 The Legion Of The Bouncy Castle (http://www.bouncycastle.org)
+// Copyright (c) 2005 The Legion Of The Bouncy Castle (https://www.bouncycastle.org)
 package org.bouncycastle.mail.smime.test;
 
 import junit.extensions.TestSetup;

--- a/pg/src/main/java/org/bouncycastle/apache/bzip2/BZip2Constants.java
+++ b/pg/src/main/java/org/bouncycastle/apache/bzip2/BZip2Constants.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pg/src/main/java/org/bouncycastle/apache/bzip2/CBZip2InputStream.java
+++ b/pg/src/main/java/org/bouncycastle/apache/bzip2/CBZip2InputStream.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pg/src/main/java/org/bouncycastle/apache/bzip2/CBZip2OutputStream.java
+++ b/pg/src/main/java/org/bouncycastle/apache/bzip2/CBZip2OutputStream.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pg/src/main/java/org/bouncycastle/apache/bzip2/CRC.java
+++ b/pg/src/main/java/org/bouncycastle/apache/bzip2/CRC.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pg/src/main/java/org/bouncycastle/gpg/SXprUtils.java
+++ b/pg/src/main/java/org/bouncycastle/gpg/SXprUtils.java
@@ -11,7 +11,7 @@ import org.bouncycastle.util.io.Streams;
  * Utility functions for looking a S-expression keys. This class will move when it finds a better home!
  * <p>
  * Format documented here:
- * http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=agent/keyformat.txt;h=42c4b1f06faf1bbe71ffadc2fee0fad6bec91a97;hb=refs/heads/master
+ * https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=agent/keyformat.txt;h=42c4b1f06faf1bbe71ffadc2fee0fad6bec91a97;hb=refs/heads/master
  * </p>
  */
 class SXprUtils

--- a/pg/src/main/java/org/bouncycastle/gpg/keybox/Blob.java
+++ b/pg/src/main/java/org/bouncycastle/gpg/keybox/Blob.java
@@ -9,7 +9,7 @@ import org.bouncycastle.util.Strings;
  * GnuPG keybox blob.
  * Based on:
  *
- * @see <a href="http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=kbx/keybox-blob.c;hb=HEAD"></a>
+ * @see <a href="https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=kbx/keybox-blob.c;hb=HEAD"></a>
  */
 
 public class Blob

--- a/pg/src/main/java/org/bouncycastle/gpg/keybox/bc/BcBlobVerifier.java
+++ b/pg/src/main/java/org/bouncycastle/gpg/keybox/bc/BcBlobVerifier.java
@@ -24,7 +24,7 @@ public class BcBlobVerifier
             //
 
           /*
-           http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=kbx/keybox-blob.c;hb=HEAD#l129
+           https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=kbx/keybox-blob.c;hb=HEAD#l129
            SHA-1 checksum (useful for KS syncronisation?)
            Note, that KBX versions before GnuPG 2.1 used an MD5
            checksum.  However it was only created but never checked.

--- a/pg/src/main/java/org/bouncycastle/gpg/keybox/jcajce/JcaBlobVerifier.java
+++ b/pg/src/main/java/org/bouncycastle/gpg/keybox/jcajce/JcaBlobVerifier.java
@@ -46,7 +46,7 @@ public class JcaBlobVerifier
             //
 
           /*
-           http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=kbx/keybox-blob.c;hb=HEAD#l129
+           https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=kbx/keybox-blob.c;hb=HEAD#l129
            SHA-1 checksum (useful for KS syncronisation?)
            Note, that KBX versions before GnuPG 2.1 used an MD5
            checksum.  However it was only created but never checked.

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPKeyRingTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPKeyRingTest.java
@@ -1148,7 +1148,7 @@ public class PGPKeyRingTest
         "POOoD7oxdRmJSU5hSspOCHrCwCa3");
 
 
-    // Key from http://www.angelfire.com/pr/pgpf/pgpoddities.html
+    // Key from https://www.angelfire.com/pr/pgpf/pgpoddities.html
     private static final char[] v3KeyPass = "test@key.test".toCharArray();
 
     private static final byte[] pubv3 = Base64.decode(

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPUnicodeTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPUnicodeTest.java
@@ -122,7 +122,7 @@ public class PGPUnicodeTest
             BigInteger keyId = new BigInteger("B7773AF32BE4EC1806B1BACC4680E7F3960C44E7", 16);
 
             // XXX The password text file must not have the UTF-8 BOM !
-            // Ref: http://stackoverflow.com/questions/2223882/whats-different-between-utf-8-and-utf-8-without-bom
+            // Ref: https://stackoverflow.com/questions/2223882/whats-different-between-utf-8-and-utf-8-without-bom
 
             InputStream passwordFile = this.getClass().getResourceAsStream("unicode/" + "passphrase_cyr.txt");
             Reader reader = new InputStreamReader(passwordFile, Charset.forName("UTF-8"));

--- a/pg/src/test/jdk1.1/org/bouncycastle/openpgp/test/PGPKeyRingTest.java
+++ b/pg/src/test/jdk1.1/org/bouncycastle/openpgp/test/PGPKeyRingTest.java
@@ -1129,7 +1129,7 @@ public class PGPKeyRingTest
         "POOoD7oxdRmJSU5hSspOCHrCwCa3");
 
 
-    // Key from http://www.angelfire.com/pr/pgpf/pgpoddities.html
+    // Key from https://www.angelfire.com/pr/pgpf/pgpoddities.html
     private static final char[] v3KeyPass = "test@key.test".toCharArray();
 
     private static final byte[] pubv3 = Base64.decode(

--- a/pkix/src/main/javadoc/org/bouncycastle/cert/cmp/package.html
+++ b/pkix/src/main/javadoc/org/bouncycastle/cert/cmp/package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <body bgcolor="#ffffff">
 Basic support package for handling and creating CMP (RFC 4210) certificate management messages.

--- a/pkix/src/main/javadoc/org/bouncycastle/cert/crmf/jcajce/package.html
+++ b/pkix/src/main/javadoc/org/bouncycastle/cert/crmf/jcajce/package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <body bgcolor="#ffffff">
 JCA extensions to the CRMF online certificate request package.

--- a/pkix/src/main/javadoc/org/bouncycastle/cert/crmf/package.html
+++ b/pkix/src/main/javadoc/org/bouncycastle/cert/crmf/package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <body bgcolor="#ffffff">
 Basic support package for handling and creating CRMF (RFC 4211) certificate request messages.

--- a/pkix/src/main/javadoc/org/bouncycastle/cert/jcajce/package.html
+++ b/pkix/src/main/javadoc/org/bouncycastle/cert/jcajce/package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <body bgcolor="#ffffff">
 JCA extensions to the certificate building and processing package.

--- a/pkix/src/main/javadoc/org/bouncycastle/cert/ocsp/jcajce/package.html
+++ b/pkix/src/main/javadoc/org/bouncycastle/cert/ocsp/jcajce/package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <body bgcolor="#ffffff">
 JCA extensions to the OCSP online certificate status package.

--- a/pkix/src/main/javadoc/org/bouncycastle/cert/ocsp/package.html
+++ b/pkix/src/main/javadoc/org/bouncycastle/cert/ocsp/package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <body bgcolor="#ffffff">
 Basic support package for handling and creating OCSP (RFC 2560) online certificate status requests.

--- a/pkix/src/main/javadoc/org/bouncycastle/cert/selector/package.html
+++ b/pkix/src/main/javadoc/org/bouncycastle/cert/selector/package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <body bgcolor="#ffffff">
 Specialised Selector classes for certificates, CRLs, and attribute certificates.

--- a/pkix/src/main/javadoc/org/bouncycastle/pkcs/bc/package.html
+++ b/pkix/src/main/javadoc/org/bouncycastle/pkcs/bc/package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <body bgcolor="#ffffff">
 BC lightweight API extensions and operators for the PKCS#10 certification request package.

--- a/pkix/src/main/javadoc/org/bouncycastle/pkcs/jcajce/package.html
+++ b/pkix/src/main/javadoc/org/bouncycastle/pkcs/jcajce/package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <body bgcolor="#ffffff">
 JCA extensions and operators for the PKCS#10 certification request package.

--- a/pkix/src/main/javadoc/org/bouncycastle/pkcs/package.html
+++ b/pkix/src/main/javadoc/org/bouncycastle/pkcs/package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <body bgcolor="#ffffff">
 Basic support package for handling and creating PKCS#10 certification requests, PKCS#8 encrypted keys and PKCS#12 keys stores.

--- a/pkix/src/test/java/org/bouncycastle/pkcs/test/BCTestSetup.java
+++ b/pkix/src/test/java/org/bouncycastle/pkcs/test/BCTestSetup.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2005 The Legion Of The Bouncy Castle (http://www.bouncycastle.org)
+// Copyright (c) 2005 The Legion Of The Bouncy Castle (https://www.bouncycastle.org)
 package org.bouncycastle.pkcs.test;
 
 import java.security.Security;

--- a/prov/src/main/java/org/bouncycastle/jce/provider/BrokenPBE.java
+++ b/prov/src/main/java/org/bouncycastle/jce/provider/BrokenPBE.java
@@ -24,7 +24,7 @@ import org.bouncycastle.jcajce.provider.symmetric.util.BCPBEKey;
  * use it (it won't be staying around).
  * <p>
  * The document this implementation is based on can be found at
- * <a href=http://www.rsasecurity.com/rsalabs/pkcs/pkcs-12/index.html>
+ * <a href=https://www.rsasecurity.com/rsalabs/pkcs/pkcs-12/index.html>
  * RSA's PKCS12 Page</a>
  */
 class OldPKCS12ParametersGenerator

--- a/prov/src/main/java/org/bouncycastle/pqc/jcajce/provider/rainbow/BCRainbowPrivateKey.java
+++ b/prov/src/main/java/org/bouncycastle/pqc/jcajce/provider/rainbow/BCRainbowPrivateKey.java
@@ -25,7 +25,7 @@ import org.bouncycastle.pqc.jcajce.spec.RainbowPrivateKeySpec;
  * </p><p>
  * More detailed information about the private key is to be found in the paper
  * of Jintai Ding, Dieter Schmidt: Rainbow, a New Multivariable Polynomial
- * Signature Scheme. ACNS 2005: 164-175 (http://dx.doi.org/10.1007/11496137_12)
+ * Signature Scheme. ACNS 2005: 164-175 (https://dx.doi.org/10.1007/11496137_12)
  * </p>
  */
 public class BCRainbowPrivateKey

--- a/prov/src/main/java/org/bouncycastle/pqc/jcajce/provider/rainbow/BCRainbowPublicKey.java
+++ b/prov/src/main/java/org/bouncycastle/pqc/jcajce/provider/rainbow/BCRainbowPublicKey.java
@@ -27,7 +27,7 @@ import org.bouncycastle.util.Arrays;
  * </p><p>
  * More detailed information on the public key is to be found in the paper of
  * Jintai Ding, Dieter Schmidt: Rainbow, a New Multivariable Polynomial
- * Signature Scheme. ACNS 2005: 164-175 (http://dx.doi.org/10.1007/11496137_12)
+ * Signature Scheme. ACNS 2005: 164-175 (https://dx.doi.org/10.1007/11496137_12)
  * </p>
  */
 public class BCRainbowPublicKey

--- a/prov/src/main/java/org/bouncycastle/pqc/jcajce/spec/RainbowParameterSpec.java
+++ b/prov/src/main/java/org/bouncycastle/pqc/jcajce/spec/RainbowParameterSpec.java
@@ -11,7 +11,7 @@ import org.bouncycastle.util.Arrays;
  * More detailed information about the needed parameters for the Rainbow
  * Signature Scheme is to be found in the paper of Jintai Ding, Dieter Schmidt:
  * Rainbow, a New Multivariable Polynomial Signature Scheme. ACNS 2005: 164-175
- * (http://dx.doi.org/10.1007/11496137_12)
+ * (https://dx.doi.org/10.1007/11496137_12)
  * </p>
  */
 public class RainbowParameterSpec

--- a/prov/src/main/java/org/bouncycastle/x509/util/LDAPStoreHelper.java
+++ b/prov/src/main/java/org/bouncycastle/x509/util/LDAPStoreHelper.java
@@ -56,9 +56,9 @@ import org.bouncycastle.x509.X509CertificatePair;
  * </p><p>
  * For the used schemes see:
  * <ul>
- * <li><a href="http://www.ietf.org/rfc/rfc2587.txt">RFC 2587</a>
+ * <li><a href="https://www.ietf.org/rfc/rfc2587.txt">RFC 2587</a>
  * <li><a
- * href="http://www3.ietf.org/proceedings/01mar/I-D/pkix-ldap-schema-01.txt">Internet
+ * href="https://www3.ietf.org/proceedings/01mar/I-D/pkix-ldap-schema-01.txt">Internet
  * X.509 Public Key Infrastructure Additional LDAP Schema for PKIs and PMIs</a>
  * </ul>
  */

--- a/prov/src/main/jdk1.4/org/bouncycastle/x509/util/LDAPStoreHelper.java
+++ b/prov/src/main/jdk1.4/org/bouncycastle/x509/util/LDAPStoreHelper.java
@@ -56,9 +56,9 @@ import org.bouncycastle.x509.X509CertificatePair;
  * </p><p>
  * For the used schemes see:
  * <ul>
- * <li><a href="http://www.ietf.org/rfc/rfc2587.txt">RFC 2587</a>
+ * <li><a href="https://www.ietf.org/rfc/rfc2587.txt">RFC 2587</a>
  * <li><a
- * href="http://www3.ietf.org/proceedings/01mar/I-D/pkix-ldap-schema-01.txt">Internet
+ * href="https://www3.ietf.org/proceedings/01mar/I-D/pkix-ldap-schema-01.txt">Internet
  * X.509 Public Key Infrastructure Additional LDAP Schema for PKIs and PMIs</a>
  * </ul>
  * </p>

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/CMacTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/CMacTest.java
@@ -12,7 +12,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.test.SimpleTest;
 
 /**
- * CMAC tester - <a href="http://www.nuee.nagoya-u.ac.jp/labs/tiwata/omac/tv/omac1-tv.txt">AES Official Test Vectors</a>.
+ * CMAC tester - <a href="https://www.nuee.nagoya-u.ac.jp/labs/tiwata/omac/tv/omac1-tv.txt">AES Official Test Vectors</a>.
  */
 public class CMacTest
     extends SimpleTest

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/FIPSDESTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/FIPSDESTest.java
@@ -23,7 +23,7 @@ import org.bouncycastle.util.test.TestResult;
 
 /**
  * basic FIPS test class for a block cipher, just to make sure ECB/CBC/OFB/CFB are behaving
- * correctly. Tests from <a href=http://www.itl.nist.gov/fipspubs/fip81.htm>FIPS 81</a>.
+ * correctly. Tests from <a href=https://www.itl.nist.gov/fipspubs/fip81.htm>FIPS 81</a>.
  */
 public class FIPSDESTest
     implements Test

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/MacTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/MacTest.java
@@ -13,8 +13,8 @@ import org.bouncycastle.util.test.SimpleTest;
 
 /**
  * MAC tester - vectors from 
- * <a href=http://www.itl.nist.gov/fipspubs/fip81.htm>FIP 81</a> and 
- * <a href=http://www.itl.nist.gov/fipspubs/fip113.htm>FIP 113</a>.
+ * <a href=https://www.itl.nist.gov/fipspubs/fip81.htm>FIP 81</a> and
+ * <a href=https://www.itl.nist.gov/fipspubs/fip113.htm>FIP 113</a>.
  */
 public class MacTest
     extends SimpleTest

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/NISTCertPathTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/NISTCertPathTest.java
@@ -26,7 +26,7 @@ import org.bouncycastle.util.test.SimpleTest;
 
 /*
  * These tests are taken from the NIST X.509 Validation Test Suite
- * available at: http://csrc.nist.gov/pki/testing/x509paths.html
+ * available at: https://csrc.nist.gov/pki/testing/x509paths.html
  * 
  * Only the relevant certificate and crl data has been kept, in order
  * to keep the class size to a minimum.

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/PKIXTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/PKIXTest.java
@@ -18,7 +18,7 @@ public class PKIXTest
 {
     /*
      * The following certs and crls are described in:
-     * http://www.ietf.org/internet-drafts/draft-ietf-pkix-new-part1-08.txt
+     * https://www.ietf.org/internet-drafts/draft-ietf-pkix-new-part1-08.txt
      *
      *   This section contains four examples: three certificates and a CRL.
      *   The first two certificates and the CRL comprise a minimal
@@ -150,8 +150,8 @@ public class PKIXTest
         * (g)  the certificate is an end entity certificate (not a CA
         * certificate);
         * (h)  the certificate includes an alternative subject name of
-     *    "<http://www.itl.nist.gov/div893/staff/polk/index.html>" and an
-        * alternative issuer name of "<http://www.nist.gov/>" - both are URLs;
+     *    "<https://www.itl.nist.gov/div893/staff/polk/index.html>" and an
+        * alternative issuer name of "<https://www.nist.gov/>" - both are URLs;
         * (i)  the certificate include an authority key identifier extension
         * and a certificate policies extension psecifying the policy OID
         * 2.16.840.1.101.3.2.1.48.9; and

--- a/prov/src/test/jdk1.3/org/bouncycastle/jce/provider/test/NISTCertPathTest.java
+++ b/prov/src/test/jdk1.3/org/bouncycastle/jce/provider/test/NISTCertPathTest.java
@@ -26,7 +26,7 @@ import org.bouncycastle.util.test.SimpleTest;
 
 /*
  * These tests are taken from the NIST X.509 Validation Test Suite
- * available at: http://csrc.nist.gov/pki/testing/x509paths.html
+ * available at: https://csrc.nist.gov/pki/testing/x509paths.html
  * 
  * Only the relevant certificate and crl data has been kept, in order
  * to keep the class size to a minimum.

--- a/prov/src/test/resources/PKITS/README
+++ b/prov/src/test/resources/PKITS/README
@@ -1,3 +1,3 @@
-PKITS test data from http://csrc.nist.gov/pki/testing/x509paths.html
+PKITS test data from https://csrc.nist.gov/pki/testing/x509paths.html
 
 For more details please check the website above.

--- a/tls/docs/GnuTLSSetup.html
+++ b/tls/docs/GnuTLSSetup.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+    "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
 <body>
 <h3>Instructions for setting up a GnuTLS server for use with DTLSClientTest, TlsClientTest.</h3>
 <ul>
-<li> Download GnuTLS from http://www.gnutls.org/download.html
+<li> Download GnuTLS from https://www.gnutls.org/download.html
 
 <li> Unpack to folder and add ${GNUTLS_HOME}/bin to PATH
 
@@ -25,6 +25,6 @@
 </ul>
 </li>
 </ul>
-<p> Further information in GnuTLS documentation at <a href="http://www.gnutls.org/documentation.html">http://www.gnutls.org/documentation.html</a> see "7.2. Invoking gnutls-serv", section titled "gnutls-serv Examples" if you want to generate your own keys and certificates.</p>
+<p> Further information in GnuTLS documentation at <a href="https://www.gnutls.org/documentation.html">https://www.gnutls.org/documentation.html</a> see "7.2. Invoking gnutls-serv", section titled "gnutls-serv Examples" if you want to generate your own keys and certificates.</p>
 </body>
 </html>

--- a/tls/docs/OpenSSLSetup.html
+++ b/tls/docs/OpenSSLSetup.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+    "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
 <body>
 <h3>Instructions for setting up an OpenSSL server for use with DTLSClientTest, DTLSServerTest, TlsClientTest, TlsServerTest.</h3>
 


### PR DESCRIPTION
HTTP is a plaintext protocol which means that someone may be able to eavesdrop the data. To prevent this, HTTPS should be used whenever possible. However, maintaining using `https://` in all URLs may be difficult. The `nohttp` tool can help here. The tool scans all the files in a repository and reports where `http://` is used.

Here is a list of main updates:

- Updated `build.gradle` to call `nohttp` during the build.
- Updated `http://` to `https://` in URLs.
- Added an exclude list.

Sorry for many updated files. All the findings had to be fixed or suppressed.

Here are some info about the tool:

- https://github.com/spring-io/nohttp
- https://spring.io/blog/2019/06/10/announcing-nohttp