### PR TITLE
Simplify PGPPublicKey.isMasterKey()

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -22,6 +22,7 @@ import org.bouncycastle.bcpg.ECPublicBCPGKey;
 import org.bouncycastle.bcpg.ElGamalPublicBCPGKey;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.bouncycastle.bcpg.PublicKeyPacket;
+import org.bouncycastle.bcpg.PublicSubkeyPacket;
 import org.bouncycastle.bcpg.RSAPublicBCPGKey;
 import org.bouncycastle.bcpg.SignatureSubpacketTags;
 import org.bouncycastle.bcpg.TrustPacket;
@@ -410,7 +411,7 @@ public class PGPPublicKey
      */
     public boolean isMasterKey()
     {
-        return (subSigs == null) && !(this.isEncryptionKey() && publicPk.getAlgorithm() != PublicKeyAlgorithmTags.RSA_GENERAL);
+        return !(publicPk instanceof PublicSubkeyPacket);
     }
     
     /**


### PR DESCRIPTION
The current implementation of `PGPPublicKey.isMasterKey()` is a bit unstable.
This PR replaces it with a more straight forward implementation that inspects the public key packet to infer the key type.