### PR TITLE
Generify most lists and iterators in PGP key/-ring classes

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRing.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRing.java
@@ -43,13 +43,13 @@ public abstract class PGPKeyRing
             :   null;
     }
 
-    static List readSignaturesAndTrust(
+    static List<PGPSignature> readSignaturesAndTrust(
         BCPGInputStream pIn)
         throws IOException
     {
         try
         {
-            List sigList = new ArrayList();
+            List<PGPSignature> sigList = new ArrayList<>();
 
             while (pIn.nextPacketTag() == PacketTags.SIGNATURE)
             {
@@ -71,8 +71,8 @@ public abstract class PGPKeyRing
     static void readUserIDs(
         BCPGInputStream pIn,
         List ids,
-        List idTrusts,
-        List idSigs)
+        List<TrustPacket> idTrusts,
+        List<List<PGPSignature>> idSigs)
         throws IOException
     {
         while (pIn.nextPacketTag() == PacketTags.USER_ID

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRingGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRingGenerator.java
@@ -18,10 +18,10 @@ import org.bouncycastle.openpgp.operator.PGPDigestCalculator;
  */
 public class PGPKeyRingGenerator
 {    
-    List                                keys = new ArrayList();
+    List<PGPSecretKey>                  keys = new ArrayList<>();
 
     private PBESecretKeyEncryptor       keyEncryptor;
-    private PGPDigestCalculator checksumCalculator;
+    private PGPDigestCalculator         checksumCalculator;
     private PGPKeyPair                  masterKey;
     private PGPSignatureSubpacketVector hashedPcks;
     private PGPSignatureSubpacketVector unhashedPcks;
@@ -87,8 +87,8 @@ public class PGPKeyRingGenerator
         this.checksumCalculator = checksumCalculator;
         this.keySignerBuilder = keySignerBuilder;
 
-        PGPSignature certSig = (PGPSignature)originalSecretRing.getPublicKey().getSignatures().next();
-        List hashedVec = new ArrayList();
+        PGPSignature certSig = originalSecretRing.getPublicKey().getSignatures().next();
+        List<SignatureSubpacket> hashedVec = new ArrayList<>();
         PGPSignatureSubpacketVector existing = certSig.getHashedSubPackets();
         for (int i = 0; i != existing.size(); i++)
         {
@@ -99,7 +99,7 @@ public class PGPKeyRingGenerator
             hashedVec.add(existing.packets[i]);
         }
         this.hashedPcks = new PGPSignatureSubpacketVector(
-            (SignatureSubpacket[])hashedVec.toArray(new SignatureSubpacket[hashedVec.size()]));
+                hashedVec.toArray(new SignatureSubpacket[0]));
         this.unhashedPcks = certSig.getUnhashedSubPackets();
 
         keys.addAll(originalSecretRing.keys);
@@ -146,7 +146,7 @@ public class PGPKeyRingGenerator
             sGen.setHashedSubpackets(hashedPcks);
             sGen.setUnhashedSubpackets(unhashedPcks);
 
-            List                 subSigs = new ArrayList();
+            List<PGPSignature> subSigs = new ArrayList<>();
             
             subSigs.add(sGen.generateCertification(masterKey.getPublicKey(), keyPair.getPublicKey()));
 
@@ -184,14 +184,14 @@ public class PGPKeyRingGenerator
      */
     public PGPPublicKeyRing generatePublicKeyRing()
     {
-        Iterator it = keys.iterator();
-        List     pubKeys = new ArrayList();
+        Iterator<PGPSecretKey> it = keys.iterator();
+        List<PGPPublicKey>     pubKeys = new ArrayList<>();
         
-        pubKeys.add(((PGPSecretKey)it.next()).getPublicKey());
+        pubKeys.add(it.next().getPublicKey());
         
         while (it.hasNext())
         {
-            pubKeys.add(((PGPSecretKey)it.next()).getPublicKey());
+            pubKeys.add(it.next().getPublicKey());
         }
         
         return new PGPPublicKeyRing(pubKeys);

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKeyRing.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKeyRing.java
@@ -29,7 +29,7 @@ public class PGPPublicKeyRing
     extends PGPKeyRing
     implements Iterable<PGPPublicKey>
 {
-    List keys;
+    List<PGPPublicKey> keys;
 
     public PGPPublicKeyRing(
         byte[]    encoding,
@@ -39,13 +39,13 @@ public class PGPPublicKeyRing
         this(new ByteArrayInputStream(encoding), fingerPrintCalculator);
     }
 
-    private static List checkKeys(List keys)
+    private static List<PGPPublicKey> checkKeys(List<PGPPublicKey> keys)
     {
-        List rv = new ArrayList(keys.size());
+        List<PGPPublicKey> rv = new ArrayList<>(keys.size());
 
         for (int i = 0; i != keys.size(); i++)
         {
-            PGPPublicKey k = (PGPPublicKey)keys.get(i);
+            PGPPublicKey k = keys.get(i);
 
             if (i == 0)
             {
@@ -74,7 +74,7 @@ public class PGPPublicKeyRing
      * @param pubKeys the list of keys making up the ring.
      */
     public PGPPublicKeyRing(
-        List pubKeys)
+        List<PGPPublicKey> pubKeys)
     {
         this.keys = checkKeys(pubKeys);
     }
@@ -84,7 +84,7 @@ public class PGPPublicKeyRing
         KeyFingerPrintCalculator fingerPrintCalculator)
         throws IOException
     {
-        this.keys = new ArrayList();
+        this.keys = new ArrayList<>();
 
         BCPGInputStream pIn = wrap(in);
 
@@ -100,11 +100,11 @@ public class PGPPublicKeyRing
         TrustPacket     trustPk = readOptionalTrustPacket(pIn);
 
         // direct signatures and revocations
-        List keySigs = readSignaturesAndTrust(pIn);
+        List<PGPSignature> keySigs = readSignaturesAndTrust(pIn);
 
         List ids = new ArrayList();
-        List idTrusts = new ArrayList();
-        List idSigs = new ArrayList();
+        List<TrustPacket> idTrusts = new ArrayList<>();
+        List<List<PGPSignature>> idSigs = new ArrayList<>();
         readUserIDs(pIn, ids, idTrusts, idSigs);
 
         try
@@ -130,7 +130,7 @@ public class PGPPublicKeyRing
      */
     public PGPPublicKey getPublicKey()
     {
-        return (PGPPublicKey)keys.get(0);
+        return keys.get(0);
     }
     
     /**
@@ -145,7 +145,7 @@ public class PGPPublicKeyRing
     {    
         for (int i = 0; i != keys.size(); i++)
         {
-            PGPPublicKey    k = (PGPPublicKey)keys.get(i);
+            PGPPublicKey    k = keys.get(i);
             
             if (keyID == k.getKeyID())
             {
@@ -167,7 +167,7 @@ public class PGPPublicKeyRing
     {
         for (int i = 0; i != keys.size(); i++)
         {
-            PGPPublicKey    k = (PGPPublicKey)keys.get(i);
+            PGPPublicKey    k = keys.get(i);
 
             if (Arrays.areEqual(fingerprint, k.getFingerprint()))
             {
@@ -186,13 +186,13 @@ public class PGPPublicKeyRing
      */
     public Iterator<PGPPublicKey> getKeysWithSignaturesBy(long keyID)
     {
-        List keysWithSigs = new ArrayList();
+        List<PGPPublicKey> keysWithSigs = new ArrayList<>();
 
         for (int i = 0; i != keys.size(); i++)
         {
-            PGPPublicKey    k = (PGPPublicKey)keys.get(i);
+            PGPPublicKey    k = keys.get(i);
 
-            Iterator sigIt = k.getSignaturesForKeyID(keyID);
+            Iterator<PGPSignature> sigIt = k.getSignaturesForKeyID(keyID);
 
             if (sigIt.hasNext())
             {
@@ -269,7 +269,7 @@ public class PGPPublicKeyRing
     {
         for (int i = 0; i != keys.size(); i++)
         {
-            PGPPublicKey    k = (PGPPublicKey)keys.get(i);
+            PGPPublicKey    k = keys.get(i);
 
             k.encode(outStream, forTransfer);
         }
@@ -287,13 +287,13 @@ public class PGPPublicKeyRing
         PGPPublicKeyRing  pubRing,
         PGPPublicKey      pubKey)
     {
-        List       keys = new ArrayList(pubRing.keys);
+        List<PGPPublicKey>       keys = new ArrayList<>(pubRing.keys);
         boolean    found = false;
         boolean    masterFound = false;
 
         for (int i = 0; i != keys.size();i++)
         {
-            PGPPublicKey   key = (PGPPublicKey)keys.get(i);
+            PGPPublicKey   key = keys.get(i);
             
             if (key.getKeyID() == pubKey.getKeyID())
             {
@@ -338,12 +338,12 @@ public class PGPPublicKeyRing
         PGPPublicKeyRing  pubRing,
         PGPPublicKey      pubKey)
     {
-        List       keys = new ArrayList(pubRing.keys);
+        List<PGPPublicKey> keys = new ArrayList<>(pubRing.keys);
         boolean    found = false;
         
-        for (int i = 0; i < keys.size();i++)
+        for (int i = keys.size() - 1; i >= 0; i--)
         {
-            PGPPublicKey   key = (PGPPublicKey)keys.get(i);
+            PGPPublicKey   key = keys.get(i);
             
             if (key.getKeyID() == pubKey.getKeyID())
             {
@@ -379,7 +379,7 @@ public class PGPPublicKeyRing
         TrustPacket kTrust = readOptionalTrustPacket(in);
 
         // PGP 8 actually leaves out the signature.
-        List sigList = readSignaturesAndTrust(in);
+        List<PGPSignature> sigList = readSignaturesAndTrust(in);
 
         return new PGPPublicKey(pk, kTrust, sigList, fingerPrintCalculator);
     }

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -12,7 +12,6 @@ import java.util.List;
 import org.bouncycastle.bcpg.BCPGInputStream;
 import org.bouncycastle.bcpg.BCPGObject;
 import org.bouncycastle.bcpg.BCPGOutputStream;
-import org.bouncycastle.bcpg.ContainedPacket;
 import org.bouncycastle.bcpg.DSASecretBCPGKey;
 import org.bouncycastle.bcpg.ECSecretBCPGKey;
 import org.bouncycastle.bcpg.EdSecretBCPGKey;
@@ -282,7 +281,7 @@ public class PGPSecretKey
         sGen.setHashedSubpackets(hashedPcks);
         sGen.setUnhashedSubpackets(unhashedPcks);
 
-        List subSigs = new ArrayList();
+        List<PGPSignature> subSigs = new ArrayList<>();
 
         subSigs.add(sGen.generateCertification(masterKeyPair.getPublicKey(), keyPair.getPublicKey()));
 
@@ -725,7 +724,7 @@ public class PGPSecretKey
         {
             for (int i = 0; i != pub.keySigs.size(); i++)
             {
-                ((PGPSignature)pub.keySigs.get(i)).encode(out);
+                pub.keySigs.get(i).encode(out);
             }
 
             for (int i = 0; i != pub.ids.size(); i++)
@@ -745,14 +744,14 @@ public class PGPSecretKey
 
                 if (pub.idTrusts.get(i) != null)
                 {
-                    out.writePacket((ContainedPacket)pub.idTrusts.get(i));
+                    out.writePacket(pub.idTrusts.get(i));
                 }
 
-                List sigs = (ArrayList)pub.idSigs.get(i);
+                List<PGPSignature> sigs = pub.idSigs.get(i);
 
                 for (int j = 0; j != sigs.size(); j++)
                 {
-                    ((PGPSignature)sigs.get(j)).encode(out);
+                    sigs.get(j).encode(out);
                 }
             }
         }
@@ -760,7 +759,7 @@ public class PGPSecretKey
         {
             for (int j = 0; j != pub.subSigs.size(); j++)
             {
-                ((PGPSignature)pub.subSigs.get(j)).encode(out);
+                pub.subSigs.get(j).encode(out);
             }
         }
     }

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKeyRing.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKeyRing.java
@@ -32,16 +32,16 @@ public class PGPSecretKeyRing
     extends PGPKeyRing
     implements Iterable<PGPSecretKey>
 {    
-    List keys;
-    List extraPubKeys;
+    List<PGPSecretKey> keys;
+    List<PGPPublicKey> extraPubKeys;
 
-    private static List checkKeys(List keys)
+    private static List<PGPSecretKey> checkKeys(List<PGPSecretKey> keys)
     {
-        List rv = new ArrayList(keys.size());
+        List<PGPSecretKey> rv = new ArrayList<>(keys.size());
 
         for (int i = 0; i != keys.size(); i++)
         {
-            PGPSecretKey k = (PGPSecretKey)keys.get(i);
+            PGPSecretKey k = keys.get(i);
 
             if (i == 0)
             {
@@ -69,12 +69,12 @@ public class PGPSecretKeyRing
      *
      * @param secKeys the list of keys making up the ring.
      */
-    public PGPSecretKeyRing(List secKeys)
+    public PGPSecretKeyRing(List<PGPSecretKey> secKeys)
     {
-        this(checkKeys(secKeys), new ArrayList());
+        this(checkKeys(secKeys), new ArrayList<>());
     }
 
-    private PGPSecretKeyRing(List keys, List extraPubKeys)
+    private PGPSecretKeyRing(List<PGPSecretKey> keys, List<PGPPublicKey> extraPubKeys)
     {
         this.keys = keys;
         this.extraPubKeys = extraPubKeys;
@@ -93,8 +93,8 @@ public class PGPSecretKeyRing
         KeyFingerPrintCalculator fingerPrintCalculator)
         throws IOException, PGPException
     {
-        this.keys = new ArrayList();
-        this.extraPubKeys = new ArrayList();
+        this.keys = new ArrayList<>();
+        this.extraPubKeys = new ArrayList<>();
 
         BCPGInputStream pIn = wrap(in);
 
@@ -119,11 +119,11 @@ public class PGPSecretKeyRing
         TrustPacket trust = readOptionalTrustPacket(pIn);
 
         // revocation and direct signatures
-        List keySigs = readSignaturesAndTrust(pIn);
+        List<PGPSignature> keySigs = readSignaturesAndTrust(pIn);
 
         List ids = new ArrayList();
-        List idTrusts = new ArrayList();
-        List idSigs = new ArrayList();
+        List<TrustPacket> idTrusts = new ArrayList<>();
+        List<List<PGPSignature>> idSigs = new ArrayList<>();
         readUserIDs(pIn, ids, idTrusts, idSigs);
 
         keys.add(new PGPSecretKey(secret, new PGPPublicKey(secret.getPublicKeyPacket(), trust, keySigs, ids, idTrusts, idSigs, fingerPrintCalculator)));
@@ -146,7 +146,7 @@ public class PGPSecretKeyRing
                 }
 
                 TrustPacket subTrust = readOptionalTrustPacket(pIn);
-                List        sigList = readSignaturesAndTrust(pIn);
+                List<PGPSignature>        sigList = readSignaturesAndTrust(pIn);
 
                 keys.add(new PGPSecretKey(sub, new PGPPublicKey(sub.getPublicKeyPacket(), subTrust, sigList, fingerPrintCalculator)));
             }
@@ -155,7 +155,7 @@ public class PGPSecretKeyRing
                 PublicSubkeyPacket sub = (PublicSubkeyPacket)pIn.readPacket();
 
                 TrustPacket subTrust = readOptionalTrustPacket(pIn);
-                List        sigList = readSignaturesAndTrust(pIn);
+                List<PGPSignature>        sigList = readSignaturesAndTrust(pIn);
 
                 extraPubKeys.add(new PGPPublicKey(sub, subTrust, sigList, fingerPrintCalculator));
             }
@@ -169,7 +169,7 @@ public class PGPSecretKeyRing
      */
     public PGPPublicKey getPublicKey()
     {
-        return ((PGPSecretKey)keys.get(0)).getPublicKey();
+        return keys.get(0).getPublicKey();
     }
 
     /**
@@ -190,7 +190,7 @@ public class PGPSecretKeyRing
 
         for (int i = 0; i != extraPubKeys.size(); i++)
         {
-            PGPPublicKey    k = (PGPPublicKey)keys.get(i);
+            PGPPublicKey    k = extraPubKeys.get(i);
 
             if (keyID == k.getKeyID())
             {
@@ -218,7 +218,7 @@ public class PGPSecretKeyRing
 
         for (int i = 0; i != extraPubKeys.size(); i++)
         {
-            PGPPublicKey    k = (PGPPublicKey)keys.get(i);
+            PGPPublicKey    k = extraPubKeys.get(i);
 
             if (Arrays.areEqual(fingerprint, k.getFingerprint()))
             {
@@ -237,13 +237,13 @@ public class PGPSecretKeyRing
      */
     public Iterator<PGPPublicKey> getKeysWithSignaturesBy(long keyID)
     {
-        List keysWithSigs = new ArrayList();
+        List<PGPPublicKey> keysWithSigs = new ArrayList<>();
 
-        for (Iterator keyIt = getPublicKeys(); keyIt.hasNext();)
+        for (Iterator<PGPPublicKey> keyIt = getPublicKeys(); keyIt.hasNext();)
         {
-            PGPPublicKey    k = (PGPPublicKey)keyIt.next();
+            PGPPublicKey    k = keyIt.next();
 
-            Iterator sigIt = k.getSignaturesForKeyID(keyID);
+            Iterator<PGPSignature> sigIt = k.getSignaturesForKeyID(keyID);
 
             if (sigIt.hasNext())
             {
@@ -261,11 +261,11 @@ public class PGPSecretKeyRing
      */
     public Iterator<PGPPublicKey> getPublicKeys()
     {
-        List pubKeys = new ArrayList();
+        List<PGPPublicKey> pubKeys = new ArrayList<>();
 
-        for (Iterator it = getSecretKeys(); it.hasNext();)
+        for (Iterator<PGPSecretKey> it = getSecretKeys(); it.hasNext();)
         {            
-            PGPPublicKey key = ((PGPSecretKey)it.next()).getPublicKey();
+            PGPPublicKey key = it.next().getPublicKey();
             pubKeys.add(key);
         }
 
@@ -281,7 +281,7 @@ public class PGPSecretKeyRing
      */
     public PGPSecretKey getSecretKey()
     {
-        return ((PGPSecretKey)keys.get(0));
+        return keys.get(0);
     }
     
     /**
@@ -306,7 +306,7 @@ public class PGPSecretKeyRing
     {    
         for (int i = 0; i != keys.size(); i++)
         {
-            PGPSecretKey    k = (PGPSecretKey)keys.get(i);
+            PGPSecretKey    k = keys.get(i);
             
             if (keyID == k.getKeyID())
             {
@@ -328,7 +328,7 @@ public class PGPSecretKeyRing
     {
         for (int i = 0; i != keys.size(); i++)
         {
-            PGPSecretKey    k = (PGPSecretKey)keys.get(i);
+            PGPSecretKey    k = keys.get(i);
 
             if (Arrays.areEqual(fingerprint, k.getPublicKey().getFingerprint()))
             {
@@ -367,13 +367,13 @@ public class PGPSecretKeyRing
     {
         for (int i = 0; i != keys.size(); i++)
         {
-            PGPSecretKey    k = (PGPSecretKey)keys.get(i);
+            PGPSecretKey    k = keys.get(i);
             
             k.encode(outStream);
         }
         for (int i = 0; i != extraPubKeys.size(); i++)
         {
-            PGPPublicKey    k = (PGPPublicKey)extraPubKeys.get(i);
+            PGPPublicKey    k = extraPubKeys.get(i);
 
             k.encode(outStream);
         }
@@ -395,11 +395,11 @@ public class PGPSecretKeyRing
      */
     public static PGPSecretKeyRing replacePublicKeys(PGPSecretKeyRing secretRing, PGPPublicKeyRing publicRing)
     {
-        List newList = new ArrayList(secretRing.keys.size());
+        List<PGPSecretKey> newList = new ArrayList<>(secretRing.keys.size());
 
-        for (Iterator it = secretRing.keys.iterator(); it.hasNext();)
+        for (Iterator<PGPSecretKey> it = secretRing.keys.iterator(); it.hasNext();)
         {
-            PGPSecretKey sk = (PGPSecretKey)it.next();
+            PGPSecretKey sk = it.next();
             PGPPublicKey pk = publicRing.getPublicKey(sk.getKeyID());
 
             newList.add(PGPSecretKey.replacePublicKey(sk, pk));
@@ -423,11 +423,11 @@ public class PGPSecretKeyRing
         PBESecretKeyEncryptor  newKeyEncryptor)
         throws PGPException
     {
-        List newKeys = new ArrayList(ring.keys.size());
+        List<PGPSecretKey> newKeys = new ArrayList<>(ring.keys.size());
 
-        for (Iterator keys = ring.getSecretKeys(); keys.hasNext();)
+        for (Iterator<PGPSecretKey> keys = ring.getSecretKeys(); keys.hasNext();)
         {
-            PGPSecretKey key = (PGPSecretKey)keys.next();
+            PGPSecretKey key = keys.next();
 
             if (key.isPrivateKeyEmpty())
             {
@@ -454,13 +454,13 @@ public class PGPSecretKeyRing
         PGPSecretKeyRing  secRing,
         PGPSecretKey      secKey)
     {
-        List       keys = new ArrayList(secRing.keys);
+        List<PGPSecretKey>       keys = new ArrayList<>(secRing.keys);
         boolean    found = false;
         boolean    masterFound = false;
         
         for (int i = 0; i != keys.size();i++)
         {
-            PGPSecretKey   key = (PGPSecretKey)keys.get(i);
+            PGPSecretKey   key = keys.get(i);
             
             if (key.getKeyID() == secKey.getKeyID())
             {
@@ -505,12 +505,12 @@ public class PGPSecretKeyRing
         PGPSecretKeyRing  secRing,
         PGPSecretKey      secKey)
     {
-        List       keys = new ArrayList(secRing.keys);
+        List<PGPSecretKey>       keys = new ArrayList<>(secRing.keys);
         boolean    found = false;
         
-        for (int i = 0; i < keys.size();i++)
+        for (int i = keys.size() - 1; i >= 0; i--)
         {
-            PGPSecretKey   key = (PGPSecretKey)keys.get(i);
+            PGPSecretKey   key = keys.get(i);
             
             if (key.getKeyID() == secKey.getKeyID())
             {


### PR DESCRIPTION
This PR adds generics to most lists and iterator methods of `PGPPublicKey`, `PGPSecretKey`, `PGPPublicKeyRing`, `PGPSecretKeyRing`, `PGPKeyRing`.

It also fixes some possible `ConcurrentModificatonExceptions` when removing from a list by iterating over it with increasing index.