### PR TITLE
Algorithm parameters lost on fallback

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/operator/jcajce/JceAsymmetricKeyUnwrapper.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/jcajce/JceAsymmetricKeyUnwrapper.java
@@ -145,7 +145,14 @@ public class JceAsymmetricKeyUnwrapper
             // some providers do not support UNWRAP (this appears to be only for asymmetric algorithms)
             if (sKey == null)
             {
-                keyCipher.init(Cipher.DECRYPT_MODE, privKey);
+                if (algParams != null)
+                {
+                    keyCipher.init(Cipher.DECRYPT_MODE, privKey, algParams);
+                }
+                else
+                {
+                    keyCipher.init(Cipher.DECRYPT_MODE, privKey);
+                }
                 sKey = new SecretKeySpec(keyCipher.doFinal(encryptedKey), encryptedKeyAlgorithm.getAlgorithm().getId());
             }
 

--- a/pkix/src/main/java/org/bouncycastle/operator/jcajce/JceAsymmetricKeyWrapper.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/jcajce/JceAsymmetricKeyWrapper.java
@@ -272,7 +272,14 @@ public class JceAsymmetricKeyWrapper
             {
                 try
                 {
-                    keyEncryptionCipher.init(Cipher.ENCRYPT_MODE, publicKey, random);
+                    if (algParams != null)
+                    {
+                        keyEncryptionCipher.init(Cipher.ENCRYPT_MODE, publicKey, algParams, random);
+                    }
+                    else
+                    {
+                        keyEncryptionCipher.init(Cipher.ENCRYPT_MODE, publicKey, random);
+                    }
                     encryptedKeyBytes = keyEncryptionCipher.doFinal(OperatorUtils.getJceKey(encryptionKey).getEncoded());
                 }
                 catch (InvalidKeyException e)

--- a/pkix/src/main/jdk1.1/org/bouncycastle/operator/jcajce/JceAsymmetricKeyUnwrapper.java
+++ b/pkix/src/main/jdk1.1/org/bouncycastle/operator/jcajce/JceAsymmetricKeyUnwrapper.java
@@ -137,7 +137,14 @@ public class JceAsymmetricKeyUnwrapper
             // some providers do not support UNWRAP (this appears to be only for asymmetric algorithms)
             if (sKey == null)
             {
-                keyCipher.init(Cipher.DECRYPT_MODE, privKey);
+                if (algParams != null)
+                {
+                    keyCipher.init(Cipher.DECRYPT_MODE, privKey, algParams);
+                }
+                else
+                {
+                    keyCipher.init(Cipher.DECRYPT_MODE, privKey);
+                }
                 sKey = new SecretKeySpec(keyCipher.doFinal(encryptedKey), encryptedKeyAlgorithm.getAlgorithm().getId());
             }
 


### PR DESCRIPTION
I have noticed that the algorithm parameters get lost when using the fallback to encrypt/decrypt mode. This doesn't work for example with RSA OAEP when non default parameters are used.