### PR TITLE
Create PGPSignatureSubpacketVector factory method

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketVector.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketVector.java
@@ -34,6 +34,14 @@ public class PGPSignatureSubpacketVector
     {
         this.packets = packets;
     }
+
+    public PGPSignatureSubpacketVector fromSubpackets(SignatureSubpacket[] packets)
+    {
+        if (packets == null) {
+            packets = new SignatureSubpacket[0];
+        }
+        return new PGPSignatureSubpacketVector(packets);
+    }
     
     public SignatureSubpacket getSubpacket(
         int    type)


### PR DESCRIPTION
This PR adds a factory method to the `PGPSignatureSubpacketVector` class that allows instantiation of an object without the need to use the fiddly `PGPSignatureSubpacketGenerator` class.
