### PR TITLE
Properly rewind streams for messages with multiple SKESK packets

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/InputStreamPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/InputStreamPacket.java
@@ -1,27 +1,27 @@
 package org.bouncycastle.bcpg;
 
+import java.io.BufferedInputStream;
+
 /**
  * A block of data associated with other packets in a PGP object stream.
  */
 public class InputStreamPacket
     extends Packet
 {
-    private BCPGInputStream        in;
+    private BufferedInputStream        in;
 
     public InputStreamPacket(
         BCPGInputStream  in)
     {
-        this.in = in;
+        this.in = new BufferedInputStream(in);
     }
 
     /**
      * Obtains an input stream to read the contents of the packet.
-     * <p>
-     * Note: you can only read from this once...
-     * </p>
+     *
      * @return the data in this packet.
      */
-    public BCPGInputStream getInputStream()
+    public BufferedInputStream getInputStream()
     {
         return in;
     }

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/RewindStreamWhenDecryptingMultiSKESKMessageTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/RewindStreamWhenDecryptingMultiSKESKMessageTest.java
@@ -1,0 +1,99 @@
+package org.bouncycastle.openpgp.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import org.bouncycastle.openpgp.PGPCompressedData;
+import org.bouncycastle.openpgp.PGPEncryptedData;
+import org.bouncycastle.openpgp.PGPEncryptedDataList;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPLiteralData;
+import org.bouncycastle.openpgp.PGPObjectFactory;
+import org.bouncycastle.openpgp.PGPPBEEncryptedData;
+import org.bouncycastle.openpgp.PGPUtil;
+import org.bouncycastle.openpgp.bc.BcPGPObjectFactory;
+import org.bouncycastle.openpgp.operator.PBEDataDecryptorFactory;
+import org.bouncycastle.openpgp.operator.bc.BcPBEDataDecryptorFactory;
+import org.bouncycastle.openpgp.operator.bc.BcPGPDigestCalculatorProvider;
+import org.bouncycastle.util.io.Streams;
+
+public class RewindStreamWhenDecryptingMultiSKESKMessageTest {
+
+    private static final byte[] message = "Hello World!\n".getBytes(StandardCharsets.UTF_8);
+
+    public static void main(String[] args) throws Exception {
+        decryptFaultyExample();
+    }
+
+    // pgpMessage was symmetrically encrypted using "password1" and "password2".
+    // As the "password2" SKESK comes after "password1", but decryption of the
+    // "password1" SKESK would result in a session key that looks okay, decryption
+    // would commence and then fail when the checksum check fails.
+    // After that the "password2" SKESK would be decrypted with "password2" which results
+    // in the correct session key, but the encryption stream was already advanced, resulting
+    // in a PGPDataViolationException or EOFException.
+    // This has been fixed and this test verifies the now correct behavior.
+    // Note that GnuPG < 2.3 also fails to decrypt the pgpMessage correctly.
+    public static void decryptFaultyExample() throws Exception {
+        String pgpMessage = "-----BEGIN PGP MESSAGE-----\n" +
+                "Version: BCPG v1.68\n" +
+                "\n" +
+                "jC4ECQMCtL4bq5btiMJgL6wPT4kDozGheHZa1fmAUpp3CIBeLXw4B3IUZ05QSPRF\n" +
+                "jC4ECQMC5nZ8aoh9uYpgtDeGdkTLP+obVSiMvs99ibpcFm60vJY7feYNTiSk2StJ\n" +
+                "0kgB9vDAT0vUdXz1sPTEv2YIK2zeNyoA7pD9BDd68VgFVj61vSQ6Ovf6Uidv2v0M\n" +
+                "5cfawfKpjRn0Ku3JEzDv3TuYioRWzuzxptc=\n" +
+                "=9QAC\n" +
+                "-----END PGP MESSAGE-----\n";
+
+        byte[] decrypted = decrypt(pgpMessage.getBytes(StandardCharsets.UTF_8), "password2");
+        if (!Arrays.equals(message, decrypted)) {
+            throw new Exception("Decryption unsuccessful.");
+        }
+    }
+
+    public static byte[] decrypt(byte[] ciphertext, String password) throws IOException, PGPException {
+        InputStream stream = PGPUtil.getDecoderStream(new ByteArrayInputStream(ciphertext));
+        PGPObjectFactory objectFactory = new BcPGPObjectFactory(stream);
+        Object o = objectFactory.nextObject();
+        if (o instanceof PGPEncryptedDataList) {
+            PGPEncryptedDataList dataList = (PGPEncryptedDataList) o;
+            Iterator<PGPEncryptedData> iterator = dataList.iterator();
+            while (iterator.hasNext()) {
+                PGPEncryptedData data = iterator.next();
+                if (data instanceof PGPPBEEncryptedData) {
+                    PGPPBEEncryptedData pbeData = (PGPPBEEncryptedData) data;
+                    try {
+                        PBEDataDecryptorFactory decryptorFactory = new BcPBEDataDecryptorFactory(password.toCharArray(), new BcPGPDigestCalculatorProvider());
+                        InputStream decryptionStream = pbeData.getDataStream(decryptorFactory);
+                        byte[] decrypted = decryptIntern(decryptionStream);
+                        return decrypted;
+                    } catch (PGPException e) {
+                        // Wrong passphrase for this block.
+                    }
+                }
+            }
+        }
+
+        throw new PGPException("Decryption failed.");
+    }
+
+    private static byte[] decryptIntern(InputStream inputStream) throws IOException {
+        PGPObjectFactory objectFactory = new BcPGPObjectFactory(inputStream);
+        Object object = objectFactory.nextObject();
+        if (object instanceof PGPCompressedData) {
+            PGPCompressedData compressedData = (PGPCompressedData) object;
+            return decryptIntern(compressedData.getInputStream());
+        } else if (object instanceof PGPLiteralData) {
+            PGPLiteralData literalData = (PGPLiteralData) object;
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            Streams.pipeAll(literalData.getInputStream(), outputStream);
+            return outputStream.toByteArray();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
This fixes #880

When an OpenPGP message was encrypted with multiple encryption methods, eg. symmetric keys,
it would sometimes happen that the first SKESK (symmetric-key encrypted session key packet) would be decrypted with a wrong passphrase. This would most of the time fail, as the very first byte of the result that notates the used symmetric encryption algorithm would often not be a valid algorithm id.
However, sometimes (3.5% of times) it would match a valid algorithm ID.
Decryption would then commence, reading some bytes from the SEIP (symmetrically encrypted integrity-protected data packet).
The number of bytes that would be read is equal to the length of the IV of the symmetric encryption algorithm plus 2 bytes checksum.
Decryption would then finally fail due to checksum mismatch.
Note that BC would not rewind the SEIP inputstream.

Now when the next SKESK would be decrypted using the correct passphrase, BC would again decrypt it, this time resulting in the correct session key. When this session key was used to decrypt the SEIP inputstream, either an EOFException would be thrown, or the checksum would again mismatch, as the first (iv.length + 2) octets were lost in the previous decryption attempt.

This PR fixes the issue by wrapping the SEIP input stream with a bufferedInputStream and resetting it after a decryption attempt failed.