### PR TITLE
ArmoredOutputStream: Add method to clear out all headers

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
@@ -181,6 +181,13 @@ public class ArmoredOutputStream
         }
     }
 
+    /**
+     * Remove all headers.
+     */
+    public void noHeaders() {
+        headers.clear();
+    }
+
 
     /**
      * Set an additional header entry. The current value(s) will continue to exist together


### PR DESCRIPTION
This PR adds a method to remove all headers from the ArmoredOutputStream.
This is useful to prevent fingerprinting.