### PR TITLE
Fixed encoding of AlgorithmIdentifier.parameters

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/cms/CMSObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/CMSObjectIdentifiers.java
@@ -40,4 +40,16 @@ public interface CMSObjectIdentifiers
     static final ASN1ObjectIdentifier    id_ri_ocsp_response = id_ri.branch("2");
     /** 1.3.6.1.5.5.7.16.4 */
     static final ASN1ObjectIdentifier    id_ri_scvp = id_ri.branch("4");
+
+    /** 1.3.6.1.5.5.7.6 */
+    static final ASN1ObjectIdentifier id_alg  = new ASN1ObjectIdentifier("1.3.6.1.5.5.7.6");
+
+    static final ASN1ObjectIdentifier id_RSASSA_PSS_SHAKE128 = id_alg.branch("30");
+
+    static final ASN1ObjectIdentifier id_RSASSA_PSS_SHAKE256 = id_alg.branch("31");
+
+    static final ASN1ObjectIdentifier id_ecdsa_with_shake128 = id_alg.branch("32");
+
+    static final ASN1ObjectIdentifier id_ecdsa_with_shake256 = id_alg.branch("33");
+
 }

--- a/core/src/main/java/org/bouncycastle/crypto/signers/SHAKEPSSSigner.java
+++ b/core/src/main/java/org/bouncycastle/crypto/signers/SHAKEPSSSigner.java
@@ -1,0 +1,321 @@
+package org.bouncycastle.crypto.signers;
+
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.AsymmetricBlockCipher;
+import org.bouncycastle.crypto.CipherParameters;
+import org.bouncycastle.crypto.CryptoException;
+import org.bouncycastle.crypto.CryptoServicesRegistrar;
+import org.bouncycastle.crypto.DataLengthException;
+import org.bouncycastle.crypto.Signer;
+import org.bouncycastle.crypto.digests.SHAKEDigest;
+import org.bouncycastle.crypto.params.ParametersWithRandom;
+import org.bouncycastle.crypto.params.RSABlindingParameters;
+import org.bouncycastle.crypto.params.RSAKeyParameters;
+import org.bouncycastle.util.Arrays;
+
+/**
+ *
+ * SHAKE with RSA-PSS as described in PKCS#1 v2.1 and RFC 8702
+ * <p/>
+ * Note: the usual value for the salt length is the number of
+ * bytes in the hash function.
+ */
+// Code based on PSSSigner.java
+public class SHAKEPSSSigner
+    implements Signer {
+    static final public byte TRAILER_IMPLICIT    = (byte)0xBC;
+
+    private final SHAKEDigest           digest;
+    private final AsymmetricBlockCipher cipher;
+    private SecureRandom                random;
+
+    private final int                   hLen;
+    private final boolean               sSet;
+    private final int                   sLen;
+    private int                         emBits;
+    private byte[]                      salt;
+    private byte[]                      mDash;
+    private byte[]                      block;
+
+    /**
+     * basic constructor
+     *
+     * @param cipher the asymmetric cipher to use.
+     * @param digest the digest to use.
+     */
+    public SHAKEPSSSigner(
+        AsymmetricBlockCipher cipher,
+        int type,
+        int size)
+    {
+        this.cipher = cipher;
+        this.digest = new SHAKEDigest(type);
+        this.hLen = size / 8;
+
+        this.sSet = false;
+        this.sLen = hLen;
+        this.salt = new byte[hLen];
+        this.mDash = new byte[8 + sLen + hLen];
+    }
+
+    public SHAKEPSSSigner(
+        AsymmetricBlockCipher   cipher,
+        int                     type,
+        int                     size,
+        byte[]                  salt)
+    {
+        this.cipher = cipher;
+        this.digest = new SHAKEDigest(type);
+        this.hLen = size / 8;
+
+        if (salt.length != hLen) {
+          throw new IllegalArgumentException("salt.length != " + hLen);
+        }
+        this.sSet = true;
+        this.sLen = salt.length;
+        this.salt = salt;
+        this.mDash = new byte[8 + sLen + hLen];
+    }
+
+    public void init(
+        boolean                 forSigning,
+        CipherParameters        param)
+    {
+        CipherParameters  params;
+
+        if (param instanceof ParametersWithRandom)
+        {
+            ParametersWithRandom    p = (ParametersWithRandom)param;
+
+            params = p.getParameters();
+            random = p.getRandom();
+        }
+        else
+        {
+            params = param;
+            if (forSigning)
+            {
+                random = CryptoServicesRegistrar.getSecureRandom();
+            }
+        }
+
+        RSAKeyParameters kParam;
+
+        if (params instanceof RSABlindingParameters)
+        {
+            kParam = ((RSABlindingParameters)params).getPublicKey();
+
+            cipher.init(forSigning, param);   // pass on random
+        }
+        else
+        {
+            kParam = (RSAKeyParameters)params;
+
+            cipher.init(forSigning, params);
+        }
+
+        emBits = kParam.getModulus().bitLength() - 1;
+
+        if (emBits < (8 * hLen + 8 * sLen + 9))
+        {
+            throw new IllegalArgumentException("key too small for specified hash and salt lengths");
+        }
+
+        block = new byte[(emBits + 7) / 8];
+
+        reset();
+    }
+
+    /**
+     * clear possible sensitive data
+     */
+    private void clearBlock(
+        byte[]  block)
+    {
+        for (int i = 0; i != block.length; i++)
+        {
+            block[i] = 0;
+        }
+    }
+
+    /**
+     * update the internal digest with the byte b
+     */
+    public void update(
+        byte    b)
+    {
+        digest.update(b);
+    }
+
+    /**
+     * update the internal digest with the byte array in
+     */
+    public void update(
+        byte[]  in,
+        int     off,
+        int     len)
+    {
+        digest.update(in, off, len);
+    }
+
+    /**
+     * reset the internal state
+     */
+    public void reset()
+    {
+        digest.reset();
+    }
+
+    /**
+     * generate a signature for the message we've been loaded with using
+     * the key we were initialised with.
+     */
+    public byte[] generateSignature()
+        throws CryptoException, DataLengthException
+    {
+        doFinal(mDash, mDash.length - hLen - sLen);
+
+        if (sLen != 0)
+        {
+            if (!sSet)
+            {
+                random.nextBytes(salt);
+            }
+
+            System.arraycopy(salt, 0, mDash, mDash.length - sLen, sLen);
+        }
+
+        byte[]  h = new byte[hLen];
+
+        digest.update(mDash, 0, mDash.length);
+
+        doFinal(h, 0);
+
+        block[block.length - sLen - 1 - hLen - 1] = 0x01;
+        System.arraycopy(salt, 0, block, block.length - sLen - hLen - 1, sLen);
+
+        byte[] dbMask = maskGeneratorFunction(h, 0, h.length, block.length - hLen - 1);
+        for (int i = 0; i != dbMask.length; i++)
+        {
+            block[i] ^= dbMask[i];
+        }
+
+        System.arraycopy(h, 0, block, block.length - hLen - 1, hLen);
+
+        int firstByteMask = 0xff >>> ((block.length * 8) - emBits);
+
+        block[0] &= firstByteMask;
+        block[block.length - 1] = TRAILER_IMPLICIT;
+
+        byte[]  b = cipher.processBlock(block, 0, block.length);
+
+        clearBlock(block);
+
+        return b;
+    }
+
+    /**
+     * return true if the internal state represents the signature described
+     * in the passed in array.
+     */
+    public boolean verifySignature(
+        byte[]      signature)
+    {
+        doFinal(mDash, mDash.length - hLen - sLen);
+
+        try
+        {
+            byte[] b = cipher.processBlock(signature, 0, signature.length);
+            Arrays.fill(block, 0, block.length - b.length, (byte)0);
+            System.arraycopy(b, 0, block, block.length - b.length, b.length);
+        }
+        catch (Exception e)
+        {
+            return false;
+        }
+
+        int firstByteMask = 0xff >>> ((block.length * 8) - emBits);
+
+        if ((block[0] & 0xff) != (block[0] & firstByteMask)
+            || block[block.length - 1] != TRAILER_IMPLICIT)
+        {
+            clearBlock(block);
+            return false;
+        }
+
+        byte[] dbMask = maskGeneratorFunction(block, block.length - hLen - 1, hLen,
+                        block.length - hLen - 1);
+
+        for (int i = 0; i != dbMask.length; i++)
+        {
+            block[i] ^= dbMask[i];
+        }
+
+        block[0] &= firstByteMask;
+
+        for (int i = 0; i != block.length - hLen - sLen - 2; i++)
+        {
+            if (block[i] != 0)
+            {
+                clearBlock(block);
+                return false;
+            }
+        }
+
+        if (block[block.length - hLen - sLen - 2] != 0x01)
+        {
+            clearBlock(block);
+            return false;
+        }
+
+        if (sSet)
+        {
+            System.arraycopy(salt, 0, mDash, mDash.length - sLen, sLen);
+        }
+        else
+        {
+            System.arraycopy(block, block.length - sLen - hLen - 1,
+                mDash, mDash.length - sLen, sLen);
+        }
+
+        digest.update(mDash, 0, mDash.length);
+        doFinal(mDash, mDash.length - hLen);
+
+        for (int i = block.length - hLen - 1, j = mDash.length - hLen;
+                                                 j != mDash.length; i++, j++)
+        {
+            if ((block[i] ^ mDash[j]) != 0)
+            {
+                clearBlock(mDash);
+                clearBlock(block);
+                return false;
+            }
+        }
+
+        clearBlock(mDash);
+        clearBlock(block);
+
+        return true;
+    }
+
+    /**
+     * mask generator function, as described in RFC 8692 and RFC 8702.
+     */
+    private byte[] maskGeneratorFunction(
+        byte[]  Z,
+        int     zOff,
+        int     zLen,
+        int     length) {
+        byte[]  mask = new byte[length];
+        digest.reset();
+        digest.update(Z, zOff, zLen);
+        digest.doFinal(mask, 0, length);
+        return mask;
+    }
+
+    private int doFinal(byte[] out, int outOff) {
+        return digest.doFinal(out, outOff, hLen);
+    }
+
+}

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSSignedData.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSSignedData.java
@@ -514,7 +514,7 @@ public class CMSSignedData
         while (it.hasNext())
         {
             SignerInformation signer = (SignerInformation)it.next();
-            digestAlgs.add(CMSSignedHelper.INSTANCE.fixAlgID(signer.getDigestAlgorithmID()));
+            digestAlgs.add(CMSSignedHelper.INSTANCE.fixDigestAlgID(signer.getDigestAlgorithmID()));
             vec.add(signer.toASN1Structure());
         }
 

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSSignedDataGenerator.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSSignedDataGenerator.java
@@ -127,7 +127,7 @@ public class CMSSignedDataGenerator
         for (Iterator it = _signers.iterator(); it.hasNext();)
         {
             SignerInformation signer = (SignerInformation)it.next();
-            digestAlgs.add(CMSSignedHelper.INSTANCE.fixAlgID(signer.getDigestAlgorithmID()));
+            digestAlgs.add(CMSSignedHelper.INSTANCE.fixDigestAlgID(signer.getDigestAlgorithmID()));
 
             // TODO Verify the content type and calculated digest match the precalculated SignerInfo
             signerInfos.add(signer.toASN1Structure());

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSSignedDataParser.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSSignedDataParser.java
@@ -441,7 +441,7 @@ public class CMSSignedDataParser
         for (Iterator it = signerInformationStore.getSigners().iterator(); it.hasNext();)
         {
             SignerInformation signer = (SignerInformation)it.next();
-            digestAlgs.add(CMSSignedHelper.INSTANCE.fixAlgID(signer.getDigestAlgorithmID()));
+            digestAlgs.add(CMSSignedHelper.INSTANCE.fixDigestAlgID(signer.getDigestAlgorithmID()));
         }
 
         sigGen.getRawOutputStream().write(new DERSet(digestAlgs).getEncoded());

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSSignedDataStreamGenerator.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSSignedDataStreamGenerator.java
@@ -197,7 +197,7 @@ public class CMSSignedDataStreamGenerator
         for (Iterator it = _signers.iterator(); it.hasNext();)
         {
             SignerInformation signer = (SignerInformation)it.next();
-            AlgorithmIdentifier digAlg = CMSSignedHelper.INSTANCE.fixAlgID(signer.getDigestAlgorithmID());
+            AlgorithmIdentifier digAlg = CMSSignedHelper.INSTANCE.fixDigestAlgID(signer.getDigestAlgorithmID());
 
             digestAlgs.add(digAlg);
         }
@@ -247,7 +247,7 @@ public class CMSSignedDataStreamGenerator
         for (Iterator it = _signers.iterator(); it.hasNext();)
         {
             SignerInformation signer = (SignerInformation)it.next();
-            AlgorithmIdentifier digAlg = CMSSignedHelper.INSTANCE.fixAlgID(signer.getDigestAlgorithmID());
+            AlgorithmIdentifier digAlg = CMSSignedHelper.INSTANCE.fixDigestAlgID(signer.getDigestAlgorithmID());
 
             digestAlorithms.add(digAlg);
         }

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSSignedHelper.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSSignedHelper.java
@@ -30,12 +30,16 @@ import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.cert.X509AttributeCertificateHolder;
 import org.bouncycastle.cert.X509CRLHolder;
 import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
 import org.bouncycastle.util.CollectionStore;
 import org.bouncycastle.util.Store;
 
 class CMSSignedHelper
 {
+
     static final CMSSignedHelper INSTANCE = new CMSSignedHelper();
+
+    private static final DefaultDigestAlgorithmIdentifierFinder dgstAlgFinder = new DefaultDigestAlgorithmIdentifierFinder();
 
     private static final Map     encryptionAlgs = new HashMap();
 
@@ -135,6 +139,19 @@ class CMSSignedHelper
         }
 
         return algId;
+    }
+
+    AlgorithmIdentifier fixDigestAlgID(AlgorithmIdentifier algId)
+    {
+        ASN1Encodable params = algId.getParameters();
+        if (params == null || DERNull.INSTANCE.equals(params))
+        {
+            return dgstAlgFinder.find(algId.getAlgorithm());
+        }
+        else
+        {
+            return algId;
+        }
     }
 
     void setSigningEncryptionAlgorithmMapping(ASN1ObjectIdentifier oid, String algorithmName)

