### PR TITLE
Add id_RSAES_OAEP to asymmetricWrapperAlgNames

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/operator/jcajce/OperatorHelper.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/jcajce/OperatorHelper.java
@@ -118,6 +118,7 @@ class OperatorHelper
         oids.put(TeleTrusTObjectIdentifiers.ripemd256, "RIPEMD256");
 
         asymmetricWrapperAlgNames.put(PKCSObjectIdentifiers.rsaEncryption, "RSA/ECB/PKCS1Padding");
+        asymmetricWrapperAlgNames.put(PKCSObjectIdentifiers.id_RSAES_OAEP, "RSA/ECB/OAEPWithSHA-1AndMGF1Padding");
 
         asymmetricWrapperAlgNames.put(CryptoProObjectIdentifiers.gostR3410_2001, "ECGOST3410");
 


### PR DESCRIPTION
This makes it easier to decode SCEP requests from some Windows computers with OAEP Padding using the JSCEP library.
Without the patch, I see this Exception:

Caused by: org.bouncycastle.cms.CMSException: exception unwrapping key: cannot create cipher: Cannot find any provider supporting 1.2.840.113549.1.1.7
    at org.bouncycastle.cms.jcajce.JceKeyTransRecipient.extractSecretKey(Unknown Source)
    at org.bouncycastle.cms.jcajce.JceKeyTransEnvelopedRecipient.getRecipientOperator(Unknown Source)
    at org.jscep.message.PkcsPkiEnvelopeDecoder$InternalKeyTransEnvelopedRecipient.getRecipientOperator(PkcsPkiEnvelopeDecoder.java:150)
    at org.bouncycastle.cms.KeyTransRecipientInformation.getRecipientOperator(Unknown Source)
    at org.bouncycastle.cms.RecipientInformation.getContentStream(Unknown Source)
    at org.bouncycastle.cms.RecipientInformation.getContent(Unknown Source)
    at org.jscep.message.PkcsPkiEnvelopeDecoder.decode(PkcsPkiEnvelopeDecoder.java:92)
    ... 67 more
    Caused by: org.bouncycastle.operator.OperatorCreationException: cannot create cipher: Cannot find any provider supporting 1.2.840.113549.1.1.7
    at org.bouncycastle.operator.jcajce.OperatorHelper.createAsymmetricWrapper(Unknown Source)
    at org.bouncycastle.operator.jcajce.JceAsymmetricKeyUnwrapper.generateUnwrappedKey(Unknown Source)
    ... 74 more
    Caused by: java.security.NoSuchAlgorithmException: Cannot find any provider supporting 1.2.840.113549.1.1.7
    at javax.crypto.Cipher.getInstance(Unknown Source)
    at org.bouncycastle.jcajce.util.DefaultJcaJceHelper.createCipher(Unknown Source)
    ... 76 more