### PR TITLE
Enabling DH and ECDH anon ciphers

### DIFF
--- a/tls/src/main/java/org/bouncycastle/jsse/provider/CipherSuiteInfo.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/CipherSuiteInfo.java
@@ -304,6 +304,13 @@ class CipherSuiteInfo
         case CipherSuite.TLS_RSA_WITH_CAMELLIA_128_CBC_SHA:
         case CipherSuite.TLS_RSA_WITH_CAMELLIA_256_CBC_SHA:
         case CipherSuite.TLS_RSA_WITH_NULL_SHA:
+        case CipherSuite.TLS_DH_anon_WITH_AES_128_CBC_SHA:
+        case CipherSuite.TLS_DH_anon_WITH_AES_256_CBC_SHA:
+        case CipherSuite.TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA:
+        case CipherSuite.TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA:
+        case CipherSuite.TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA:
+        case CipherSuite.TLS_ECDH_anon_WITH_AES_128_CBC_SHA:
+        case CipherSuite.TLS_ECDH_anon_WITH_AES_256_CBC_SHA:
             /*
              * TODO[jsse] We follow SunJSSE behaviour here, but it's not quite right; these cipher
              * suites will actually use the legacy PRF based on MD5/SHA1 for TLS 1.1 or earlier.
@@ -366,6 +373,14 @@ class CipherSuiteInfo
         case CipherSuite.TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256:
         case CipherSuite.TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256:
         case CipherSuite.TLS_RSA_WITH_NULL_SHA256:
+        case CipherSuite.TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256:
+        case CipherSuite.TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256:
+        case CipherSuite.TLS_DH_anon_WITH_ARIA_128_CBC_SHA256:
+        case CipherSuite.TLS_DH_anon_WITH_ARIA_128_GCM_SHA256:
+        case CipherSuite.TLS_DH_anon_WITH_CAMELLIA_128_GCM_SHA256:
+        case CipherSuite.TLS_DH_anon_WITH_AES_128_CBC_SHA256:
+        case CipherSuite.TLS_DH_anon_WITH_AES_256_CBC_SHA256:
+        case CipherSuite.TLS_DH_anon_WITH_AES_128_GCM_SHA256:
             return CryptoHashAlgorithm.sha256;
 
         case CipherSuite.TLS_AES_256_GCM_SHA384:
@@ -393,6 +408,10 @@ class CipherSuiteInfo
         case CipherSuite.TLS_RSA_WITH_ARIA_256_CBC_SHA384:
         case CipherSuite.TLS_RSA_WITH_ARIA_256_GCM_SHA384:
         case CipherSuite.TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384:
+        case CipherSuite.TLS_DH_anon_WITH_ARIA_256_CBC_SHA384:
+        case CipherSuite.TLS_DH_anon_WITH_ARIA_256_GCM_SHA384:
+        case CipherSuite.TLS_DH_anon_WITH_CAMELLIA_256_GCM_SHA384:
+        case CipherSuite.TLS_DH_anon_WITH_AES_256_GCM_SHA384:
             return CryptoHashAlgorithm.sha384;
 
         case CipherSuite.TLS_SM4_CCM_SM3:

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLContextSpi.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLContextSpi.java
@@ -297,6 +297,26 @@ class ProvSSLContextSpi
         addCipherSuite(cs, "TLS_RSA_WITH_NULL_SHA", CipherSuite.TLS_RSA_WITH_NULL_SHA);
         addCipherSuite(cs, "TLS_RSA_WITH_NULL_SHA256", CipherSuite.TLS_RSA_WITH_NULL_SHA256);
 
+        addCipherSuite(cs, "TLS_DH_anon_WITH_AES_128_CBC_SHA", CipherSuite.TLS_DH_anon_WITH_AES_128_CBC_SHA);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_AES_256_CBC_SHA", CipherSuite.TLS_DH_anon_WITH_AES_256_CBC_SHA);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA", CipherSuite.TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA", CipherSuite.TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256", CipherSuite.TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256", CipherSuite.TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256);
+        addCipherSuite(cs, "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA", CipherSuite.TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA);
+        addCipherSuite(cs, "TLS_ECDH_anon_WITH_AES_128_CBC_SHA", CipherSuite.TLS_ECDH_anon_WITH_AES_128_CBC_SHA);
+        addCipherSuite(cs, "TLS_ECDH_anon_WITH_AES_256_CBC_SHA", CipherSuite.TLS_ECDH_anon_WITH_AES_256_CBC_SHA);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_ARIA_128_CBC_SHA256", CipherSuite.TLS_DH_anon_WITH_ARIA_128_CBC_SHA256);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_ARIA_256_CBC_SHA384", CipherSuite.TLS_DH_anon_WITH_ARIA_256_CBC_SHA384);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_ARIA_128_GCM_SHA256", CipherSuite.TLS_DH_anon_WITH_ARIA_128_GCM_SHA256);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_ARIA_256_GCM_SHA384", CipherSuite.TLS_DH_anon_WITH_ARIA_256_GCM_SHA384);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_CAMELLIA_128_GCM_SHA256", CipherSuite.TLS_DH_anon_WITH_CAMELLIA_128_GCM_SHA256);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_CAMELLIA_256_GCM_SHA384", CipherSuite.TLS_DH_anon_WITH_CAMELLIA_256_GCM_SHA384);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_AES_128_CBC_SHA256", CipherSuite.TLS_DH_anon_WITH_AES_128_CBC_SHA256);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_AES_256_CBC_SHA256", CipherSuite.TLS_DH_anon_WITH_AES_256_CBC_SHA256);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_AES_128_GCM_SHA256", CipherSuite.TLS_DH_anon_WITH_AES_128_GCM_SHA256);
+        addCipherSuite(cs, "TLS_DH_anon_WITH_AES_256_GCM_SHA384", CipherSuite.TLS_DH_anon_WITH_AES_256_GCM_SHA384);
+
         return Collections.unmodifiableMap(cs);
     }
 

--- a/tls/src/test/java/org/bouncycastle/jsse/provider/test/CipherSuitesEngineTestSuite.java
+++ b/tls/src/test/java/org/bouncycastle/jsse/provider/test/CipherSuitesEngineTestSuite.java
@@ -31,7 +31,8 @@ public class CipherSuitesEngineTestSuite
                  * TODO[jsse] jdk.tls.disabledAlgorithms default value doesn't permit these. Perhaps
                  * we could modify that security property when running this test suite.
                  */