--- a/pkix/src/main/java/org/bouncycastle/operator/DefaultDigestAlgorithmIdentifierFinder.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/DefaultDigestAlgorithmIdentifierFinder.java
@@ -7,6 +7,7 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.bc.BCObjectIdentifiers;
 import org.bouncycastle.asn1.bsi.BSIObjectIdentifiers;
+import org.bouncycastle.asn1.cms.CMSObjectIdentifiers;
 import org.bouncycastle.asn1.cryptopro.CryptoProObjectIdentifiers;
 import org.bouncycastle.asn1.eac.EACObjectIdentifiers;
 import org.bouncycastle.asn1.edec.EdECObjectIdentifiers;
@@ -105,6 +106,11 @@ public class DefaultDigestAlgorithmIdentifierFinder
 //        digestOids.put(GMObjectIdentifiers.sm2sign_with_sha384, NISTObjectIdentifiers.id_sha384);
 //        digestOids.put(GMObjectIdentifiers.sm2sign_with_sha512, NISTObjectIdentifiers.id_sha512);
         digestOids.put(GMObjectIdentifiers.sm2sign_with_sm3, GMObjectIdentifiers.sm3);
+
+        digestOids.put(CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE128, NISTObjectIdentifiers.id_shake128);
+        digestOids.put(CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE256, NISTObjectIdentifiers.id_shake256);
+        digestOids.put(CMSObjectIdentifiers.id_ecdsa_with_shake128, NISTObjectIdentifiers.id_shake128);
+        digestOids.put(CMSObjectIdentifiers.id_ecdsa_with_shake256, NISTObjectIdentifiers.id_shake256);
 
         digestNameToOids.put("SHA-1", OIWObjectIdentifiers.idSHA1);
         digestNameToOids.put("SHA-224", NISTObjectIdentifiers.id_sha224);

