### PR TITLE
Add factory method to instantiate a public subkey from a public key packet

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -148,6 +148,19 @@ public class PGPPublicKey
         init(fingerPrintCalculator);
      }
 
+    /**
+     * Factory method to create a subkey from the given public key packet.
+     *
+     * @param publicKeyPacket public key packet
+     * @param fingerPrintCalculator fingerprint calculator
+     * @return subkey
+     * @throws PGPException
+     */
+     public static PGPPublicKey createSubkey(PublicKeyPacket publicKeyPacket, KeyFingerPrintCalculator fingerPrintCalculator)
+             throws PGPException {
+         return new PGPPublicKey(new PGPPublicKey(publicKeyPacket, fingerPrintCalculator), null, new ArrayList<>());
+     }
+
     PGPPublicKey(
         PGPPublicKey key,
         TrustPacket trust, 


### PR DESCRIPTION
Unfortunately, the only public constructor for public keys does not set
subSigs to a non-null value. Since isMasterKey() derives its result
from the nullity of the subSigs list, it is not possible to create
public subkey objects without going a detour over the KeyRingGenerator.
This commit adds a factory method which sets the subSigs list to an
empty but non-null list.