### PR TITLE
Add support for PolicyURI signature subpacket

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/SignatureSubpacketInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignatureSubpacketInputStream.java
@@ -13,6 +13,7 @@ import org.bouncycastle.bcpg.sig.IssuerKeyID;
 import org.bouncycastle.bcpg.sig.KeyExpirationTime;
 import org.bouncycastle.bcpg.sig.KeyFlags;
 import org.bouncycastle.bcpg.sig.NotationData;
+import org.bouncycastle.bcpg.sig.PolicyURI;
 import org.bouncycastle.bcpg.sig.PreferredAlgorithms;
 import org.bouncycastle.bcpg.sig.PrimaryUserID;
 import org.bouncycastle.bcpg.sig.RegularExpression;
@@ -167,6 +168,8 @@ public class SignatureSubpacketInputStream
             return new PreferredAlgorithms(type, isCritical, isLongLength, data);
         case KEY_FLAGS:
             return new KeyFlags(isCritical, isLongLength, data);
+        case POLICY_URL:
+            return new PolicyURI(isCritical, isLongLength, data);
         case PRIMARY_USER_ID:
             return new PrimaryUserID(isCritical, isLongLength, data);
         case SIGNER_USER_ID:

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/PolicyURI.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/PolicyURI.java
@@ -1,0 +1,27 @@
+package org.bouncycastle.bcpg.sig;
+
+import org.bouncycastle.bcpg.SignatureSubpacket;
+import org.bouncycastle.bcpg.SignatureSubpacketTags;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.Strings;
+
+public class PolicyURI extends SignatureSubpacket {
+
+    public PolicyURI(boolean critical, boolean isLongLength, byte[] data) {
+        super(SignatureSubpacketTags.POLICY_URL, critical, isLongLength, data);
+    }
+
+    public PolicyURI(boolean critical, String uri) {
+        this(critical, false, Strings.toUTF8ByteArray(uri));
+    }
+
+    public String getURI()
+    {
+        return Strings.fromUTF8ByteArray(data);
+    }
+
+    public byte[] getRawURI()
+    {
+        return Arrays.clone(data);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketGenerator.java
@@ -16,6 +16,7 @@ import org.bouncycastle.bcpg.sig.IssuerKeyID;
 import org.bouncycastle.bcpg.sig.KeyExpirationTime;
 import org.bouncycastle.bcpg.sig.KeyFlags;
 import org.bouncycastle.bcpg.sig.NotationData;
+import org.bouncycastle.bcpg.sig.PolicyURI;
 import org.bouncycastle.bcpg.sig.PreferredAlgorithms;
 import org.bouncycastle.bcpg.sig.PrimaryUserID;
 import org.bouncycastle.bcpg.sig.Revocable;
@@ -190,6 +191,10 @@ public class PGPSignatureSubpacketGenerator
     {
         packets.add(new PreferredAlgorithms(SignatureSubpacketTags.PREFERRED_AEAD_ALGORITHMS, isCritical,
             algorithms));
+    }
+
+    public void addPolicyURI(boolean isCritical, String policyUri) {
+        packets.add(new PolicyURI(isCritical, policyUri));
     }
 
     /**

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketVector.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketVector.java
@@ -16,6 +16,7 @@ import org.bouncycastle.bcpg.sig.IssuerKeyID;
 import org.bouncycastle.bcpg.sig.KeyExpirationTime;
 import org.bouncycastle.bcpg.sig.KeyFlags;
 import org.bouncycastle.bcpg.sig.NotationData;
+import org.bouncycastle.bcpg.sig.PolicyURI;
 import org.bouncycastle.bcpg.sig.PreferredAlgorithms;
 import org.bouncycastle.bcpg.sig.PrimaryUserID;
 import org.bouncycastle.bcpg.sig.RegularExpression;
@@ -405,6 +406,26 @@ public class PGPSignatureSubpacketVector
     {
         Exportable exportable = getExportable();
         return exportable == null || exportable.isExportable();
+    }
+
+    public PolicyURI getPolicyURI()
+    {
+        SignatureSubpacket p = getSubpacket(SignatureSubpacketTags.POLICY_URL);
+        if (p == null)
+        {
+            return null;
+        }
+        return new PolicyURI(p.isCritical(), p.isLongLength(), p.getData());
+    }
+
+    public PolicyURI[] getPolicyURIs() {
+        SignatureSubpacket[] subpackets = getSubpackets(SignatureSubpacketTags.POLICY_URL);
+        PolicyURI[] policyURIS = new PolicyURI[subpackets.length];
+        for (int i = 0; i < subpackets.length; i++) {
+            SignatureSubpacket p = subpackets[i];
+            policyURIS[i] = new PolicyURI(p.isCritical(), p.isLongLength(), p.getData());
+        }
+        return policyURIS;
     }
 
     public RegularExpression getRegularExpression()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PolicyURITest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PolicyURITest.java
@@ -1,0 +1,82 @@
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.bcpg.sig.PolicyURI;
+import org.bouncycastle.openpgp.PGPObjectFactory;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.PGPSignatureList;
+import org.bouncycastle.openpgp.bc.BcPGPObjectFactory;
+import org.bouncycastle.util.test.SimpleTest;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+public class PolicyURITest
+        extends SimpleTest
+{
+
+    public static void main(String[] args)
+    {
+        runTest(new PolicyURITest());
+    }
+
+    @Override
+    public String getName()
+    {
+        return PolicyURITest.class.getSimpleName();
+    }
+
+    @Override
+    public void performTest()
+            throws Exception
+    {
+        testGetURI();
+        testParsingFromSignature();
+    }
+
+    public void testGetURI()
+    {
+        PolicyURI policyURI = new PolicyURI(true, "https://bouncycastle.org/policy/alice.txt");
+        isTrue(policyURI.isCritical());
+        isEquals("https://bouncycastle.org/policy/alice.txt", policyURI.getURI());
+
+        policyURI = new PolicyURI(false, "https://bouncycastle.org/policy/bob.txt");
+        isTrue(!policyURI.isCritical());
+        isEquals("https://bouncycastle.org/policy/bob.txt", policyURI.getURI());
+    }
+
+    public void testParsingFromSignature()
+            throws IOException
+    {
+        String signatureWithPolicyUri = "-----BEGIN PGP SIGNATURE-----\n" +
+                "\n" +
+                "iKQEHxYKAFYFAmIRIAgJEDXXpSQjWzWvFiEEVSc3S9X9kRTsyfjqNdelJCNbNa8u\n" +
+                "Gmh0dHBzOi8vZXhhbXBsZS5vcmcvfmFsaWNlL3NpZ25pbmctcG9saWN5LnR4dAAA\n" +
+                "NnwBAImA2KdiS/7kLWoQpwc+A6N2PtAvLxG0gkZmGzYgRWvGAP9g4GLAA/GQ0plr\n" +
+                "Xn7uLnOG49S1fFA9P+R1Dd8Qoa4+Dg==\n" +
+                "=OPUu\n" +
+                "-----END PGP SIGNATURE-----\n";
+
+        ByteArrayInputStream byteIn = new ByteArrayInputStream(signatureWithPolicyUri.getBytes(Charset.defaultCharset()));
+        ArmoredInputStream armorIn = new ArmoredInputStream(byteIn);
+        PGPObjectFactory objectFactory = new BcPGPObjectFactory(armorIn);
+
+        PGPSignatureList signatures = (PGPSignatureList) objectFactory.nextObject();
+        PGPSignature signature = signatures.get(0);
+
+        PolicyURI policyURI = signature.getHashedSubPackets().getPolicyURI();
+        isEquals("https://example.org/~alice/signing-policy.txt", policyURI.getURI());
+
+        PolicyURI other = new PolicyURI(false, "https://example.org/~alice/signing-policy.txt");
+
+        ByteArrayOutputStream first = new ByteArrayOutputStream();
+        policyURI.encode(first);
+
+        ByteArrayOutputStream second = new ByteArrayOutputStream();
+        other.encode(second);
+
+        areEqual(first.toByteArray(), second.toByteArray());
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
@@ -42,7 +42,8 @@ public class RegressionTest
         new ArmoredInputStreamIngoreMissingCRCSum(),
         new PGPSessionKeyTest(),
         new PGPCanonicalizedDataGeneratorTest(),
-        new RegexTest()
+        new RegexTest(),
+        new PolicyURITest()
     };
 
     public static void main(String[] args)


### PR DESCRIPTION
This PR adds support for the [Policy URI Signature Subpacket](https://datatracker.ietf.org/doc/html/rfc4880#section-5.2.3.20).

TODO:
* [x] Write tests