--- a/pkix/src/main/java/org/bouncycastle/operator/DefaultSignatureAlgorithmIdentifierFinder.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/DefaultSignatureAlgorithmIdentifierFinder.java
@@ -11,6 +11,7 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.bc.BCObjectIdentifiers;
 import org.bouncycastle.asn1.bsi.BSIObjectIdentifiers;
+import org.bouncycastle.asn1.cms.CMSObjectIdentifiers;
 import org.bouncycastle.asn1.cryptopro.CryptoProObjectIdentifiers;
 import org.bouncycastle.asn1.eac.EACObjectIdentifiers;
 import org.bouncycastle.asn1.edec.EdECObjectIdentifiers;
@@ -136,6 +137,14 @@ public class DefaultSignatureAlgorithmIdentifierFinder
 
         algorithms.put("ED25519", EdECObjectIdentifiers.id_Ed25519);
         algorithms.put("ED448", EdECObjectIdentifiers.id_Ed448);
+
+        // RFC 8702
+        algorithms.put("SHAKE128WITHRSAPSS", CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE128);
+        algorithms.put("SHAKE256WITHRSAPSS", CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE256);
+        algorithms.put("SHAKE128WITHRSASSA-PSS", CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE128);
+        algorithms.put("SHAKE256WITHRSASSA-PSS", CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE256);
+        algorithms.put("SHAKE128WITHECDSA", CMSObjectIdentifiers.id_ecdsa_with_shake128);
+        algorithms.put("SHAKE256WITHECDSA", CMSObjectIdentifiers.id_ecdsa_with_shake256);
 
 //        algorithms.put("RIPEMD160WITHSM2", GMObjectIdentifiers.sm2sign_with_rmd160);
 //        algorithms.put("SHA1WITHSM2", GMObjectIdentifiers.sm2sign_with_sha1);
