### PR TITLE
Add binary-signing-time CMS attribute [RFC6019]

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/pkcs/PKCSObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/pkcs/PKCSObjectIdentifiers.java
@@ -185,6 +185,8 @@ public interface PKCSObjectIdentifiers
     ASN1ObjectIdentifier    pkcs_9_at_smimeCapabilities  = pkcs_9.branch("15").intern();
     /** PKCS#9: 1.2.840.113549.1.9.16 */
     ASN1ObjectIdentifier    id_smime                     = pkcs_9.branch("16").intern();
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.46 */
+    ASN1ObjectIdentifier    pkcs_9_at_binarySigningTime  = pkcs_9.branch("16.2.46").intern();
 
     /** PKCS#9: 1.2.840.113549.1.9.20 */
     ASN1ObjectIdentifier    pkcs_9_at_friendlyName  = pkcs_9.branch("20").intern();

--- a/util/src/main/java/org/bouncycastle/asn1/cms/CMSAttributes.java
+++ b/util/src/main/java/org/bouncycastle/asn1/cms/CMSAttributes.java
@@ -5,15 +5,18 @@ import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 
 
 /**
- * <a href="https://tools.ietf.org/html/rfc5652">RFC 5652</a> CMS attribute OID constants.
+ * <a href="https://tools.ietf.org/html/rfc5652">RFC 5652</a> CMS attribute OID constants,
+ * <a href="https://tools.ietf.org/html/rfc6019">RFC 6019</a> Binary Time,
  * and <a href="https://tools.ietf.org/html/rfc6211">RFC 6211</a> Algorithm Identifier Protection Attribute.
  * <pre>
- * contentType      ::= 1.2.840.113549.1.9.3
- * messageDigest    ::= 1.2.840.113549.1.9.4
- * signingTime      ::= 1.2.840.113549.1.9.5
- * counterSignature ::= 1.2.840.113549.1.9.6
+ * contentType       ::= 1.2.840.113549.1.9.3
+ * messageDigest     ::= 1.2.840.113549.1.9.4
+ * signingTime       ::= 1.2.840.113549.1.9.5
+ * counterSignature  ::= 1.2.840.113549.1.9.6
  *
- * contentHint      ::= 1.2.840.113549.1.9.16.2.4
+ * binarySigningTime ::= 1.2.840.113549.1.9.16.2.46
+ *
+ * contentHint       ::= 1.2.840.113549.1.9.16.2.4
  * cmsAlgorithmProtect := 1.2.840.113549.1.9.52
  * </pre>
  */
@@ -28,6 +31,9 @@ public interface CMSAttributes
     ASN1ObjectIdentifier  signingTime = PKCSObjectIdentifiers.pkcs_9_at_signingTime;
     /** PKCS#9: 1.2.840.113549.1.9.6 */
     ASN1ObjectIdentifier  counterSignature = PKCSObjectIdentifiers.pkcs_9_at_counterSignature;
+    /** PKCS#9: 1.2.840.113549.1.9.16.2.46 */
+    ASN1ObjectIdentifier  binarySigningTime = PKCSObjectIdentifiers.pkcs_9_at_binarySigningTime;
+
     /** PKCS#9: 1.2.840.113549.1.9.16.6.2.4 - See <a href="https://tools.ietf.org/html/rfc2634">RFC 2634</a> */
     ASN1ObjectIdentifier  contentHint = PKCSObjectIdentifiers.id_aa_contentHint;
 


### PR DESCRIPTION
Include the binary-sigining-time CMS attribute as described in RFC 6019.