### PR TITLE
Pull setWithIntegrityPacket up into PGPDataEncryptorBuilder interface

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PGPDataEncryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PGPDataEncryptorBuilder.java
@@ -34,4 +34,6 @@ public interface PGPDataEncryptorBuilder
      * constructed and retained by the this builder.</p>
      */
     SecureRandom getSecureRandom();
+
+    PGPDataEncryptorBuilder setWithIntegrityPacket(boolean withIntegrityPacket);
 }

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPDataEncryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPDataEncryptorBuilder.java
@@ -45,6 +45,7 @@ public class BcPGPDataEncryptorBuilder
      * @param withIntegrityPacket true if an integrity packet is to be included, false otherwise.
      * @return the current builder.
      */
+    @Override
     public BcPGPDataEncryptorBuilder setWithIntegrityPacket(boolean withIntegrityPacket)
     {
         this.withIntegrityPacket = withIntegrityPacket;

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePGPDataEncryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePGPDataEncryptorBuilder.java
@@ -58,6 +58,7 @@ public class JcePGPDataEncryptorBuilder
      * @param withIntegrityPacket true if an integrity packet is to be included, false otherwise.
      * @return the current builder.
      */
+    @Override
     public JcePGPDataEncryptorBuilder setWithIntegrityPacket(boolean withIntegrityPacket)
     {
         this.withIntegrityPacket = withIntegrityPacket;


### PR DESCRIPTION
Both the Jce as well as the Bc implementation of `PGPDataEncryptorBuilder` do have a `setWithIntegrityPacket(boolean)` method, which however is not present in the parent interface.

This PR simply pulls up the method declaration into the interface.