@@ -265,6 +274,12 @@ public class DefaultSignatureAlgorithmIdentifierFinder
         noParams.add(EdECObjectIdentifiers.id_Ed25519);
         noParams.add(EdECObjectIdentifiers.id_Ed448);
 
+        // RFC 8702
+        noParams.add(CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE128);
+        noParams.add(CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE256);
+        noParams.add(CMSObjectIdentifiers.id_ecdsa_with_shake128);
+        noParams.add(CMSObjectIdentifiers.id_ecdsa_with_shake256);
+
         //
         // PKCS 1.5 encrypted  algorithms
         //
@@ -354,6 +369,11 @@ public class DefaultSignatureAlgorithmIdentifierFinder
 //        digestOids.put(GMObjectIdentifiers.sm2sign_with_sha384, NISTObjectIdentifiers.id_sha384);
 //        digestOids.put(GMObjectIdentifiers.sm2sign_with_sha512, NISTObjectIdentifiers.id_sha512);
         digestOids.put(GMObjectIdentifiers.sm2sign_with_sm3, GMObjectIdentifiers.sm3);
+
+        digestOids.put(CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE128, NISTObjectIdentifiers.id_shake128);
+        digestOids.put(CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE256, NISTObjectIdentifiers.id_shake256);
+        digestOids.put(CMSObjectIdentifiers.id_ecdsa_with_shake128, NISTObjectIdentifiers.id_shake128);
+        digestOids.put(CMSObjectIdentifiers.id_ecdsa_with_shake256, NISTObjectIdentifiers.id_shake256);
     }
 
     private static AlgorithmIdentifier generate(String signatureAlgorithm)

