### PR TITLE
Allow empty password in PKCS12KeyStoreSpi.

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/keystore/pkcs12/PKCS12KeyStoreSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/keystore/pkcs12/PKCS12KeyStoreSpi.java
@@ -836,7 +836,7 @@ public class PKCS12KeyStoreSpi
                 throw new IOException("error constructing MAC: " + e.toString());
             }
         }
-        else if (password != null)
+        else if (password != null && password.length != 0)
         {
             if (!Properties.isOverrideSet("org.bouncycastle.pkcs12.ignore_useless_passwd"))
             {

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/PKCS12StoreTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/PKCS12StoreTest.java
@@ -624,6 +624,10 @@ public class PKCS12StoreTest
 
         isTrue(pkcs12.containsAlias("alias"));
 
+        pkcs12.load(new ByteArrayInputStream(certsOnly), new char[] {});
+
+        isTrue(pkcs12.containsAlias("alias"));
+
         try
         {
             pkcs12.load(new ByteArrayInputStream(certsOnly), "1".toCharArray());


### PR DESCRIPTION
Previously empty array was considered as effective password.