### PR TITLE
add support for ASN.1 private tags

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/ASN1InputStream.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ASN1InputStream.java
@@ -141,6 +141,11 @@ public class ASN1InputStream
 
         DefiniteLengthInputStream defIn = new DefiniteLengthInputStream(this, length, limit);
 
+        if ((tag & PRIVATE) != 0)
+        {
+            return new DLPrivate(isConstructed, tagNo, defIn.toByteArray());
+        }
+
         if ((tag & APPLICATION) != 0)
         {
             return new DLApplicationSpecific(isConstructed, tagNo, defIn.toByteArray());
@@ -259,6 +264,11 @@ public class ASN1InputStream
             if ((tag & TAGGED) != 0)
             {
                 return new BERTaggedObjectParser(true, tagNo, sp).getLoadedObject();
+            }
+
+            if ((tag & PRIVATE) != 0)
+            {
+                return new BERPrivateParser(tagNo, sp).getLoadedObject();
             }
 
             // TODO There are other tags that may be constructed (e.g. BIT_STRING)

--- a/core/src/main/java/org/bouncycastle/asn1/ASN1Private.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ASN1Private.java
@@ -1,0 +1,246 @@
+package org.bouncycastle.asn1;
+
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.io.IOException;
+
+/**
+ * Base class for an ASN.1 Private object
+ */
+public abstract class ASN1Private
+    extends ASN1Primitive
+{
+    protected final boolean   isConstructed;
+    protected final int       tag;
+    protected final byte[]    octets;
+
+    ASN1Private(
+        boolean isConstructed,
+        int tag,
+        byte[] octets)
+    {
+        this.isConstructed = isConstructed;
+        this.tag = tag;
+        this.octets = Arrays.clone(octets);
+    }
+
+    /**
+     * Return an ASN1Private from the passed in object, which may be a byte array, or null.
+     *
+     * @param obj the object to be converted.
+     * @return obj's representation as an ASN1Private object.
+     */
+    public static ASN1Private getInstance(Object obj)
+    {
+        if (obj == null || obj instanceof ASN1Private)
+        {
+            return (ASN1Private)obj;
+        }
+        else if (obj instanceof byte[])
+        {
+            try
+            {
+                return ASN1Private.getInstance(ASN1Primitive.fromByteArray((byte[])obj));
+            }
+            catch (IOException e)
+            {
+                throw new IllegalArgumentException("Failed to construct object from byte[]: " + e.getMessage());
+            }
+        }
+
+        throw new IllegalArgumentException("unknown object in getInstance: " + obj.getClass().getName());
+    }
+
+    protected static int getLengthOfHeader(byte[] data)
+    {
+        int length = data[1] & 0xff; // TODO: assumes 1 byte tag
+
+        if (length == 0x80)
+        {
+            return 2;      // indefinite-length encoding
+        }
+
+        if (length > 127)
+        {
+            int size = length & 0x7f;
+
+            // Note: The invalid long form "0xff" (see X.690 8.1.3.5c) will be caught here
+            if (size > 4)
+            {
+                throw new IllegalStateException("DER length more than 4 bytes: " + size);
+            }
+
+            return size + 2;
+        }
+
+        return 2;
+    }
+
+    /**
+     * Return true if the object is marked as constructed, false otherwise.
+     *
+     * @return true if constructed, otherwise false.
+     */
+    public boolean isConstructed()
+    {
+        return isConstructed;
+    }
+
+    /**
+     * Return the contents of this object as a byte[]
+     *
+     * @return the encoded contents of the object.
+     */
+    public byte[] getContents()
+    {
+        return Arrays.clone(octets);
+    }
+
+    /**
+     * Return the tag number associated with this object,
+     *
+     * @return the application tag number.
+     */
+    public int getPrivateTag() 
+    {
+        return tag;
+    }
+
+    /**
+     * Return the enclosed object assuming explicit tagging.
+     *
+     * @return  the resulting object
+     * @throws IOException if reconstruction fails.
+     */
+    public ASN1Primitive getObject()
+        throws IOException 
+    {
+        return ASN1Primitive.fromByteArray(getContents());
+    }
+
+    /**
+     * Return the enclosed object assuming implicit tagging.
+     *
+     * @param derTagNo the type tag that should be applied to the object's contents.
+     * @return  the resulting object
+     * @throws IOException if reconstruction fails.
+     */
+    public ASN1Primitive getObject(int derTagNo)
+        throws IOException
+    {
+        if (derTagNo >= 0x1f)
+        {
+            throw new IOException("unsupported tag number");
+        }
+
+        byte[] orig = this.getEncoded();
+        byte[] tmp = replaceTagNumber(derTagNo, orig);
+
+        if ((orig[0] & BERTags.CONSTRUCTED) != 0)
+        {
+            tmp[0] |= BERTags.CONSTRUCTED;
+        }
+
+        return ASN1Primitive.fromByteArray(tmp);
+    }
+
+    int encodedLength()
+        throws IOException
+    {
+        return StreamUtil.calculateTagLength(tag) + StreamUtil.calculateBodyLength(octets.length) + octets.length;
+    }
+
+    /* (non-Javadoc)
+     * @see org.bouncycastle.asn1.ASN1Primitive#encode(org.bouncycastle.asn1.DEROutputStream)
+     */
+    void encode(ASN1OutputStream out, boolean withTag) throws IOException
+    {
+        int flags = BERTags.PRIVATE;
+        if (isConstructed)
+        {
+            flags |= BERTags.CONSTRUCTED;
+        }
+
+        out.writeEncoded(withTag, flags, tag, octets);
+    }
+
+    boolean asn1Equals(
+        ASN1Primitive o)
+    {
+        if (!(o instanceof ASN1Private))
+        {
+            return false;
+        }
+
+        ASN1Private other = (ASN1Private)o;
+
+        return isConstructed == other.isConstructed
+            && tag == other.tag
+            && Arrays.areEqual(octets, other.octets);
+    }
+
+    public int hashCode()
+    {
+        return (isConstructed ? 1 : 0) ^ tag ^ Arrays.hashCode(octets);
+    }
+
+    private byte[] replaceTagNumber(int newTag, byte[] input)
+        throws IOException
+    {
+        int tagNo = input[0] & 0x1f;
+        int index = 1;
+        //
+        // with tagged object tag number is bottom 5 bits, or stored at the start of the content
+        //
+        if (tagNo == 0x1f)
+        {
+            int b = input[index++] & 0xff;
+
+            // X.690-0207 8.1.2.4.2
+            // "c) bits 7 to 1 of the first subsequent octet shall not all be zero."
+            if ((b & 0x7f) == 0) // Note: -1 will pass
+            {
+                throw new IOException("corrupted stream - invalid high tag number found");
+            }
+
+            while ((b & 0x80) != 0)
+            {
+                b = input[index++] & 0xff;
+            }
+        }
+
+        byte[] tmp = new byte[input.length - index + 1];
+
+        System.arraycopy(input, index, tmp, 1, tmp.length - 1);
+
+        tmp[0] = (byte)newTag;
+
+        return tmp;
+    }
+
+    public String toString()
+    {
+        StringBuffer sb = new StringBuffer();
+        sb.append("[");
+        if (isConstructed())
+        {
+            sb.append("CONSTRUCTED ");
+        }
+        sb.append("PRIVATE ");
+        sb.append(Integer.toString(getPrivateTag()));
+        sb.append("]");
+        // @todo content encoding somehow?
+        if (this.octets != null)
+        {
+            sb.append(" #");
+            sb.append(Hex.toHexString(this.octets));
+        }
+        else
+        {
+            sb.append(" #null");
+        }
+        sb.append(" ");
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/org/bouncycastle/asn1/ASN1PrivateParser.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ASN1PrivateParser.java
@@ -1,0 +1,19 @@
+package org.bouncycastle.asn1;
+
+import java.io.IOException;
+
+/**
+ * Interface to parse ASN.1 Private objects.
+ */
+public interface ASN1PrivateParser
+    extends ASN1Encodable, InMemoryRepresentable
+{
+    /**
+     * Read the next object in the parser.
+     *
+     * @return an ASN1Encodable
+     * @throws IOException on a parsing or decoding error.
+     */
+    ASN1Encodable readObject()
+        throws IOException;
+}

--- a/core/src/main/java/org/bouncycastle/asn1/ASN1StreamParser.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ASN1StreamParser.java
@@ -155,6 +155,11 @@ public class ASN1StreamParser
             IndefiniteLengthInputStream indIn = new IndefiniteLengthInputStream(_in, _limit);
             ASN1StreamParser sp = new ASN1StreamParser(indIn, _limit);
 
+            if ((tag & BERTags.PRIVATE) != 0)
+            {
+                return new BERPrivateParser(tagNo, sp);
+            }
+
             if ((tag & BERTags.APPLICATION) != 0)
             {
                 return new BERApplicationSpecificParser(tagNo, sp);
@@ -170,6 +175,11 @@ public class ASN1StreamParser
         else
         {
             DefiniteLengthInputStream defIn = new DefiniteLengthInputStream(_in, length, _limit);
+
+            if ((tag & BERTags.PRIVATE) != 0)
+            {
+                return new DLPrivate(isConstructed, tagNo, defIn.toByteArray());
+            }
 
             if ((tag & BERTags.APPLICATION) != 0)
             {

--- a/core/src/main/java/org/bouncycastle/asn1/BERPrivate.java
+++ b/core/src/main/java/org/bouncycastle/asn1/BERPrivate.java
@@ -1,0 +1,110 @@
+package org.bouncycastle.asn1;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ * An indefinite-length encoding version of an ASN.1 Private object.
+ */
+public class BERPrivate
+    extends ASN1Private
+{
+    BERPrivate(
+        boolean isConstructed,
+        int tag,
+        byte[] octets)
+    {
+        super(isConstructed, tag, octets);
+    }
+
+    /**
+     * Create a private object with a tagging of explicit/constructed.
+     *
+     * @param tag the tag number for this object.
+     * @param object the object to be contained.
+     */
+    public BERPrivate(
+        int tag,
+        ASN1Encodable object)
+        throws IOException
+    {
+        this(true, tag, object);
+    }
+
+    /**
+     * Create a private object with the tagging style given by the value of constructed.
+     *
+     * @param constructed true if the object is constructed.
+     * @param tag the tag number for this object.
+     * @param object the object to be contained.
+     */
+    public BERPrivate(
+        boolean constructed,
+        int tag,
+        ASN1Encodable object)
+        throws IOException
+    {
+        super(constructed || object.toASN1Primitive().isConstructed(), tag, getEncoding(constructed, object));
+    }
+
+    private static byte[] getEncoding(boolean explicit, ASN1Encodable object)
+        throws IOException
+    {
+        byte[] data = object.toASN1Primitive().getEncoded(ASN1Encoding.BER);
+
+        if (explicit)
+        {
+            return data;
+        }
+        else
+        {
+            int lenBytes = getLengthOfHeader(data);
+            byte[] tmp = new byte[data.length - lenBytes];
+            System.arraycopy(data, lenBytes, tmp, 0, tmp.length);
+            return tmp;
+        }
+    }
+
+    /**
+     * Create a private object which is marked as constructed
+     *
+     * @param tagNo the tag number for this object.
+     * @param vec the objects making up the private object.
+     */
+    public BERPrivate(int tagNo, ASN1EncodableVector vec)
+    {
+        super(true, tagNo, getEncodedVector(vec));
+    }
+
+    private static byte[] getEncodedVector(ASN1EncodableVector vec)
+    {
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+
+        for (int i = 0; i != vec.size(); i++)
+        {
+            try
+            {
+                bOut.write(((ASN1Object)vec.get(i)).getEncoded(ASN1Encoding.BER));
+            }
+            catch (IOException e)
+            {
+                throw new ASN1ParsingException("malformed object: " + e, e);
+            }
+        }
+        return bOut.toByteArray();
+    }
+
+    /* (non-Javadoc)
+     * @see org.bouncycastle.asn1.ASN1Primitive#encode(org.bouncycastle.asn1.DEROutputStream)
+     */
+    void encode(ASN1OutputStream out, boolean withTag) throws IOException
+    {
+        int flags = BERTags.PRIVATE;
+        if (isConstructed)
+        {
+            flags |= BERTags.CONSTRUCTED;
+        }
+
+        out.writeEncodedIndef(withTag, flags, tag, octets);
+    }
+}

--- a/core/src/main/java/org/bouncycastle/asn1/BERPrivateParser.java
+++ b/core/src/main/java/org/bouncycastle/asn1/BERPrivateParser.java
@@ -1,0 +1,59 @@
+package org.bouncycastle.asn1;
+
+import java.io.IOException;
+
+/**
+ * A parser for indefinite-length ASN.1 Private objects.
+ */
+public class BERPrivateParser
+    implements ASN1PrivateParser
+{
+    private final int tag;
+    private final ASN1StreamParser parser;
+
+    BERPrivateParser(int tag, ASN1StreamParser parser)
+    {
+        this.tag = tag;
+        this.parser = parser;
+    }
+
+    /**
+     * Return the object contained in this private object,
+     * @return the contained object.
+     * @throws IOException if the underlying stream cannot be read, or does not contain an ASN.1 encoding.
+     */
+    public ASN1Encodable readObject()
+        throws IOException
+    {
+        return parser.readObject();
+    }
+
+    /**
+     * Return an in-memory, encodable, representation of the private object.
+     *
+     * @return a BERPrivate.
+     * @throws IOException if there is an issue loading the data.
+     */
+    public ASN1Primitive getLoadedObject()
+        throws IOException
+    {
+         return new BERPrivate(tag, parser.readVector());
+    }
+
+    /**
+     * Return a BERPrivate representing this parser and its contents.
+     *
+     * @return a BERPrivate
+     */
+    public ASN1Primitive toASN1Primitive()
+    {
+        try
+        {
+            return getLoadedObject();
+        }
+        catch (IOException e)
+        {
+            throw new ASN1ParsingException(e.getMessage(), e);
+        }
+    }
+}

--- a/core/src/main/java/org/bouncycastle/asn1/BERTags.java
+++ b/core/src/main/java/org/bouncycastle/asn1/BERTags.java
@@ -33,4 +33,5 @@ public interface BERTags
     public static final int CONSTRUCTED         = 0x20; // decimal 32
     public static final int APPLICATION         = 0x40; // decimal 64
     public static final int TAGGED              = 0x80; // decimal 128
+    public static final int PRIVATE             = 0xC0; // decimal 192
 }

--- a/core/src/main/java/org/bouncycastle/asn1/DERPrivate.java
+++ b/core/src/main/java/org/bouncycastle/asn1/DERPrivate.java
@@ -1,0 +1,124 @@
+package org.bouncycastle.asn1;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ * A DER encoding version of an private object.
+ */
+public class DERPrivate 
+    extends ASN1Private
+{
+    DERPrivate(
+        boolean isConstructed,
+        int     tag,
+        byte[]  octets)
+    {
+        super(isConstructed, tag, octets);
+    }
+
+    /**
+     * Create an private object from the passed in data. This will assume
+     * the data does not represent a constructed object.
+     *
+     * @param tag the tag number for this object.
+     * @param octets the encoding of the object's body.
+     */
+    public DERPrivate(
+        int    tag,
+        byte[] octets)
+    {
+        this(false, tag, octets);
+    }
+
+    /**
+     * Create an private object with a tagging of explicit/constructed.
+     *
+     * @param tag the tag number for this object.
+     * @param object the object to be contained.
+     */
+    public DERPrivate(
+        int           tag,
+        ASN1Encodable object)
+        throws IOException 
+    {
+        this(true, tag, object);
+    }
+
+    /**
+     * Create an private object with the tagging style given by the value of constructed.
+     *
+     * @param constructed true if the object is constructed.
+     * @param tag the tag number for this object.
+     * @param object the object to be contained.
+     */
+    public DERPrivate(
+        boolean      constructed,
+        int          tag,
+        ASN1Encodable object)
+        throws IOException
+    {
+        super(constructed || object.toASN1Primitive().isConstructed(), tag, getEncoding(constructed, object));
+    }
+
+    private static byte[] getEncoding(boolean explicit, ASN1Encodable object)
+        throws IOException
+    {
+        byte[] data = object.toASN1Primitive().getEncoded(ASN1Encoding.DER);
+
+        if (explicit)
+        {
+            return data;
+        }
+        else
+        {
+            int lenBytes = getLengthOfHeader(data);
+            byte[] tmp = new byte[data.length - lenBytes];
+            System.arraycopy(data, lenBytes, tmp, 0, tmp.length);
+            return tmp;
+        }
+    }
+
+    /**
+     * Create an private object which is marked as constructed
+     *
+     * @param tagNo the tag number for this object.
+     * @param vec the objects making up the private object.
+     */
+    public DERPrivate(int tagNo, ASN1EncodableVector vec)
+    {
+        super(true, tagNo, getEncodedVector(vec));
+    }
+
+    private static byte[] getEncodedVector(ASN1EncodableVector vec)
+    {
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+
+        for (int i = 0; i != vec.size(); i++)
+        {
+            try
+            {
+                bOut.write(((ASN1Object)vec.get(i)).getEncoded(ASN1Encoding.DER));
+            }
+            catch (IOException e)
+            {
+                throw new ASN1ParsingException("malformed object: " + e, e);
+            }
+        }
+        return bOut.toByteArray();
+    }
+
+    /* (non-Javadoc)
+     * @see org.bouncycastle.asn1.ASN1Primitive#encode(org.bouncycastle.asn1.DEROutputStream)
+     */
+    void encode(ASN1OutputStream out, boolean withTag) throws IOException
+    {
+        int flags = BERTags.PRIVATE;
+        if (isConstructed)
+        {
+            flags |= BERTags.CONSTRUCTED;
+        }
+
+        out.writeEncoded(withTag, flags, tag, octets);
+    }
+}

--- a/core/src/main/java/org/bouncycastle/asn1/DLPrivate.java
+++ b/core/src/main/java/org/bouncycastle/asn1/DLPrivate.java
@@ -1,0 +1,124 @@
+package org.bouncycastle.asn1;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ * A DER encoding version of an private object.
+ */
+public class DLPrivate
+    extends ASN1Private
+{
+    DLPrivate(
+        boolean isConstructed,
+        int     tag,
+        byte[]  octets)
+    {
+        super(isConstructed, tag, octets);
+    }
+
+    /**
+     * Create an private object from the passed in data. This will assume
+     * the data does not represent a constructed object.
+     *
+     * @param tag the tag number for this object.
+     * @param octets the encoding of the object's body.
+     */
+    public DLPrivate(
+        int    tag,
+        byte[] octets)
+    {
+        this(false, tag, octets);
+    }
+
+    /**
+     * Create an private object with a tagging of explicit/constructed.
+     *
+     * @param tag the tag number for this object.
+     * @param object the object to be contained.
+     */
+    public DLPrivate(
+        int           tag,
+        ASN1Encodable object)
+        throws IOException
+    {
+        this(true, tag, object);
+    }
+
+    /**
+     * Create an private object with the tagging style given by the value of constructed.
+     *
+     * @param constructed true if the object is constructed.
+     * @param tag the tag number for this object.
+     * @param object the object to be contained.
+     */
+    public DLPrivate(
+        boolean      constructed,
+        int          tag,
+        ASN1Encodable object)
+        throws IOException
+    {
+        super(constructed || object.toASN1Primitive().isConstructed(), tag, getEncoding(constructed, object));
+    }
+
+    private static byte[] getEncoding(boolean explicit, ASN1Encodable object)
+        throws IOException
+    {
+        byte[] data = object.toASN1Primitive().getEncoded(ASN1Encoding.DL);
+
+        if (explicit)
+        {
+            return data;
+        }
+        else
+        {
+            int lenBytes = getLengthOfHeader(data);
+            byte[] tmp = new byte[data.length - lenBytes];
+            System.arraycopy(data, lenBytes, tmp, 0, tmp.length);
+            return tmp;
+        }
+    }
+
+    /**
+     * Create a private object which is marked as constructed
+     *
+     * @param tagNo the tag number for this object.
+     * @param vec the objects making up the private object.
+     */
+    public DLPrivate(int tagNo, ASN1EncodableVector vec)
+    {
+        super(true, tagNo, getEncodedVector(vec));
+    }
+
+    private static byte[] getEncodedVector(ASN1EncodableVector vec)
+    {
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+
+        for (int i = 0; i != vec.size(); i++)
+        {
+            try
+            {
+                bOut.write(((ASN1Object)vec.get(i)).getEncoded(ASN1Encoding.DL));
+            }
+            catch (IOException e)
+            {
+                throw new ASN1ParsingException("malformed object: " + e, e);
+            }
+        }
+        return bOut.toByteArray();
+    }
+
+    /* (non-Javadoc)
+     * @see org.bouncycastle.asn1.ASN1Primitive#encode(org.bouncycastle.asn1.DEROutputStream)
+     */
+    void encode(ASN1OutputStream out, boolean withTag) throws IOException
+    {
+        int flags = BERTags.PRIVATE;
+        if (isConstructed)
+        {
+            flags |= BERTags.CONSTRUCTED;
+        }
+
+        out.writeEncoded(withTag, flags, tag, octets);
+    }
+}

--- a/core/src/test/java/org/bouncycastle/asn1/test/DERPrivateTest.java
+++ b/core/src/test/java/org/bouncycastle/asn1/test/DERPrivateTest.java
@@ -1,0 +1,132 @@
+package org.bouncycastle.asn1.test;
+
+import org.bouncycastle.asn1.*;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.encoders.Hex;
+import org.bouncycastle.util.test.SimpleTest;
+
+public class DERPrivateTest
+    extends SimpleTest
+{
+    private static final byte[] impData = Hex.decode("C30109");
+
+    private static final byte[] certData = Hex.decode(
+        "FF218201897F4E8201495F290100420E44454356434145504153533030317F49"
+      + "81FD060A04007F00070202020202811CD7C134AA264366862A18302575D1D787"
+      + "B09F075797DA89F57EC8C0FF821C68A5E62CA9CE6C1C299803A6C1530B514E18"
+      + "2AD8B0042A59CAD29F43831C2580F63CCFE44138870713B1A92369E33E2135D2"
+      + "66DBB372386C400B8439040D9029AD2C7E5CF4340823B2A87DC68C9E4CE3174C"
+      + "1E6EFDEE12C07D58AA56F772C0726F24C6B89E4ECDAC24354B9E99CAA3F6D376"
+      + "1402CD851CD7C134AA264366862A18302575D0FB98D116BC4B6DDEBCA3A5A793"
+      + "9F863904393EE8E06DB6C7F528F8B4260B49AA93309824D92CDB1807E5437EE2"
+      + "E26E29B73A7111530FA86B350037CB9415E153704394463797139E148701015F"
+      + "200E44454356434145504153533030317F4C0E060904007F0007030102015301"
+      + "C15F25060007000400015F24060009000400015F37384CCF25C59F3612EEE188"
+      + "75F6C5F2E2D21F0395683B532A26E4C189B71EFE659C3F26E0EB9AEAE9986310"
+      + "7F9B0DADA16414FFA204516AEE2B");
+
+    private final static byte[] sampleData = Hex.decode(
+        "613280020780a106060456000104a203020101a305a103020101be80288006025101020109a080b2800a01000000000000000000");
+
+    public String getName()
+    {
+        return "DERPrivate";
+    }
+
+    private void testTaggedObject()
+                throws Exception
+    {
+        // boolean explicit, int tagNo, ASN1Encodable obj
+        boolean explicit = false;
+
+        // Type1 ::= VisibleString
+        DERVisibleString type1 = new DERVisibleString("Jones");
+        if (!Arrays.areEqual(Hex.decode("1A054A6F6E6573"), type1.getEncoded()))
+        {
+            fail("ERROR: expected value doesn't match!");
+        }
+
+        // Type2 ::= [PRIVATE 3] IMPLICIT Type1
+        explicit = false;
+        DERPrivate type2 = new DERPrivate(explicit, 3, type1);
+        // type2.isConstructed()
+        if (!Arrays.areEqual(Hex.decode("C3054A6F6E6573"), type2.getEncoded()))
+        {
+            fail("ERROR: expected value doesn't match!");
+        }
+
+        // Type3 ::= [2] Type2
+        explicit = true;
+        DERTaggedObject type3 = new DERTaggedObject(explicit, 2, type2);
+        if (!Arrays.areEqual(Hex.decode("A207C3054A6F6E6573"), type3.getEncoded()))
+        {
+            fail("ERROR: expected value doesn't match!");
+        }
+
+        // Type4 ::= [PRIVATE 7] IMPLICIT Type3
+        explicit = false;
+        DERPrivate type4 = new DERPrivate(explicit, 7, type3);
+        if (!Arrays.areEqual(Hex.decode("E707C3054A6F6E6573"), type4.getEncoded()))
+        {
+            fail("ERROR: expected value doesn't match!");
+        }
+
+        // Type5 ::= [2] IMPLICIT Type2
+        explicit = false;
+        DERTaggedObject type5 = new DERTaggedObject(explicit, 2, type2);
+        // type5.isConstructed()
+        if (!Arrays.areEqual(Hex.decode("82054A6F6E6573"), type5.getEncoded()))
+        {
+            fail("ERROR: expected value doesn't match!");
+        }
+    }
+
+    public void performTest()
+        throws Exception
+    {
+        testTaggedObject();
+
+        ASN1Private privateSpec = (ASN1Private)ASN1Primitive.fromByteArray(sampleData);
+
+        if (1 != privateSpec.getPrivateTag())
+        {
+            fail("wrong tag detected");
+        }
+
+        ASN1Integer value = new ASN1Integer(9);
+
+        DERPrivate tagged = new DERPrivate(false, 3, value);
+
+        if (!areEqual(impData, tagged.getEncoded()))
+        {
+            fail("implicit encoding failed");
+        }
+
+        ASN1Integer recVal = (ASN1Integer)tagged.getObject(BERTags.INTEGER);
+
+        if (!value.equals(recVal))
+        {
+            fail("implicit read back failed");
+        }
+
+        ASN1Private certObj = (ASN1Private) ASN1Primitive.fromByteArray(certData);
+
+        if (!certObj.isConstructed() || certObj.getPrivateTag() != 33)
+        {
+            fail("parsing of certificate data failed");
+        }
+
+        byte[] encoded = certObj.getEncoded(ASN1Encoding.DER);
+    
+        if (!Arrays.areEqual(certData, encoded))
+        {
+            fail("re-encoding of certificate data failed");
+        }
+    }
+
+    public static void main(
+        String[]    args)
+    {
+        runTest(new DERPrivateTest());
+    }
+}


### PR DESCRIPTION
The ASN.1 standard defines a total of 4 tag classes: 
* Universal
* Application Specific
* Context Specific
* Private

This PR adds support for the currently absent "Private" tag class to the bc-java ASN.1 library and addresses issue #153 