### PR TITLE
Add addSubkeyBindingCertification method to PGPPublicKey

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -19,6 +19,7 @@ import org.bouncycastle.bcpg.ECPublicBCPGKey;
 import org.bouncycastle.bcpg.ElGamalPublicBCPGKey;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.bouncycastle.bcpg.PublicKeyPacket;
+import org.bouncycastle.bcpg.PublicSubkeyPacket;
 import org.bouncycastle.bcpg.RSAPublicBCPGKey;
 import org.bouncycastle.bcpg.SignatureSubpacketTags;
 import org.bouncycastle.bcpg.TrustPacket;
@@ -1011,6 +1012,35 @@ public class PGPPublicKey
 
         return returnKey;
     }
+
+    /**
+     * Add a subkey binding certification, changing the key type from master to subkey.
+     *
+     * @param key the key the revocation is to be added to.
+     * @param certification the key signature to be added.
+     * @return the new changed public key object.
+     */
+    public static PGPPublicKey addSubkeyBindingCertification(
+            PGPPublicKey    key,
+            PGPSignature    certification)
+    {
+        // make sure no subSigs are previously present
+        if (!key.isMasterKey())
+        {
+            throw new IllegalArgumentException("key is already a subkey!");
+        }
+
+        PGPPublicKey    returnKey = new PGPPublicKey(key);
+
+        // change the packet type from key to subkey
+        returnKey.publicPk = new PublicSubkeyPacket(
+                returnKey.publicPk.getAlgorithm(), returnKey.publicPk.getTime(), returnKey.publicPk.getKey());
+
+        returnKey.subSigs = new ArrayList();
+        returnKey.subSigs.add(certification);
+        return returnKey;
+    }
+
 
     /**
      * Add a revocation or some other key certification to a key.


### PR DESCRIPTION
Hi!
This is the first of (probably) a series of pull requests that aim to upstream some of the useful changes the OpenKeychain project made in their fork of bouncycastle.

This PR adds the method `addSubkeyBindingCertification` to `PGPPublicKey` which enables the user to add subkeys to existing `PGPPublicKeyRing`s. This is to my knowledge not possible without this change.