### PR TITLE
Fix length of arraycopy to avoid ArrayIndexOutOfBoundsException

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/params/X25519PublicKeyParameters.java
+++ b/core/src/main/java/org/bouncycastle/crypto/params/X25519PublicKeyParameters.java
@@ -19,7 +19,7 @@ public final class X25519PublicKeyParameters
     {
         super(false);
 
-        System.arraycopy(buf, off, data, 0, KEY_SIZE);
+        System.arraycopy(buf, off, data, 0, buf.length);
     }
 
     public X25519PublicKeyParameters(InputStream input) throws IOException


### PR DESCRIPTION
Hi,
since bcprov_1.68 we see a lot of errors like this in our tests:

Caused by: java.lang.ArrayIndexOutOfBoundsException: arraycopy: last source index 32 out of bounds for byte[31]
at java.lang.System.arraycopy(Native Method) ~[?:?]
at org.bouncycastle.crypto.params.X25519PublicKeyParameters.(Unknown Source) ~[bcprov_1.68.0.jar:1.68.0]
at org.bouncycastle.jcajce.provider.asymmetric.edec.KeyAgreementSpi.engineDoPhase(KeyAgreementSpi.java:163) ~[bcprov_1.68.0.jar:1.68.0]
at javax.crypto.KeyAgreement.doPhase(KeyAgreement.java:579) ~[?:?]

The arraycopy should only copy as much bytes as the buffer contains.