### PR TITLE
SignatureSubpacketInputStream: return RevocationKey subpacket

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/SignatureSubpacketInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignatureSubpacketInputStream.java
@@ -4,24 +4,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.bouncycastle.bcpg.sig.EmbeddedSignature;
-import org.bouncycastle.bcpg.sig.Exportable;
-import org.bouncycastle.bcpg.sig.Features;
-import org.bouncycastle.bcpg.sig.IntendedRecipientFingerprint;
-import org.bouncycastle.bcpg.sig.IssuerFingerprint;
-import org.bouncycastle.bcpg.sig.IssuerKeyID;
-import org.bouncycastle.bcpg.sig.KeyExpirationTime;
-import org.bouncycastle.bcpg.sig.KeyFlags;
-import org.bouncycastle.bcpg.sig.NotationData;
-import org.bouncycastle.bcpg.sig.PreferredAlgorithms;
-import org.bouncycastle.bcpg.sig.PrimaryUserID;
-import org.bouncycastle.bcpg.sig.Revocable;
-import org.bouncycastle.bcpg.sig.RevocationReason;
-import org.bouncycastle.bcpg.sig.SignatureCreationTime;
-import org.bouncycastle.bcpg.sig.SignatureExpirationTime;
-import org.bouncycastle.bcpg.sig.SignatureTarget;
-import org.bouncycastle.bcpg.sig.SignerUserID;
-import org.bouncycastle.bcpg.sig.TrustSignature;
+import org.bouncycastle.bcpg.sig.*;
 import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.io.Streams;
 
@@ -173,6 +156,8 @@ public class SignatureSubpacketInputStream
             return new NotationData(isCritical, isLongLength, data);
         case REVOCATION_REASON:
             return new RevocationReason(isCritical, isLongLength, data);
+        case REVOCATION_KEY:
+            return new RevocationKey(isCritical, isLongLength, data);
         case SIGNATURE_TARGET:
             return new SignatureTarget(isCritical, isLongLength, data);
         case ISSUER_FINGERPRINT:


### PR DESCRIPTION
When trying to extract `RevocationKey` subpackets from a `PGPSignatureSubpacketVector`, I ran into `ClassCastingException`s.
Turns out the `SignatureSubpacketInputStream` was missing a branch to parse `RevocationKey` subpackets.