### PR TITLE
Add SHAKE256-len and SHAKE128-len digest to BcDefaultDigestProvider

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/operator/bc/BcDefaultDigestProvider.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/bc/BcDefaultDigestProvider.java
@@ -150,6 +150,20 @@ public class BcDefaultDigestProvider
                 return new RIPEMD256Digest();
             }
         });
+        table.put(NISTObjectIdentifiers.id_shake256_len, new BcDigestProvider()
+        {
+            public ExtendedDigest get(AlgorithmIdentifier digestAlgorithmIdentifier)
+            {
+                return new SHAKEDigest(256);
+            }
+        });
+        table.put(NISTObjectIdentifiers.id_shake128_len, new BcDigestProvider()
+        {
+            public ExtendedDigest get(AlgorithmIdentifier digestAlgorithmIdentifier)
+            {
+                return new SHAKEDigest(128);
+            }
+        });
 
         return Collections.unmodifiableMap(table);
     }


### PR DESCRIPTION
Although there is support for shake256-len and shake128-len in other
 classes throughout the project, it's still missing from the BcDefaultDigestProvider. 

This can cause a lot of headache when trying to sign certain types of CMS.