### PR TITLE
RFC 5280 boundaries checks

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/x509/CRLNumber.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/CRLNumber.java
@@ -20,6 +20,9 @@ public class CRLNumber
     public CRLNumber(
         BigInteger number)
     {
+        if (BigInteger.ZERO.compareTo(number) > 0) {
+            throw new IllegalArgumentException("Invalid CRL number : not in (0..MAX)");
+        }
         this.number = number;
     }
 

--- a/core/src/main/java/org/bouncycastle/asn1/x509/CRLReason.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/CRLReason.java
@@ -109,6 +109,9 @@ public class CRLReason
     private CRLReason(
         int reason)
     {
+        if (reason < 0) {
+            throw new IllegalArgumentException("Invalid CRL reason : not in (0..MAX)");
+        }
         value = new ASN1Enumerated(reason);
     }
 


### PR DESCRIPTION
Checks the boundaries specified in RFC 5280 for `CRLReason`, `CRLNumber` and `IssuerSerial`.

`CRLReason` must be an integer between 0 and 10. `CRLNumber` and `IssuerSerial` must have a maximum size of 20 octets.