-                return cipherSuite.contains("_WITH_NULL_") || cipherSuite.contains("_WITH_3DES_EDE_CBC_");
+                return cipherSuite.contains("_WITH_NULL_") || cipherSuite.contains("_WITH_3DES_EDE_CBC_")
+                        || cipherSuite.contains("_anon_");
             }
 
             public boolean isPermitted(String cipherSuite)

--- a/tls/src/test/java/org/bouncycastle/jsse/provider/test/CipherSuitesTestSuite.java
+++ b/tls/src/test/java/org/bouncycastle/jsse/provider/test/CipherSuitesTestSuite.java
@@ -31,7 +31,8 @@ public class CipherSuitesTestSuite
                  * TODO[jsse] jdk.tls.disabledAlgorithms default value doesn't permit these. Perhaps
                  * we could modify that security property when running this test suite.
                  */
-                return cipherSuite.contains("_WITH_NULL_") || cipherSuite.contains("_WITH_3DES_EDE_CBC_");
+                return cipherSuite.contains("_WITH_NULL_") || cipherSuite.contains("_WITH_3DES_EDE_CBC_")
+                        || cipherSuite.contains("_anon_");
             }
 
             public boolean isPermitted(String cipherSuite)


### PR DESCRIPTION
This work is to enable use-cases that require them such as encrypted VNC connections to Vino VNC Server.

Specifically, this work is needed to provide a better UX for https://github.com/iiordanov/remote-desktop-clients/issues/60 (the current solution is to pop up a message advising users to disable requiring encryption with Vino, the default Ubuntu remote desktop server, for instance).

In addition, the request to support other encryption modes was denied by the Vino project. Here is a issue opened against the project requesting new encryption modes that was closed as "won't fix" that gives some background:

https://bugzilla.gnome.org/show_bug.cgi?id=728267
