### PR TITLE
PGPPublicKey: Improve handling of signatures for duplicated user-id/attributes

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -533,15 +533,19 @@ public class PGPPublicKey
     private Iterator<PGPSignature> getSignaturesForID(
         UserIDPacket   id)
     {
+        List<PGPSignature> signatures = new ArrayList<>();
+        boolean userIdFound = false;
+
         for (int i = 0; i != ids.size(); i++)
         {
             if (id.equals(ids.get(i)))
             {
-                return ((List<PGPSignature>)idSigs.get(i)).iterator();
+                userIdFound = true;
+                signatures.addAll(idSigs.get(i));
             }
         }
 
-        return null;
+        return userIdFound ? signatures.iterator() : null;
     }
 
     /**
@@ -553,15 +557,19 @@ public class PGPPublicKey
     public Iterator<PGPSignature> getSignaturesForUserAttribute(
         PGPUserAttributeSubpacketVector    userAttributes)
     {
+        List<PGPSignature> signatures = new ArrayList<>();
+        boolean attributeFound = false;
+
         for (int i = 0; i != ids.size(); i++)
         {
             if (userAttributes.equals(ids.get(i)))
             {
-                return ((ArrayList<PGPSignature>)idSigs.get(i)).iterator();
+                attributeFound = true;
+                signatures.addAll(idSigs.get(i));
             }
         }
-        
-        return null;
+
+        return attributeFound ? signatures.iterator() : null;
     }
     
     /**


### PR DESCRIPTION
Since BC internally relies on `List<List<PGPSignature>>` and indices to keep track of which signatures belong to which user-id, it cannot properly handle duplicate user-id packets.

As a consequence, BC will not return all signatures on a duplicated user-id, if the certificate is of the form
```
Public Key
User-id
User-id (duplicate)
User-id Signature
```
since it will return the idSigs item at index 0, which is empty in this case.

This PR changes the behavior of BC by accumulating all signatures that match a given user-id / user-attributes packet before returning all collected signatures. The behavior of returning null if no user-id matches is preserved.