### PR TITLE
Add MPInteger encoding without multiple leading zeros

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/MPInteger.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/MPInteger.java
@@ -50,13 +50,12 @@ public class MPInteger
         
         byte[]    bytes = value.toByteArray();
         
-        if (bytes[0] == 0)
-        {
-            out.write(bytes, 1, bytes.length - 1);
+        int off = 0;
+        
+        while (off < bytes.length && bytes[off] == 0) {
+            off += 1;
         }
-        else
-        {
-            out.write(bytes, 0, bytes.length);
-        }
+        
+        out.write(bytes, off, bytes.length - off);
     }
 }


### PR DESCRIPTION
It appears that there are some pathological `BigInteger` implementations which include multiple leading zero bytes in the output of the `#toByteArray()` method.

This is probably fine in other places, such as ASN.1 integers, but for some reason it confuses GPG. Attached you'll find two experimental ECDSA P-256 keys that differ only in their encoding of the Q point (`pkey[1]`) section which includes an extra leading 0 byte. The keys have been generated in the Android emulator, so the pathological representations might be due to Android's implementation of either `BigInteger` or the AndroidKeyStore EC key generator.

Regardless, the change below will strip any leading zero bytes from the `BigInteger`'s big-endian representation as returned by `#toByteArray()`.

The flow which impacts the operations I'm using goes through `org.bouncycastle.openpgp.PGPUtil#dsaSigToMpi(byte[])`.

[RFC4880](https://datatracker.ietf.org/doc/html/rfc4880#section-3.2) does not directly say, but it does imply that there are only as many leading zero-bits so that the octet boundary is met.

Interestingly, the `MPInteger(BCPGInputStream)` constructor is unlikely to be able to decode this type of integer properly.

Invalid public key, notice `0400` prefix in `pkey[1]`, length of byte array is 66:
```
:public key packet:
	version 4, algo 19, created 1644879111, expires 0
	pkey[0]: 082A8648CE3D030107 nistp256 (1.2.840.10045.3.1.7)
	pkey[1]: 04008769EFA44930B41273D7F3004F1B90E534ED104E1A80BC5BB33FB73F01FCA3A6338A09439A4BAD759E661346EDD9563A916614EE8AFC923C1112E079B5AB2949
	keyid: 1D345FE607BC8518
```

Valid public key, length of byte array is 65:
```
:public key packet:
	version 4, algo 19, created 1644878896, expires 0
	pkey[0]: 082A8648CE3D030107 nistp256 (1.2.840.10045.3.1.7)
	pkey[1]: 0431094A4E7B9CBBA41696B31178105DE4CD635B83BD5088A9A83A352AE27AB6E55170991F6F7C38AFA8A39D6E085B3283BE1EF78CA02BBCF6907EEBAD52CFF093
	keyid: F54CF38AC9CFE768
```