--- a/pkix/src/main/java/org/bouncycastle/operator/jcajce/JcaAlgorithmParametersConverter.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/jcajce/JcaAlgorithmParametersConverter.java
@@ -13,6 +13,7 @@ import javax.crypto.spec.PSource;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.RSAESOAEPparams;
@@ -61,7 +62,13 @@ public class JcaAlgorithmParametersConverter
                 }
 
                 AlgorithmIdentifier hashAlgorithm = new DefaultDigestAlgorithmIdentifierFinder().find(oaepSpec.getDigestAlgorithm());
+                if (hashAlgorithm.getParameters() == null) {
+                    hashAlgorithm = new AlgorithmIdentifier(hashAlgorithm.getAlgorithm(), DERNull.INSTANCE);
+                }
                 AlgorithmIdentifier mgf1HashAlgorithm = new DefaultDigestAlgorithmIdentifierFinder().find((((MGF1ParameterSpec)oaepSpec.getMGFParameters()).getDigestAlgorithm()));
+                if (mgf1HashAlgorithm.getParameters() == null) {
+                    mgf1HashAlgorithm = new AlgorithmIdentifier(mgf1HashAlgorithm.getAlgorithm(), DERNull.INSTANCE);
+                }
                 return new AlgorithmIdentifier(algorithm,
                                     new RSAESOAEPparams(hashAlgorithm, new AlgorithmIdentifier(PKCSObjectIdentifiers.id_mgf1, mgf1HashAlgorithm),
                                                         new AlgorithmIdentifier(PKCSObjectIdentifiers.id_pSpecified, new DEROctetString(((PSource.PSpecified)pSource).getValue()))));

