### PR TITLE
Make StreamGenerator interface public

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/StreamGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/StreamGenerator.java
@@ -6,7 +6,7 @@ import java.io.IOException;
  * Callback interface for generators that produce a stream to be informed when the stream has been
  * closed by the client.
  */
-interface StreamGenerator
+public interface StreamGenerator
 {
     /**
      * Signal that the stream has been closed.


### PR DESCRIPTION
Since both `PGPLiteralDataGenerator` and `PGPCanonicalizedDataGenerator` inherit from this interface, making it public would allow downstream users to use a variable of type `StreamGenerator` to hold either the `PGPLiteralDataGenerator` or `PGPCanonicalizedDataGenerator` in one field.

As such the user can do stuff like:
```
private StreamGenerator streamGenerator;
[...]

encode() {
    if (encoding == BINARY) {
        PGPLiteralDataGenerator literalDataGenerator = new PGPLiteralDataGenerator();
        outputStream = literalDataGenerator.open([...]);
        streamGenerator = literalDataGenerator;
    } else {
        PGPCanonicalizedDataGenerator canonicalizedDataGenerator = new PGPCanonicalizedDataGenerator();
        outputStream = canonicalizedDataGenerator.open([..});
        streamGenerator = canonicalizedDataGenerator;
    }
    [...]
    streamGenerator.close();
}
