### PR TITLE
Closeable ContentSigner

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/operator/BufferingContentSigner.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/BufferingContentSigner.java
@@ -67,4 +67,14 @@ public class BufferingContentSigner
     {
         return contentSigner.getSignature();
     }
+
+    @Override
+    public void close() throws Exception
+    {
+        output.close();
+        if (contentSigner != null)
+        {
+            contentSigner.close();
+        }
+    }
 }

--- a/pkix/src/main/java/org/bouncycastle/operator/ContentSigner.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/ContentSigner.java
@@ -8,7 +8,7 @@ import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
  * General interface for an operator that is able to create a signature from
  * a stream of output.
  */
-public interface ContentSigner
+public interface ContentSigner extends AutoCloseable
 {
     /**
      * Return the algorithm identifier describing the signature

--- a/pkix/src/main/java/org/bouncycastle/operator/bc/BcContentSignerBuilder.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/bc/BcContentSignerBuilder.java
@@ -1,5 +1,6 @@
 package org.bouncycastle.operator.bc;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.security.SecureRandom;
 import java.util.Map;
@@ -51,7 +52,7 @@ public abstract class BcContentSignerBuilder
 
         return new ContentSigner()
         {
-            private BcSignerOutputStream stream = new BcSignerOutputStream(sig);
+            private final BcSignerOutputStream stream = new BcSignerOutputStream(sig);
 
             public AlgorithmIdentifier getAlgorithmIdentifier()
             {
@@ -73,6 +74,12 @@ public abstract class BcContentSignerBuilder
                 {
                     throw new RuntimeOperatorException("exception obtaining signature: " + e.getMessage(), e);
                 }
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                stream.close();
             }
         };
     }

--- a/pkix/src/main/java/org/bouncycastle/operator/jcajce/JcaContentSignerBuilder.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/jcajce/JcaContentSignerBuilder.java
@@ -125,7 +125,7 @@ public class JcaContentSignerBuilder
 
             return new ContentSigner()
             {
-                private OutputStream stream = OutputStreamFactory.createStream(sig);
+                private final OutputStream stream = OutputStreamFactory.createStream(sig);
 
                 public AlgorithmIdentifier getAlgorithmIdentifier()
                 {
@@ -147,6 +147,12 @@ public class JcaContentSignerBuilder
                     {
                         throw new RuntimeOperatorException("exception obtaining signature: " + e.getMessage(), e);
                     }
+                }
+
+                @Override
+                public void close() throws IOException
+                {
+                    stream.close();
                 }
             };
         }
@@ -189,7 +195,7 @@ public class JcaContentSignerBuilder
 
             return new ContentSigner()
             {
-                OutputStream stream = sigStream;
+                final OutputStream stream = sigStream;
 
                 public AlgorithmIdentifier getAlgorithmIdentifier()
                 {
@@ -221,6 +227,15 @@ public class JcaContentSignerBuilder
                     catch (SignatureException e)
                     {
                         throw new RuntimeOperatorException("exception obtaining signature: " + e.getMessage(), e);
+                    }
+                }
+
+                @Override
+                public void close() throws Exception
+                {
+                    if (stream != null)
+                    {
+                        stream.close();
                     }
                 }
             };


### PR DESCRIPTION
`ContentSigner` objects hold an output stream that may need to be closed to prevent resource leaks. A caller can get the stream by calling `getOutputStream()` method, and close it once the work is done. However, it may be easy to forget to do that.

If `ContentSigner` extended `AutoCloseable`:
- a caller could use it in a try-with-resources block
- static analysis tools could detect places where a `ContentSigner.close()` is not called

Updating `ContentSigner` to extend `AutoCloseable` is definitely an update in the public API. That may potentially result to compilation errors in client apps. Those errors should be easy to fix thought. Moreover, those errors may make developers look at and fix possible resource leaks in their code.

Here is a summary of the update:

- Updated interface `ContentSigner` to extend `AutoCloseable`.
- Implemented `close()` method in several anonymous classes that implement `ContentSigner`.