--- a/pkix/src/main/java/org/bouncycastle/operator/jcajce/JcaContentSignerBuilder.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/jcajce/JcaContentSignerBuilder.java
@@ -18,6 +18,7 @@ import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERBitString;
+import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.misc.MiscObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
@@ -234,8 +235,14 @@ public class JcaContentSignerBuilder
     private static RSASSAPSSparams createPSSParams(PSSParameterSpec pssSpec)
     {
         DigestAlgorithmIdentifierFinder digFinder = new DefaultDigestAlgorithmIdentifierFinder();
-           AlgorithmIdentifier digId = digFinder.find(pssSpec.getDigestAlgorithm());
-           AlgorithmIdentifier mgfDig = digFinder.find(((MGF1ParameterSpec)pssSpec.getMGFParameters()).getDigestAlgorithm());
+        AlgorithmIdentifier digId = digFinder.find(pssSpec.getDigestAlgorithm());
+        if (digId.getParameters() == null) {
+            digId = new AlgorithmIdentifier(digId.getAlgorithm(), DERNull.INSTANCE);
+        }
+        AlgorithmIdentifier mgfDig = digFinder.find(((MGF1ParameterSpec)pssSpec.getMGFParameters()).getDigestAlgorithm());
+        if (mgfDig.getParameters() == null) {
+            mgfDig = new AlgorithmIdentifier(mgfDig.getAlgorithm(), DERNull.INSTANCE);
+        }
 
         return new RSASSAPSSparams(
             digId,

--- a/pkix/src/main/java/org/bouncycastle/operator/jcajce/OperatorHelper.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/jcajce/OperatorHelper.java
@@ -29,6 +29,7 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.bsi.BSIObjectIdentifiers;
+import org.bouncycastle.asn1.cms.CMSObjectIdentifiers;
 import org.bouncycastle.asn1.cryptopro.CryptoProObjectIdentifiers;
 import org.bouncycastle.asn1.eac.EACObjectIdentifiers;
 import org.bouncycastle.asn1.edec.EdECObjectIdentifiers;
@@ -72,6 +73,8 @@ class OperatorHelper
         oids.put(PKCSObjectIdentifiers.sha256WithRSAEncryption, "SHA256WITHRSA");
         oids.put(PKCSObjectIdentifiers.sha384WithRSAEncryption, "SHA384WITHRSA");
         oids.put(PKCSObjectIdentifiers.sha512WithRSAEncryption, "SHA512WITHRSA");
+        oids.put(CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE128, "SHAKE128WITHRSAPSS");
+        oids.put(CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE256, "SHAKE256WITHRSAPSS");
         oids.put(CryptoProObjectIdentifiers.gostR3411_94_with_gostR3410_94, "GOST3411WITHGOST3410");
         oids.put(CryptoProObjectIdentifiers.gostR3411_94_with_gostR3410_2001, "GOST3411WITHECGOST3410");
         oids.put(RosstandartObjectIdentifiers.id_tc26_signwithdigest_gost_3410_12_256, "GOST3411-2012-256WITHECGOST3410-2012-256");
@@ -98,6 +101,8 @@ class OperatorHelper
         oids.put(X9ObjectIdentifiers.ecdsa_with_SHA256, "SHA256WITHECDSA");
         oids.put(X9ObjectIdentifiers.ecdsa_with_SHA384, "SHA384WITHECDSA");
         oids.put(X9ObjectIdentifiers.ecdsa_with_SHA512, "SHA512WITHECDSA");
+        oids.put(CMSObjectIdentifiers.id_ecdsa_with_shake128, "SHAKE128WITHECDSA");
+        oids.put(CMSObjectIdentifiers.id_ecdsa_with_shake256, "SHAKE128WITHECDSA");
         oids.put(OIWObjectIdentifiers.sha1WithRSA, "SHA1WITHRSA");
         oids.put(OIWObjectIdentifiers.dsaWithSHA1, "SHA1WITHDSA");
         oids.put(NISTObjectIdentifiers.dsa_with_sha224, "SHA224WITHDSA");
@@ -351,6 +356,10 @@ class OperatorHelper
             if (digAlgId.getAlgorithm().equals(NISTObjectIdentifiers.id_shake256_len))
             {
                 dig = helper.createMessageDigest("SHAKE256-" + ASN1Integer.getInstance(digAlgId.getParameters()).getValue());
+            }
+            else if (digAlgId.getAlgorithm().equals(NISTObjectIdentifiers.id_shake128_len))
+            {
+                dig = helper.createMessageDigest("SHAKE128-" + ASN1Integer.getInstance(digAlgId.getParameters()).getValue());
             }
             else
             {

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/EC.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/EC.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.bouncycastle.asn1.bsi.BSIObjectIdentifiers;
+import org.bouncycastle.asn1.cms.CMSObjectIdentifiers;
 import org.bouncycastle.asn1.eac.EACObjectIdentifiers;
 import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 import org.bouncycastle.asn1.sec.SECObjectIdentifiers;
@@ -241,7 +242,8 @@ public class EC
             addSignatureAlgorithm(provider, "SHA3-256", "ECDSA", PREFIX + "SignatureSpi$ecDSASha3_256", NISTObjectIdentifiers.id_ecdsa_with_sha3_256);
             addSignatureAlgorithm(provider, "SHA3-384", "ECDSA", PREFIX + "SignatureSpi$ecDSASha3_384", NISTObjectIdentifiers.id_ecdsa_with_sha3_384);
             addSignatureAlgorithm(provider, "SHA3-512", "ECDSA", PREFIX + "SignatureSpi$ecDSASha3_512", NISTObjectIdentifiers.id_ecdsa_with_sha3_512);
-
+            addSignatureAlgorithm(provider, "SHAKE128", "ECDSA", PREFIX + "SignatureSpi$ecDSAShake128", CMSObjectIdentifiers.id_ecdsa_with_shake128);
+            addSignatureAlgorithm(provider, "SHAKE256", "ECDSA", PREFIX + "SignatureSpi$ecDSAShake256", CMSObjectIdentifiers.id_ecdsa_with_shake256);
             addSignatureAlgorithm(provider, "RIPEMD160", "ECDSA", PREFIX + "SignatureSpi$ecDSARipeMD160",TeleTrusTObjectIdentifiers.ecSignWithRipemd160);
 
             provider.addAlgorithm("Signature.SHA1WITHECNR", PREFIX + "SignatureSpi$ecNR");

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/RSA.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/RSA.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.cms.CMSObjectIdentifiers;
 import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
@@ -180,6 +181,9 @@ public class RSA
             addX931Signature(provider, "SHA512(224)", PREFIX + "X931SignatureSpi$SHA512_224WithRSAEncryption");
             addX931Signature(provider, "SHA512(256)", PREFIX + "X931SignatureSpi$SHA512_256WithRSAEncryption");
 
+            addSHAKEPSSSignature(provider, "SHAKE128", PREFIX + "SHAKEPSSSignatureSpi$SHAKE128WithRSAPSS", CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE128);
+            addSHAKEPSSSignature(provider, "SHAKE256", PREFIX + "SHAKEPSSSignatureSpi$SHAKE256WithRSAPSS", CMSObjectIdentifiers.id_RSASSA_PSS_SHAKE256);
+
             if (provider.hasAlgorithm("MessageDigest", "RIPEMD128"))
             {
                 addDigestSignature(provider, "RIPEMD128", PREFIX + "DigestSignatureSpi$RIPEMD128", TeleTrusTObjectIdentifiers.rsaSignatureWithripemd128);
@@ -213,6 +217,7 @@ public class RSA
                 addX931Signature(provider, "Whirlpool", PREFIX + "X931SignatureSpi$WhirlpoolWithRSAEncryption");
                 addX931Signature(provider, "WHIRLPOOL", PREFIX + "X931SignatureSpi$WhirlpoolWithRSAEncryption");
             }
+
         }
 
         private void addDigestSignature(
@@ -267,6 +272,35 @@ public class RSA
             provider.addAlgorithm("Alg.Alias.Signature." + digest + "WithRSASSA-PSS", digest + "WITHRSAANDMGF1");
             provider.addAlgorithm("Alg.Alias.Signature." + digest + "WITHRSASSA-PSS", digest + "WITHRSAANDMGF1");
             provider.addAlgorithm("Signature." + digest + "WITHRSAANDMGF1", className);
+        }
+
+        private void addSHAKEPSSSignature(
+            ConfigurableProvider provider,
+            String digest,
+            String className,
+            ASN1ObjectIdentifier oid)
+        {
+            String mainName = digest + "WITHRSAPSS";
+            String jdk11Variation1 = digest + "withRSAPSS";
+            String jdk11Variation2 = digest + "WithRSAPSS";
+            String alias = digest + "/" + "RSAPSS";
+            String longName = digest + "WITHRSASSA-PSS";
+            String longJdk11Variation1 = digest + "withRSASSA-PSS";
+            String longJdk11Variation2 = digest + "WithRSASSA-PSS";
+
+            provider.addAlgorithm("Signature." + mainName, className);
+            provider.addAlgorithm("Alg.Alias.Signature." + jdk11Variation1, mainName);
+            provider.addAlgorithm("Alg.Alias.Signature." + jdk11Variation2, mainName);
+            provider.addAlgorithm("Alg.Alias.Signature." + longName, mainName);
+            provider.addAlgorithm("Alg.Alias.Signature." + longJdk11Variation1, mainName);
+            provider.addAlgorithm("Alg.Alias.Signature." + longJdk11Variation2, mainName);
+            provider.addAlgorithm("Alg.Alias.Signature." + alias, mainName);
+
+            if (oid != null)
+            {
+                provider.addAlgorithm("Alg.Alias.Signature." + oid, mainName);
+                provider.addAlgorithm("Alg.Alias.Signature.OID." + oid, mainName);
+            }
         }
 
         private void addX931Signature(

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/SignatureSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/SignatureSpi.java
@@ -10,6 +10,7 @@ import org.bouncycastle.crypto.DSAExt;
 import org.bouncycastle.crypto.Digest;
 import org.bouncycastle.crypto.digests.NullDigest;
 import org.bouncycastle.crypto.digests.RIPEMD160Digest;
+import org.bouncycastle.crypto.digests.SHAKEDigest;
 import org.bouncycastle.crypto.params.ParametersWithRandom;
 import org.bouncycastle.crypto.signers.DSAEncoding;
 import org.bouncycastle.crypto.signers.ECDSASigner;
@@ -238,6 +239,24 @@ public class SignatureSpi
         public ecDSARipeMD160()
         {
             super(new RIPEMD160Digest(), new ECDSASigner(), StandardDSAEncoding.INSTANCE);
+        }
+    }
+
+    static public class ecDSAShake128
+         extends SignatureSpi
+    {
+        public ecDSAShake128()
+        {
+            super(new SHAKEDigest(128), new ECDSASigner(), StandardDSAEncoding.INSTANCE);
+        }
+    }
+
+    static public class ecDSAShake256
+        extends SignatureSpi
+    {
+        public ecDSAShake256()
+        {
+            super(new SHAKEDigest(256), new ECDSASigner(), StandardDSAEncoding.INSTANCE);
         }
     }
 

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/SHAKEPSSSignatureSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/SHAKEPSSSignatureSpi.java
@@ -1,0 +1,152 @@
+package org.bouncycastle.jcajce.provider.asymmetric.rsa;
+
+import java.security.AlgorithmParameters;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.SignatureException;
+import java.security.SignatureSpi;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.AlgorithmParameterSpec;
+
+import org.bouncycastle.crypto.CryptoException;
+import org.bouncycastle.crypto.Signer;
+import org.bouncycastle.crypto.engines.RSABlindedEngine;
+import org.bouncycastle.crypto.params.ParametersWithRandom;
+import org.bouncycastle.crypto.params.RSAKeyParameters;
+import org.bouncycastle.crypto.params.RSAPrivateCrtKeyParameters;
+import org.bouncycastle.crypto.signers.SHAKEPSSSigner;
+
+public class SHAKEPSSSignatureSpi
+    extends SignatureSpi {
+  private RSAKeyParameters key;
+  private SecureRandom random;
+
+  private Signer signer;
+
+  // care - this constructor is actually used by outside organisations
+  protected SHAKEPSSSignatureSpi(int type, int size) {
+      this.signer = new SHAKEPSSSigner(new RSABlindedEngine(), type, size);
+  }
+
+  protected void engineInitVerify(
+      PublicKey publicKey)
+      throws InvalidKeyException {
+    if (!(publicKey instanceof RSAPublicKey)) {
+      throw new InvalidKeyException("Supplied key is not a RSAPublicKey instance");
+    }
+
+    RSAPublicKey rsaPk = (RSAPublicKey) publicKey;
+    key = new RSAKeyParameters(false, rsaPk.getModulus(), rsaPk.getPublicExponent());
+
+    signer.init(false, key);
+  }
+
+  protected void engineInitSign(
+      PrivateKey privateKey,
+      SecureRandom random)
+      throws InvalidKeyException {
+    this.random = random;
+    engineInitSign(privateKey);
+  }
+
+  protected void engineInitSign(
+      PrivateKey privateKey)
+      throws InvalidKeyException {
+    if (!(privateKey instanceof RSAPrivateKey)) {
+      throw new InvalidKeyException("Supplied key is not a RSAPrivateKey instance");
+    }
+
+    key = generatePrivateKeyParameter((RSAPrivateKey)privateKey);
+    if (random != null) {
+      signer.init(true, new ParametersWithRandom(key, random));
+    } else {
+      signer.init(true, key);
+    }
+  }
+
+  private static RSAKeyParameters generatePrivateKeyParameter(
+      RSAPrivateKey key) {
+    if (key instanceof RSAPrivateCrtKey) {
+      RSAPrivateCrtKey k = (RSAPrivateCrtKey)key;
+
+      return new RSAPrivateCrtKeyParameters(k.getModulus(),
+          k.getPublicExponent(), k.getPrivateExponent(),
+          k.getPrimeP(), k.getPrimeQ(), k.getPrimeExponentP(),
+          k.getPrimeExponentQ(), k.getCrtCoefficient());
+    } else {
+      return new RSAKeyParameters(true, key.getModulus(), key.getPrivateExponent());
+    }
+  }
+
+  protected void engineUpdate(
+      byte    b)
+      throws SignatureException {
+    signer.update(b);
+  }
+
+  protected void engineUpdate(
+      byte[]  b,
+      int     off,
+      int     len)
+      throws SignatureException {
+    signer.update(b, off, len);
+  }
+
+  protected byte[] engineSign()
+      throws SignatureException {
+    try {
+      return signer.generateSignature();
+    } catch (CryptoException e) {
+      throw new SignatureException(e.getMessage());
+    }
+  }
+
+  protected boolean engineVerify(
+      byte[]  sigBytes)
+      throws SignatureException {
+    return signer.verifySignature(sigBytes);
+  }
+
+  protected void engineSetParameter(
+      AlgorithmParameterSpec params)
+      throws InvalidAlgorithmParameterException {
+    throw new UnsupportedOperationException("engineSetParameter unsupported");
+  }
+
+  protected AlgorithmParameters engineGetParameters() {
+    return null;
+  }
+
+  /**
+   * @deprecated replaced with
+   * <a href="#engineSetParameter(java.security.spec.AlgorithmParameterSpec)">
+   * engineSetParameter(java.security.spec.AlgorithmParameterSpec)</a>
+   */
+  protected void engineSetParameter(
+      String param,
+      Object value) {
+    throw new UnsupportedOperationException("engineSetParameter unsupported");
+  }
+
+  protected Object engineGetParameter(
+      String param) {
+    throw new UnsupportedOperationException("engineGetParameter unsupported");
+  }
+
+  static public class SHAKE128WithRSAPSS extends SHAKEPSSSignatureSpi {
+    public SHAKE128WithRSAPSS() {
+      super(128, 256);
+    }
+  }
+
+  static public class SHAKE256WithRSAPSS extends SHAKEPSSSignatureSpi {
+    public SHAKE256WithRSAPSS() {
+      super(256, 512);
+    }
+  }
+}

--- a/prov/src/main/java/org/bouncycastle/jcajce/util/MessageDigestUtils.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/util/MessageDigestUtils.java
@@ -41,6 +41,8 @@ public class MessageDigestUtils
         digestOidMap.put(NISTObjectIdentifiers.id_sha3_256, "SHA3-256");
         digestOidMap.put(NISTObjectIdentifiers.id_sha3_384, "SHA3-384");
         digestOidMap.put(NISTObjectIdentifiers.id_sha3_512, "SHA3-512");
+        digestOidMap.put(NISTObjectIdentifiers.id_shake128, "SHAKE128");
+        digestOidMap.put(NISTObjectIdentifiers.id_shake256, "SHAKE256");
         digestOidMap.put(GMObjectIdentifiers.sm3, "SM3");
     }
 

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/SignatureTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/SignatureTest.java
@@ -88,6 +88,9 @@ public class SignatureTest
         checkSig(kp, "SHA384withRSAandMGF1");
         checkSig(kp, "SHA512withRSAandMGF1");
 
+        checkSig(kp, "SHAKE128withRSAPSS");
+        checkSig(kp, "SHAKE256withRSAPSS");
+
         checkSig(kp, "SHA1withRSA/ISO9796-2");
         checkSig(kp, "MD5withRSA/ISO9796-2");
         checkSig(kp, "RIPEMD160withRSA/ISO9796-2");
@@ -130,6 +133,8 @@ public class SignatureTest
         checkSig(kp, "SHA384withECDSA");
         checkSig(kp, "SHA512withECDSA");
         checkSig(kp, "RIPEMD160withECDSA");
+        checkSig(kp, "SHAKE128withECDSA");
+        checkSig(kp, "SHAKE256withECDSA");
 
         kpGen = KeyPairGenerator.getInstance("EC", "BC");
 


### PR DESCRIPTION
- MD2, MD4, MD5, SHA1, GOSTR3411: with NULL parameters
- All others: with absent parameters, except in RSASSA-PSS-Parameters and RSAES-OAEP-Parameters