### PR TITLE
Fix McEliece KobaraImai decryption error when c5 has leading zeroes

### DIFF
--- a/core/src/main/java/org/bouncycastle/pqc/crypto/mceliece/McElieceKobaraImaiCipher.java
+++ b/core/src/main/java/org/bouncycastle/pqc/crypto/mceliece/McElieceKobaraImaiCipher.java
@@ -234,6 +234,7 @@ public class McElieceKobaraImaiCipher
 
         int c2Len = messDigest.getDigestSize();
         int c4Len = k >> 3;
+        int c5Len = (IntegerFunctions.binomial(n, t).bitLength() - 1) >> 3;
         int c6Len = input.length - nDiv8;
 
         // split cipher text (c6||encC4), where c6 may be empty
@@ -268,6 +269,13 @@ public class McElieceKobaraImaiCipher
 
         // compute c5 = Conv^-1(z)
         byte[] c5 = Conversions.decode(n, t, z);
+
+        // if c5 is shorter than expected, pad with leading zeroes
+        if (c5.length < c5Len) {
+            byte[] paddedC5 = new byte[c5Len];
+            System.arraycopy(c5, 0, paddedC5, c5Len - c5.length, c5.length);
+            c5 = paddedC5;
+        }
 
         // compute (c6||c5||c4)
         byte[] c6c5c4 = ByteUtils.concatenate(c6, c5);


### PR DESCRIPTION
Fixes issue #942. 

When c5 is split out from c2c1 in the encryption phase, it will occasionally have leading zeroes
On decryption when c5 is derived from the cipher Text, leading zeroes are stripped. This results in an incorrect decryption. This patch detects a short c5 and extends it to the correct length by restoring any stripped zeroes.