### PR TITLE
Expose PGPSignature.getDigestPrefix() to get fingerprint of signature

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
@@ -288,6 +288,17 @@ public class SignaturePacket
     {
         return keyID;
     }
+
+    /**
+     * Return the signatures fingerprint.
+     * @return fingerprint (digest prefix) of the signature
+     */
+    public byte[] getFingerPrint()
+    {
+        byte[] fp = new byte[fingerPrint.length];
+        System.arraycopy(fingerPrint, 0, fp, 0, fingerPrint.length);
+        return fp;
+    }
     
     /**
      * return the signature trailer that must be included with the data

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -117,6 +117,15 @@ public class PGPSignature
     }
 
     /**
+     * Return the digest prefix of the signature.
+     * @return digest prefix
+     */
+    public byte[] getDigestPrefix()
+    {
+        return sigPck.getFingerPrint();
+    }
+
+    /**
      * Return true if this signature represents a certification.
      *
      * @return true if this signature represents a certification, false otherwise.


### PR DESCRIPTION
This PR adds `PGPSignature.getDigestPrefix()` which calls `SignaturePacket.getFingerPrint()` to expose the signatures digest  (the left 16 bits of the signed hash value) to the user.