### PR TITLE
Fix parsing of certs, keys and messages with unrecognizable subkeys, signatures and ESKs

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyEncSessionPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyEncSessionPacket.java
@@ -22,6 +22,10 @@ public class PublicKeyEncSessionPacket
         throws IOException
     {      
         version = in.read();
+        if (version != 3)
+        {
+            throw new UnsupportedPacketVersionException("Unsupported PGP public key encrypted session key packet version encountered: " + version);
+        }
         
         keyID |= (long)in.read() << 56;
         keyID |= (long)in.read() << 48;

--- a/pg/src/main/java/org/bouncycastle/bcpg/SymmetricKeyEncSessionPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SymmetricKeyEncSessionPacket.java
@@ -19,6 +19,10 @@ public class SymmetricKeyEncSessionPacket
         throws IOException
     {
         version = in.read();
+        if (version != 4)
+        {
+            throw new UnsupportedPacketVersionException("Unsupported PGP symmetric-key encrypted session key packet version encountered: " + version);
+        }
         encAlgorithm = in.read();
 
         s2k = new S2K(in);

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java
@@ -13,6 +13,7 @@ import org.bouncycastle.bcpg.Packet;
 import org.bouncycastle.bcpg.PacketTags;
 import org.bouncycastle.bcpg.PublicKeyEncSessionPacket;
 import org.bouncycastle.bcpg.SymmetricKeyEncSessionPacket;
+import org.bouncycastle.bcpg.UnsupportedPacketVersionException;
 import org.bouncycastle.util.Iterable;
 
 /**
@@ -88,7 +89,14 @@ public class PGPEncryptedDataList
         while (pIn.nextPacketTag() == PacketTags.PUBLIC_KEY_ENC_SESSION
             || pIn.nextPacketTag() == PacketTags.SYMMETRIC_KEY_ENC_SESSION)
         {
-            list.add(pIn.readPacket());
+            try
+            {
+                list.add(pIn.readPacket());
+            }
+            catch (UnsupportedPacketVersionException e)
+            {
+                // Skip unknown packet versions
+            }
         }
 
         Packet packet = pIn.readPacket();

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKeyRing.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKeyRing.java
@@ -117,7 +117,11 @@ public class PGPPublicKeyRing
             // Read subkeys
             while (pIn.nextPacketTag() == PacketTags.PUBLIC_SUBKEY)
             {
-                keys.add(readSubkey(pIn, fingerPrintCalculator));
+                try {
+                    keys.add(readSubkey(pIn, fingerPrintCalculator));
+                } catch (IOException e) {
+                    // Skip unrecognizable subkey
+                }
             }
         }
         catch (PGPException e)

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -74,7 +74,6 @@ public class PGPSignature
 
     PGPSignature(
         SignaturePacket sigPacket)
-        throws PGPException
     {
         sigPck = sigPacket;
         signatureType = sigPck.getSignatureType();
@@ -84,7 +83,6 @@ public class PGPSignature
     PGPSignature(
         SignaturePacket sigPacket,
         TrustPacket trustPacket)
-        throws PGPException
     {
         this(sigPacket);
 

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/IgnoreUnknownEncryptedSessionKeys.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/IgnoreUnknownEncryptedSessionKeys.java
@@ -1,0 +1,248 @@
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.openpgp.*;
+import org.bouncycastle.openpgp.bc.BcPGPObjectFactory;
+import org.bouncycastle.openpgp.operator.bc.BcPublicKeyDataDecryptorFactory;
+import org.bouncycastle.util.io.Streams;
+import org.bouncycastle.util.test.SimpleTest;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class IgnoreUnknownEncryptedSessionKeys extends SimpleTest {
+
+    private PGPSecretKeyRing tsk;
+
+    public static void main(String[] args) {
+        SimpleTest.runTest(new IgnoreUnknownEncryptedSessionKeys());
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public void performTest() throws Exception {
+        readKey();
+
+        // pkesk + unknown pkesk
+        pkesk3_pkesk23_seip();
+        pkesk23_pkesk3_seip();
+
+        // pkesk + unknown skesk
+        skesk23_pkesk3_seip();
+        pkesk3_skesk23_seip();
+    }
+
+    private void readKey() throws IOException {
+        String key = "-----BEGIN PGP PRIVATE KEY BLOCK-----\n" +
+                "Comment: Bob's OpenPGP Transferable Secret Key\n" +
+                "\n" +
+                "lQVYBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAQAL/RZqbJW2IqQDCnJi4Ozm++gPqBPiX1RhTWSjwxfM\n" +
+                "cJKUZfzLj414rMKm6Jh1cwwGY9jekROhB9WmwaaKT8HtcIgrZNAlYzANGRCM4TLK\n" +
+                "3VskxfSwKKna8l+s+mZglqbAjUg3wmFuf9Tj2xcUZYmyRm1DEmcN2ZzpvRtHgX7z\n" +
+                "Wn1mAKUlSDJZSQks0zjuMNbupcpyJokdlkUg2+wBznBOTKzgMxVNC9b2g5/tMPUs\n" +
+                "hGGWmF1UH+7AHMTaS6dlmr2ZBIyogdnfUqdNg5sZwsxSNrbglKP4sqe7X61uEAIQ\n" +
+                "bD7rT3LonLbhkrj3I8wilUD8usIwt5IecoHhd9HziqZjRCc1BUBkboUEoyedbDV4\n" +
+                "i4qfsFZ6CEWoLuD5pW7dEp0M+WeuHXO164Rc+LnH6i1VQrpb1Okl4qO6ejIpIjBI\n" +
+                "1t3GshtUu/mwGBBxs60KBX5g77mFQ9lLCRj8lSYqOsHRKBhUp4qM869VA+fD0BRP\n" +
+                "fqPT0I9IH4Oa/A3jYJcg622GwQYA1LhnP208Waf6PkQSJ6kyr8ymY1yVh9VBE/g6\n" +
+                "fRDYA+pkqKnw9wfH2Qho3ysAA+OmVOX8Hldg+Pc0Zs0e5pCavb0En8iFLvTA0Q2E\n" +
+                "LR5rLue9uD7aFuKFU/VdcddY9Ww/vo4k5p/tVGp7F8RYCFn9rSjIWbfvvZi1q5Tx\n" +
+                "+akoZbga+4qQ4WYzB/obdX6SCmi6BndcQ1QdjCCQU6gpYx0MddVERbIp9+2SXDyL\n" +
+                "hpxjSyz+RGsZi/9UAshT4txP4+MZBgDfK3ZqtW+h2/eMRxkANqOJpxSjMyLO/FXN\n" +
+                "WxzTDYeWtHNYiAlOwlQZEPOydZFty9IVzzNFQCIUCGjQ/nNyhw7adSgUk3+BXEx/\n" +
+                "MyJPYY0BYuhLxLYcrfQ9nrhaVKxRJj25SVHj2ASsiwGJRZW4CC3uw40OYxfKEvNC\n" +
+                "mer/VxM3kg8qqGf9KUzJ1dVdAvjyx2Hz6jY2qWCyRQ6IMjWHyd43C4r3jxooYKUC\n" +
+                "YnstRQyb/gCSKahveSEjo07CiXMr88UGALwzEr3npFAsPW3osGaFLj49y1oRe11E\n" +
+                "he9gCHFm+fuzbXrWmdPjYU5/ZdqdojzDqfu4ThfnipknpVUM1o6MQqkjM896FHm8\n" +
+                "zbKVFSMhEP6DPHSCexMFrrSgN03PdwHTO6iBaIBBFqmGY01tmJ03SxvSpiBPON9P\n" +
+                "NVvy/6UZFedTq8A07OUAxO62YUSNtT5pmK2vzs3SAZJmbFbMh+NN204TRI72GlqT\n" +
+                "t5hcfkuv8hrmwPS/ZR6q312mKQ6w/1pqO9qitCFCb2IgQmFiYmFnZSA8Ym9iQG9w\n" +
+                "ZW5wZ3AuZXhhbXBsZT6JAc4EEwEKADgCGwMFCwkIBwIGFQoJCAsCBBYCAwECHgEC\n" +
+                "F4AWIQTRpm4aI7GCyZgPeIz7/MgqAV5zMAUCXaWe+gAKCRD7/MgqAV5zMG9sC/9U\n" +
+                "2T3RrqEbw533FPNfEflhEVRIZ8gDXKM8hU6cqqEzCmzZT6xYTe6sv4y+PJBGXJFX\n" +
+                "yhj0g6FDkSyboM5litOcTupURObVqMgA/Y4UKERznm4fzzH9qek85c4ljtLyNufe\n" +
+                "doL2pp3vkGtn7eD0QFRaLLmnxPKQ/TlZKdLE1G3u8Uot8QHicaR6GnAdc5UXQJE3\n" +
+                "BiV7jZuDyWmZ1cUNwJkKL6oRtp+ZNDOQCrLNLecKHcgCqrpjSQG5oouba1I1Q6Vl\n" +
+                "sP44dhA1nkmLHtxlTOzpeHj4jnk1FaXmyasurrrI5CgU/L2Oi39DGKTH/A/cywDN\n" +
+                "4ZplIQ9zR8enkbXquUZvFDe+Xz+6xRXtb5MwQyWODB3nHw85HocLwRoIN9WdQEI+\n" +
+                "L8a/56AuOwhs8llkSuiITjR7r9SgKJC2WlAHl7E8lhJ3VDW3ELC56KH308d6mwOG\n" +
+                "ZRAqIAKzM1T5FGjMBhq7ZV0eqdEntBh3EcOIfj2M8rg1MzJv+0mHZOIjByawikad\n" +
+                "BVgEXaWc8gEMANYwv1xsYyunXYK0X1vY/rP1NNPvhLyLIE7NpK90YNBj+xS1ldGD\n" +
+                "bUdZqZeef2xJe8gMQg05DoD1DF3GipZ0Ies65beh+d5hegb7N4pzh0LzrBrVNHar\n" +
+                "29b5ExdI7i4iYD5TO6Vr/qTUOiAN/byqELEzAb+L+b2DVz/RoCm4PIp1DU9ewcc2\n" +
+                "WB38Ofqut3nLYA5tqJ9XvAiEQme+qAVcM3ZFcaMt4I4dXhDZZNg+D9LiTWcxdUPB\n" +
+                "leu8iwDRjAgyAhPzpFp+nWoqWA81uIiULWD1Fj+IVoY3ZvgivoYOiEFBJ9lbb4te\n" +
+                "g9m5UT/AaVDTWuHzbspVlbiVe+qyB77C2daWzNyx6UYBPLOo4r0t0c91kbNE5lgj\n" +
+                "Z7xz6los0N1U8vq91EFSeQJoSQ62XWavYmlCLmdNT6BNfgh4icLsT7Vr1QMX9jzn\n" +
+                "JtTPxdXytSdHvpSpULsqJ016l0dtmONcK3z9mj5N5z0k1tg1AH970TGYOe2aUcSx\n" +
+                "IRDMXDOPyzEfjwARAQABAAv9F2CwsjS+Sjh1M1vegJbZjei4gF1HHpEM0K0PSXsp\n" +
+                "SfVvpR4AoSJ4He6CXSMWg0ot8XKtDuZoV9jnJaES5UL9pMAD7JwIOqZm/DYVJM5h\n" +
+                "OASCh1c356/wSbFbzRHPtUdZO9Q30WFNJM5pHbCJPjtNoRmRGkf71RxtvHBzy7np\n" +
+                "Ga+W6U/NVKHw0i0CYwMI0YlKDakYW3Pm+QL+gHZFvngGweTod0f9l2VLLAmeQR/c\n" +
+                "+EZs7lNumhuZ8mXcwhUc9JQIhOkpO+wreDysEFkAcsKbkQP3UDUsA1gFx9pbMzT0\n" +
+                "tr1oZq2a4QBtxShHzP/ph7KLpN+6qtjks3xB/yjTgaGmtrwM8tSe0wD1RwXS+/1o\n" +
+                "BHpXTnQ7TfeOGUAu4KCoOQLv6ELpKWbRBLWuiPwMdbGpvVFALO8+kvKAg9/r+/ny\n" +
+                "zM2GQHY+J3Jh5JxPiJnHfXNZjIKLbFbIPdSKNyJBuazXW8xIa//mEHMI5OcvsZBK\n" +
+                "clAIp7LXzjEjKXIwHwDcTn9pBgDpdOKTHOtJ3JUKx0rWVsDH6wq6iKV/FTVSY5jl\n" +
+                "zN+puOEsskF1Lfxn9JsJihAVO3yNsp6RvkKtyNlFazaCVKtDAmkjoh60XNxcNRqr\n" +
+                "gCnwdpbgdHP6v/hvZY54ZaJjz6L2e8unNEkYLxDt8cmAyGPgH2XgL7giHIp9jrsQ\n" +
+                "aS381gnYwNX6wE1aEikgtY91nqJjwPlibF9avSyYQoMtEqM/1UjTjB2KdD/MitK5\n" +
+                "fP0VpvuXpNYZedmyq4UOMwdkiNMGAOrfmOeT0olgLrTMT5H97Cn3Yxbk13uXHNu/\n" +
+                "ZUZZNe8s+QtuLfUlKAJtLEUutN33TlWQY522FV0m17S+b80xJib3yZVJteVurrh5\n" +
+                "HSWHAM+zghQAvCesg5CLXa2dNMkTCmZKgCBvfDLZuZbjFwnwCI6u/NhOY9egKuUf\n" +
+                "SA/je/RXaT8m5VxLYMxwqQXKApzD87fv0tLPlVIEvjEsaf992tFEFSNPcG1l/jpd\n" +
+                "5AVXw6kKuf85UkJtYR1x2MkQDrqY1QX/XMw00kt8y9kMZUre19aCArcmor+hDhRJ\n" +
+                "E3Gt4QJrD9z/bICESw4b4z2DbgD/Xz9IXsA/r9cKiM1h5QMtXvuhyfVeM01enhxM\n" +
+                "GbOH3gjqqGNKysx0UODGEwr6AV9hAd8RWXMchJLaExK9J5SRawSg671ObAU24SdY\n" +
+                "vMQ9Z4kAQ2+1ReUZzf3ogSMRZtMT+d18gT6L90/y+APZIaoArLPhebIAGq39HLmJ\n" +
+                "26x3z0WAgrpA1kNsjXEXkoiZGPLKIGoe3hqJAbYEGAEKACAWIQTRpm4aI7GCyZgP\n" +
+                "eIz7/MgqAV5zMAUCXaWc8gIbDAAKCRD7/MgqAV5zMOn/C/9ugt+HZIwX308zI+QX\n" +
+                "c5vDLReuzmJ3ieE0DMO/uNSC+K1XEioSIZP91HeZJ2kbT9nn9fuReuoff0T0Dief\n" +
+                "rbwcIQQHFFkrqSp1K3VWmUGp2JrUsXFVdjy/fkBIjTd7c5boWljv/6wAsSfiv2V0\n" +
+                "JSM8EFU6TYXxswGjFVfc6X97tJNeIrXL+mpSmPPqy2bztcCCHkWS5lNLWQw+R7Vg\n" +
+                "71Fe6yBSNVrqC2/imYG2J9zlowjx1XU63Wdgqp2Wxt0l8OmsB/W80S1fRF5G4SDH\n" +
+                "s9HXglXXqPsBRZJYfP+VStm9L5P/sKjCcX6WtZR7yS6G8zj/X767MLK/djANvpPd\n" +
+                "NVniEke6hM3CNBXYPAMhQBMWhCulcoz+0lxi8L34rMN+Dsbma96psdUrn7uLaB91\n" +
+                "6we0CTfF8qqm7BsVAgalon/UUiuMY80U3ueoj3okiSTiHIjD/YtpXSPioC8nMng7\n" +
+                "xqAY9Bwizt4FWgXuLm1a4+So4V9j1TRCXd12Uc2l2RNmgDE=\n" +
+                "=miES\n" +
+                "-----END PGP PRIVATE KEY BLOCK-----";
+        ByteArrayInputStream byteIn = new ByteArrayInputStream(key.getBytes(StandardCharsets.UTF_8));
+        ArmoredInputStream armorIn = new ArmoredInputStream(byteIn);
+        PGPObjectFactory objectFactory = new BcPGPObjectFactory(armorIn);
+        tsk = (PGPSecretKeyRing) objectFactory.nextObject();
+    }
+
+    private void pkesk3_pkesk23_seip() throws IOException, PGPException {
+        String msg = "-----BEGIN PGP MESSAGE-----\n" +
+                "\n" +
+                "wcDMA3wvqk35PDeyAQv/RkfFn2Ec8fev6d05zZLbMgCMxg0GVrDKOrWluSKPYTlq\n" +
+                "6TTzkn1qWIICAbM+R5Co17AEoLrHzB1deB5U8InYf3geTLKqCprEs+l4795xJxpf\n" +
+                "x6ZJUlcO2mQPsHv+O/4weLWmvZZTok5ibK/3tj+vQL/haho4qcBATIiG6gxCAHxD\n" +
+                "kXue7tNCrXlmCSoumr6sxK9+whIzcftbEDwjWnQGjZIUzM4l92Vx9s0l2Eg6gmrz\n" +
+                "sXmP6cZIPkIOV7ms31ca/xkMElE1ezx4rAcxhL7efb8ygbkP+LQHuKwnM4643t7X\n" +
+                "q2BZsMw4VIolBZGTvvFxNn1RJYkOguDhMmCXO6aRyOjidFr4DwlnV/EhzaYelZX0\n" +
+                "PgHYomrPg59+wpFYkAV80bxFmEuB7EyxYsBY44ceXFCgiVbClq62BrXZhxuaRS/+\n" +
+                "k9AGY6bicKqUnDStQopOQIh0bg1V/1rOr7Eg1ltNnib7G4HP6wlZ2ZyTMcEM8hog\n" +
+                "T97kEybBbAu/v1xX6C0cwUoXQUFBQUFBQUEJYWFhYWFhYWFhYWFhYWFhYWFhYWFh\n" +
+                "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYdJMARce\n" +
+                "/wBlQyUPYPUSlV6ksTXttx7JqiMULd28op6mGZpg/FkTiPgjGhS1Mdp7bu6q5Eo/\n" +
+                "qC2QFVHqeC6Gm0eliO1RS0sOflvhbKtJgg==\n" +
+                "=6qUY\n" +
+                "-----END PGP MESSAGE-----\n";
+
+        attemptDecryption(msg);
+    }
+
+    private void pkesk23_pkesk3_seip() throws PGPException, IOException {
+        String msg = "-----BEGIN PGP MESSAGE-----\n" +
+                "\n" +
+                "wUoXQUFBQUFBQUEJYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh\n" +
+                "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYcHAzAN8L6pN+Tw3sgEL/0ZHxZ9h\n" +
+                "HPH3r+ndOc2S2zIAjMYNBlawyjq1pbkij2E5auk085J9aliCAgGzPkeQqNewBKC6\n" +
+                "x8wdXXgeVPCJ2H94HkyyqgqaxLPpeO/ecScaX8emSVJXDtpkD7B7/jv+MHi1pr2W\n" +
+                "U6JOYmyv97Y/r0C/4WoaOKnAQEyIhuoMQgB8Q5F7nu7TQq15ZgkqLpq+rMSvfsIS\n" +
+                "M3H7WxA8I1p0Bo2SFMzOJfdlcfbNJdhIOoJq87F5j+nGSD5CDle5rN9XGv8ZDBJR\n" +
+                "NXs8eKwHMYS+3n2/MoG5D/i0B7isJzOOuN7e16tgWbDMOFSKJQWRk77xcTZ9USWJ\n" +
+                "DoLg4TJglzumkcjo4nRa+A8JZ1fxIc2mHpWV9D4B2KJqz4OffsKRWJAFfNG8RZhL\n" +
+                "gexMsWLAWOOHHlxQoIlWwpautga12YcbmkUv/pPQBmOm4nCqlJw0rUKKTkCIdG4N\n" +
+                "Vf9azq+xINZbTZ4m+xuBz+sJWdmckzHBDPIaIE/e5BMmwWwLv79cV+gtHNJMARce\n" +
+                "/wBlQyUPYPUSlV6ksTXttx7JqiMULd28op6mGZpg/FkTiPgjGhS1Mdp7bu6q5Eo/\n" +
+                "qC2QFVHqeC6Gm0eliO1RS0sOflvhbKtJgg==\n" +
+                "=qITG\n" +
+                "-----END PGP MESSAGE-----\n";
+
+        attemptDecryption(msg);
+    }
+
+    private void pkesk3_skesk23_seip() throws PGPException, IOException {
+        String msg = "-----BEGIN PGP MESSAGE-----\n" +
+                "\n" +
+                "wcDMA3wvqk35PDeyAQv/RkfFn2Ec8fev6d05zZLbMgCMxg0GVrDKOrWluSKPYTlq\n" +
+                "6TTzkn1qWIICAbM+R5Co17AEoLrHzB1deB5U8InYf3geTLKqCprEs+l4795xJxpf\n" +
+                "x6ZJUlcO2mQPsHv+O/4weLWmvZZTok5ibK/3tj+vQL/haho4qcBATIiG6gxCAHxD\n" +
+                "kXue7tNCrXlmCSoumr6sxK9+whIzcftbEDwjWnQGjZIUzM4l92Vx9s0l2Eg6gmrz\n" +
+                "sXmP6cZIPkIOV7ms31ca/xkMElE1ezx4rAcxhL7efb8ygbkP+LQHuKwnM4643t7X\n" +
+                "q2BZsMw4VIolBZGTvvFxNn1RJYkOguDhMmCXO6aRyOjidFr4DwlnV/EhzaYelZX0\n" +
+                "PgHYomrPg59+wpFYkAV80bxFmEuB7EyxYsBY44ceXFCgiVbClq62BrXZhxuaRS/+\n" +
+                "k9AGY6bicKqUnDStQopOQIh0bg1V/1rOr7Eg1ltNnib7G4HP6wlZ2ZyTMcEM8hog\n" +
+                "T97kEybBbAu/v1xX6C0cw00XCQMIH+0WngOJjNf/YWFhYWFhYWFhYWFhYWFhYWFh\n" +
+                "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYdJM\n" +
+                "ARce/wBlQyUPYPUSlV6ksTXttx7JqiMULd28op6mGZpg/FkTiPgjGhS1Mdp7bu6q\n" +
+                "5Eo/qC2QFVHqeC6Gm0eliO1RS0sOflvhbKtJgg==\n" +
+                "=erqS\n" +
+                "-----END PGP MESSAGE-----";
+        attemptDecryption(msg);
+    }
+
+    private void skesk23_pkesk3_seip() throws PGPException, IOException {
+        String msg = "-----BEGIN PGP MESSAGE-----\n" +
+                "\n" +
+                "w00XCQMIH+0WngOJjNf/YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh\n" +
+                "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYcHAzAN8L6pN+Tw3sgEL/0ZH\n" +
+                "xZ9hHPH3r+ndOc2S2zIAjMYNBlawyjq1pbkij2E5auk085J9aliCAgGzPkeQqNew\n" +
+                "BKC6x8wdXXgeVPCJ2H94HkyyqgqaxLPpeO/ecScaX8emSVJXDtpkD7B7/jv+MHi1\n" +
+                "pr2WU6JOYmyv97Y/r0C/4WoaOKnAQEyIhuoMQgB8Q5F7nu7TQq15ZgkqLpq+rMSv\n" +
+                "fsISM3H7WxA8I1p0Bo2SFMzOJfdlcfbNJdhIOoJq87F5j+nGSD5CDle5rN9XGv8Z\n" +
+                "DBJRNXs8eKwHMYS+3n2/MoG5D/i0B7isJzOOuN7e16tgWbDMOFSKJQWRk77xcTZ9\n" +
+                "USWJDoLg4TJglzumkcjo4nRa+A8JZ1fxIc2mHpWV9D4B2KJqz4OffsKRWJAFfNG8\n" +
+                "RZhLgexMsWLAWOOHHlxQoIlWwpautga12YcbmkUv/pPQBmOm4nCqlJw0rUKKTkCI\n" +
+                "dG4NVf9azq+xINZbTZ4m+xuBz+sJWdmckzHBDPIaIE/e5BMmwWwLv79cV+gtHNJM\n" +
+                "ARce/wBlQyUPYPUSlV6ksTXttx7JqiMULd28op6mGZpg/FkTiPgjGhS1Mdp7bu6q\n" +
+                "5Eo/qC2QFVHqeC6Gm0eliO1RS0sOflvhbKtJgg==\n" +
+                "=Chcy\n" +
+                "-----END PGP MESSAGE-----\n";
+        attemptDecryption(msg);
+    }
+
+    private void attemptDecryption(String msg) throws IOException, PGPException {
+        ByteArrayInputStream byteIn = new ByteArrayInputStream(msg.getBytes(StandardCharsets.UTF_8));
+        ArmoredInputStream armorIn = new ArmoredInputStream(byteIn);
+        PGPObjectFactory objectFactory = new BcPGPObjectFactory(armorIn);
+
+        PGPEncryptedDataList encryptedDataList = (PGPEncryptedDataList) objectFactory.nextObject();
+        isTrue(encryptedDataList != null);
+
+        InputStream decryptIn = null;
+        for (PGPEncryptedData encryptedData : encryptedDataList) {
+            if (encryptedData instanceof PGPPublicKeyEncryptedData) {
+                PGPPublicKeyEncryptedData pkesk = (PGPPublicKeyEncryptedData) encryptedData;
+                PGPSecretKey secretKey = tsk.getSecretKey(pkesk.getKeyID());
+                isTrue(secretKey != null);
+
+                PGPPrivateKey privateKey = secretKey.extractPrivateKey(null);
+                decryptIn = pkesk.getDataStream(new BcPublicKeyDataDecryptorFactory(privateKey));
+                break;
+            } else if (encryptedData instanceof PGPPBEEncryptedData) {
+                PGPPBEEncryptedData skesk = (PGPPBEEncryptedData) encryptedData;
+                // decryptIn = skesk.getDataStream(new BcPBEDataDecryptorFactory())
+            } else {
+                throw new PGPException("Unknown packet");
+            }
+        }
+
+        objectFactory = new BcPGPObjectFactory(decryptIn);
+        PGPLiteralData literalData = (PGPLiteralData) objectFactory.nextObject();
+
+        ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        Streams.pipeAll(literalData.getDataStream(), byteOut);
+        decryptIn.close();
+
+        isEquals("Encrypted using SEIP + MDC.", byteOut.toString());
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
@@ -46,7 +46,8 @@ public class RegressionTest
         new RegexTest(),
         new PolicyURITest(),
         new ArmoredOutputStreamUTF8Test(),
-        new UnrecognizableSubkeyParserTest()
+        new UnrecognizableSubkeyParserTest(),
+        new IgnoreUnknownEncryptedSessionKeys()
     };
 
     public static void main(String[] args)

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
@@ -45,7 +45,8 @@ public class RegressionTest
         new PGPCanonicalizedDataGeneratorTest(),
         new RegexTest(),
         new PolicyURITest(),
-        new ArmoredOutputStreamUTF8Test()
+        new ArmoredOutputStreamUTF8Test(),
+        new UnrecognizableSubkeyParserTest()
     };
 
     public static void main(String[] args)

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/UnrecognizableSubkeyParserTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/UnrecognizableSubkeyParserTest.java
@@ -1,0 +1,2 @@
+package org.bouncycastle.openpgp.test;public class UnrecognizableSubkeyParserTest {
+}

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/UnrecognizableSubkeyParserTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/UnrecognizableSubkeyParserTest.java
@@ -1,2 +1,505 @@
-package org.bouncycastle.openpgp.test;public class UnrecognizableSubkeyParserTest {
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.openpgp.PGPObjectFactory;
+import org.bouncycastle.openpgp.PGPPublicKeyRing;
+import org.bouncycastle.openpgp.bc.BcPGPObjectFactory;
+import org.bouncycastle.util.test.SimpleTest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+
+/**
+ * This test checks how stable BCs {@link PGPPublicKeyRing} parser function is when it comes to unknown key algorithms.
+ * The implementation should ignore unknown subkeys in order to be upwards compatible with future certificates.
+ *
+ * @see <a href="https://tests.sequoia-pgp.org/#Mock_PQ_subkey">OpenPGP Interoperability Test Suite - Mock PQ subkey</a>
+ */
+public class UnrecognizableSubkeyParserTest extends SimpleTest {
+
+    public static void main(String[] arg) {
+        runTest(new UnrecognizableSubkeyParserTest());
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public void performTest() throws Exception {
+        baseCase();
+        subkeyHasUnknownAlgo_MPIEncoding();
+        subkeyHasUnknownAlgoOpaqueEncodingSmall();
+        subkeyHasEcdsaUnknownCurveMPIEncoding();
+        subkeyHasEcdsaUnknownCurveOpaqueEncodingSmall();
+        subkeyHasEddsaUknownCurveMPIEncoding();
+        subkeyHasEddsaUnknownCurveOpaqueEncodingSmall();
+        subkeyHasEcdhUnknownCurveMPIEncoding();
+        subkeyHasEcdhUnknownCurveOpaqueEncodingSmall();
+    }
+
+    // base case
+    private void baseCase() throws IOException {
+        String CERT = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "\n" +
+                "xsDNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAc0hQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+wsEOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGzsDNBF2lnPIBDADW\n" +
+                "ML9cbGMrp12CtF9b2P6z9TTT74S8iyBOzaSvdGDQY/sUtZXRg21HWamXnn9sSXvI\n" +
+                "DEINOQ6A9QxdxoqWdCHrOuW3ofneYXoG+zeKc4dC86wa1TR2q9vW+RMXSO4uImA+\n" +
+                "Uzula/6k1DogDf28qhCxMwG/i/m9g1c/0aApuDyKdQ1PXsHHNlgd/Dn6rrd5y2AO\n" +
+                "baifV7wIhEJnvqgFXDN2RXGjLeCOHV4Q2WTYPg/S4k1nMXVDwZXrvIsA0YwIMgIT\n" +
+                "86Rafp1qKlgPNbiIlC1g9RY/iFaGN2b4Ir6GDohBQSfZW2+LXoPZuVE/wGlQ01rh\n" +
+                "827KVZW4lXvqsge+wtnWlszcselGATyzqOK9LdHPdZGzROZYI2e8c+paLNDdVPL6\n" +
+                "vdRBUnkCaEkOtl1mr2JpQi5nTU+gTX4IeInC7E+1a9UDF/Y85ybUz8XV8rUnR76U\n" +
+                "qVC7KidNepdHbZjjXCt8/Zo+Tec9JNbYNQB/e9ExmDntmlHEsSEQzFwzj8sxH48A\n" +
+                "EQEAAcLBPgQYAQoAcgWCXaWc8gkQ+/zIKgFeczBHFAAAAAAAHgAgc2FsdEBub3Rh\n" +
+                "dGlvbnMuc2VxdW9pYS1wZ3Aub3JniJK8Q5VEmU0QnIrlhswzdHX12wiDXkd7YN6Q\n" +
+                "RM1qbOkCmwwWIQTRpm4aI7GCyZgPeIz7/MgqAV5zMAAAxM8L+wQoJeiDA8PqBunw\n" +
+                "mAeuWMniUdKhG1w1Flrt9aZkUoBr9nIulpoRox56Uws33QjN6+CkGMuGj3FbNEHK\n" +
+                "6JL46NnUAQbkioUtHXO55KwQrvaBVwDhacIWWOKIlfOvg61XPsV6vJ65AanF1TyY\n" +
+                "/zPlhRRWam1dBPwO5Zmbi3UMAKkOd52Ju48CQAkCl1Uoo7Z0YGJwjyHuD1swX9ic\n" +
+                "atg9MO1zjmoRvgvNxO8MqPdb9ioEE9srKwTjMBWXegs8bbQJtvFU/59jI64ZKAqQ\n" +
+                "lmy3Qstz12hmgJsX1iRnE+Y287SC5KzTuysEd36zKkOCBlVbTmkaayC5bbaiLmOG\n" +
+                "sjUiF9ft2i2nfM+2v8QvpRrUV6LGRUP2I6PNiQhdTV3ZyPD1u5xD6Yg69n2XSHQE\n" +
+                "6vCrIXtj5UmlMq5Y4vrAGqzNqHHZITKhfETm+0iGOy4L6Uyuhj3gGjWJ1shhlHx4\n" +
+                "KcbFeBqrT9utHUoKfa9oUr0o6IMrmT+94bOtyPRPUF7QJl+dig==\n" +
+                "=0Jja\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----\n";
+
+        PGPPublicKeyRing bobCert = certFromString(CERT);
+        isEquals(2, count(bobCert.getPublicKeys()));
+    }
+
+    public void subkeyHasUnknownAlgo_MPIEncoding() throws IOException {
+        String CERT = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "\n" +
+                "xsDNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAc0hQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+wsEOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGzsFKBF2lnPJjCACo\n" +
+                "21HB2d5WEFpHBfjyu55+z3N45AoMDZxDa9cyy5lqa0ImwFR4At+CmH+tA3/0+LwZ\n" +
+                "CgG0sm+wMUScxLfPle6G81qXuxhaAEFwsoCWMObRmXZ/t8ujlkGCEG2BOh/bkpQd\n" +
+                "mXwznNLC9ri7Gs+V/RYCwhih/Nl6raQgi3hAMJWi+P78ZuOBgrDiiPF+F4UFTl9T\n" +
+                "fvtb05YLd1pZhLp/nUgGrIc10BHnGORfn12vDMa5tcE59K6Z97UCu6gG/HeUNw4a\n" +
+                "aLDmojN3WUFUSI3KWORzEU6zVrntQxPgt3HYoii/ZtEGOZyKvRTm/s0do10o0i7i\n" +
+                "sp9gDIXQsBme/qotf/moCAD6WjF0nEtHC33wnCowYWa8VS9sp9CYxgO6zl4WC81B\n" +
+                "wNcEHVLwt8p1Wy1GGRWPp/NtLfv000FOfrAoqjwGtIVv4QZPIywS+MKxoB0h/YVs\n" +
+                "jFxCXxHY3K9GMsTjRI55vk8DkekXOUpw5zBnBCzRE/HfdrGeuzFYcJBoCFbpg1SC\n" +
+                "gDGy1owuzZ09xT/mn2ailhgTnypsPupIOG19Ro39lz9SaJRSXFTFI12UA8bYq7OU\n" +
+                "7Kl78EkrcBV1VH/3/jlwDmE6OMN+ybpzWJ/gRL1YkV8dwPyXtGmoKkXFm+CdDVFE\n" +
+                "m+bkJk4XxiclwbfLVsY4rCKghW5hRjJtPPWgrvAXzt9xwsE+BBgBCgByBYJdpZzy\n" +
+                "CRD7/MgqAV5zMEcUAAAAAAAeACBzYWx0QG5vdGF0aW9ucy5zZXF1b2lhLXBncC5v\n" +
+                "cmddsypF+7C1PmvhG7iGs/MQFjOHDTRYU2dWxmdLSNUyWgKbDBYhBNGmbhojsYLJ\n" +
+                "mA94jPv8yCoBXnMwAACauAv/WaMjAZ2ZOO/+wlJA4CSfXBs07HeCDZBOryt1dQ7l\n" +
+                "bdSQVGP7ncWPzqeOEHvHqODLHX+D2x7fUYo9LuWyay9vnhc/GVFRwaPMNVhHCQGj\n" +
+                "rWPaldOWVEx+xtY0dEJyO9Vchb+H0I3+pgjiHP8dD6Mb0XmwgB1TprVEaoAeq1t6\n" +
+                "/oUFfU6xNpL5rlT4fm+mkP+sS605NW9ZSbUpwxvvjUmahA1tNQnfezwV8GyjosXD\n" +
+                "QtE8RDGki7EzkBEMtFGHcqOMNbqYpBxXJXS1IPC00VJZZkYnwArLLWUdWKgZjM6Q\n" +
+                "6yj9etO7BmbaaI1Ff/rJEoqRQsiXgQkCBNwQUeQopafU4SWfFwglhS0zuzM37CtN\n" +
+                "/DEDWsrDBEY9kTszlda2fN9BCuATEU9ml5KqJ1A/eOSdlRk6/eFoyrbo4wh0G9+C\n" +
+                "MrUZbPWA9DOD/VA57OE30hiCSmxmrEWdrFnhNJGxXxQlPnR2wZKihetPp3RQ2J9h\n" +
+                "/Y2Ze1hbQCOT+DqqgX4KKeVN\n" +
+                "=r4sv\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----\n";
+
+        PGPPublicKeyRing cert = certFromString(CERT);
+        isEquals("Unrecognizable subkey must be ignored", 1, count(cert.getPublicKeys()));
+    }
+
+    public void subkeyHasUnknownAlgoOpaqueEncodingSmall() throws IOException {
+        String CERT = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "\n" +
+                "xsDNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAc0hQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+wsEOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGzsFGBF2lnPJjvQJO\n" +
+                "VJxScq4+CLtil6Z8TjYbzBWwHaq86Z7bvbYPDy5pHK0ZafvZUxlVR5u3oV5OQkdt\n" +
+                "Uc+Bz32TYoGkmGAgoPOIvdXWNDsofu5LryRT0G1qmmT3yy/pm3F20/j/S2AGGR0t\n" +
+                "8+INmOZDgkDPJ0eDwLYdwtF3jUPEIKJJHYBvzQNt73o/gpZ5b/uWfpmksecRIhnK\n" +
+                "nPM75vom8IzXqENj9aqrYw1gEBoG6marAlY3cCsOwNB8XhuMF/wmvbXDs4faa+nT\n" +
+                "L84GxCZ/Vrmzmr9XPO5Bwc2dGwVpsPRkCKMndeMNRVz6iZaaGeKIhquPsRGaGB2x\n" +
+                "zexZnXy/M+q5R/p31Jz7e5P1olDxXxplBfh8PUdJU/tDSYJ5LTcxF6Yqu84/f4hO\n" +
+                "CkaWSbUDIoTCh49BVnq0Iptc2GMS42FYkRKCUxIFokk39FY0sWPg3mWoaDya1Hf4\n" +
+                "iEPSP+PPMOUYFzgTQ8JNcificKa1KQPJgt2KymG1StFMm6+eERhIt6seA8eApsRL\n" +
+                "BdOL+mvzg4qp5guu2qL2wnef8o/DjS1VdLro6uexjtd3rJNsawbL4E/4boICQd6x\n" +
+                "3nge792es533rm9gzbt82bJ3Fb6xFDbG1OjbQakQJW7TxE3Qiduu0ZwDAjsHZjei\n" +
+                "JmfoNgee/6W2AMEN5bwB3/E5+WDeP8cuuO9ldpvCwT4EGAEKAHIFgl2lnPIJEPv8\n" +
+                "yCoBXnMwRxQAAAAAAB4AIHNhbHRAbm90YXRpb25zLnNlcXVvaWEtcGdwLm9yZwmv\n" +
+                "6gvC4U2ijOJieWwup2iXb+34JkPTbrtPunh+X2ukApsMFiEE0aZuGiOxgsmYD3iM\n" +
+                "+/zIKgFeczAAAH+ZC/4otDK4pP1X7Jp3S9HuOnWXYM3uTPdaPcYKWZTwOdsx+0ha\n" +
+                "ohTINcOBdGvlJd7Kkc/eX5rstRouWjtzReIW6tPgdTSlP4jW1b1xFm4c2R+05kFM\n" +
+                "l3J/lptLuer/PIGONdqdUevHR2Zsttter3TqlyrZq0y+N2K4OgMRlBUWpCl0Wusl\n" +
+                "iHV6ALnms4zUGrhlQIKSDDU8zHVzJD6QIDOd3qEUnIqFOqP+x0nIrvYK/eSQ72nD\n" +
+                "6M0P4Lh1sa/TZcbf3fLfR52NrFToeuP5MKH1ZXrNckqjIMp0IF+TNauwgze/zshV\n" +
+                "f6ve41CgDUVFZHxGRhtJ1dLzrx9YHqjXOZ7XRZnhfgB+DCwJ1QCIWDioJ18O9pfE\n" +
+                "7IosyFzRY53V3q85p5q/5RtBePsqp6Zx9dY8zNfU+Ph18YH/c4ls1uqrRPcNdIRV\n" +
+                "6vJ6HKWePAGVj/uJJdFSc1/QyZzvuxRJVvbWiapD57cfsmmc3VkKmGOQN5v/gDn8\n" +
+                "J27Z7zpkTfD9QCroP84=\n" +
+                "=NHTB\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----\n";
+
+        PGPPublicKeyRing cert = certFromString(CERT);
+        isEquals("Unrecognizable subkey must be ignored", 1, count(cert.getPublicKeys()));
+    }
+
+    public void subkeyHasEcdsaUnknownCurveMPIEncoding() throws IOException {
+        String CERT = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "\n" +
+                "xsDNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAc0hQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+wsEOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGzsBUBF2lnPITCwYJ\n" +
+                "KwYBBAGColpjCACWbQQxg5E2dxC/pZ3ZFQyJD1gKDrXLPJ8lZVCRrKtSo2qVcqas\n" +
+                "Zb2GNojV8LD2l+3Eq+HMsFaLnkD/Ot4S0DgwfyLPNeKPXLRBD5BrhjewD2Kd5J1P\n" +
+                "4eAX/t/X8oe/66gk2Mk2ykf8IfMPk7FsX5SjurepoH8nCzfHY5NBU9+UVOFnhLPq\n" +
+                "UgKDVdkhNdhHgxPXcYE61lRpwKjSEKBx/oRshCxlyrJcQdAth1ogGT5wAu0gZ6wl\n" +
+                "d6us2Xkt3FG2CJU2xS0Xd3EaPLRmN5hmKEQHMk/aoeVXMVIXNA5OskDcIzS7UbPQ\n" +
+                "s8DEHa38TUUezGndB6605LdRmukVsTJogj+swsE+BBgBCgByBYJdpZzyCRD7/Mgq\n" +
+                "AV5zMEcUAAAAAAAeACBzYWx0QG5vdGF0aW9ucy5zZXF1b2lhLXBncC5vcmcz2ySS\n" +
+                "QEIaXr2QHnziGOW6GNcw58dJ7mxxVOF27uwEygKbIBYhBNGmbhojsYLJmA94jPv8\n" +
+                "yCoBXnMwAACu9gwAprtxTYXyrblfVgOmXHLT1TncS5S7gfrpSa8n5ckPBrIuWGxo\n" +
+                "MuJJ8GQXnqtJCBTsbq/oV/5GN3aAc37mqV7e6fYSfmoBCF5AXTXvf2Tsgo9g53Mv\n" +
+                "CWnW2glTY+tEtu2ySzVq3h7rLGvVI8qiWOAPQ0cxxTQVUPwbV+LUhtO4KCDBe2hk\n" +
+                "Oa9UFtHj51+7GomUPPdCta9E2Ws0+JEqBaHy7zshk/sRQsyQkO0nUk2ZAfnZP3ru\n" +
+                "pYcstBQLmcSt8KvTUuC48VC6lZlqydsP3AnjSGleRto4DWRAuuoQcONTBeS83a88\n" +
+                "YY7qVK4F6L/Iz1662Ojh110Ynvuj0+Br0QoBFtsEpHlTMtuFUQEQ9MaYvj880vjM\n" +
+                "NdN5tMfKKmk8lUYD0TvBQFcomuil+gJ5yyU6hHoFJA/vynXT2OkiOfxoWmzjL7Hg\n" +
+                "dRVC4ABUoe1TZyJ6vPRifaRaRz85MUJ/DspuKU02KFqLHfJmLdnBRHME8rKkHzj9\n" +
+                "V9++XwJcdrSlKEyM\n" +
+                "=H4J2\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----\n";
+
+        PGPPublicKeyRing cert = certFromString(CERT);
+        isTrue("BC must be able to deal with ecdsa subkeys with unknown curves", cert != null);
+    }
+
+    public void subkeyHasEcdsaUnknownCurveOpaqueEncodingSmall() throws IOException {
+        String CERT = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "\n" +
+                "xsDNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAc0hQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+wsEOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGzsFSBF2lnPITCwYJ\n" +
+                "KwYBBAGColpjvQJOVJxScq4+CLtil6Z8TjYbzBWwHaq86Z7bvbYPDy5pHK0ZafvZ\n" +
+                "UxlVR5u3oV5OQkdtUc+Bz32TYoGkmGAgoPOIvdXWNDsofu5LryRT0G1qmmT3yy/p\n" +
+                "m3F20/j/S2AGGR0t8+INmOZDgkDPJ0eDwLYdwtF3jUPEIKJJHYBvzQNt73o/gpZ5\n" +
+                "b/uWfpmksecRIhnKnPM75vom8IzXqENj9aqrYw1gEBoG6marAlY3cCsOwNB8XhuM\n" +
+                "F/wmvbXDs4faa+nTL84GxCZ/Vrmzmr9XPO5Bwc2dGwVpsPRkCKMndeMNRVz6iZaa\n" +
+                "GeKIhquPsRGaGB2xzexZnXy/M+q5R/p31Jz7e5P1olDxXxplBfh8PUdJU/tDSYJ5\n" +
+                "LTcxF6Yqu84/f4hOCkaWSbUDIoTCh49BVnq0Iptc2GMS42FYkRKCUxIFokk39FY0\n" +
+                "sWPg3mWoaDya1Hf4iEPSP+PPMOUYFzgTQ8JNcificKa1KQPJgt2KymG1StFMm6+e\n" +
+                "ERhIt6seA8eApsRLBdOL+mvzg4qp5guu2qL2wnef8o/DjS1VdLro6uexjtd3rJNs\n" +
+                "awbL4E/4boICQd6x3nge792es533rm9gzbt82bJ3Fb6xFDbG1OjbQakQJW7TxE3Q\n" +
+                "iduu0ZwDAjsHZjeiJmfoNgee/6W2AMEN5bwB3/E5+WDeP8cuuO9ldpvCwT4EGAEK\n" +
+                "AHIFgl2lnPIJEPv8yCoBXnMwRxQAAAAAAB4AIHNhbHRAbm90YXRpb25zLnNlcXVv\n" +
+                "aWEtcGdwLm9yZ2D5VebWq2faBWfN/Xv9L7YE6ss0CyFu8W1UO+8s77+4ApsgFiEE\n" +
+                "0aZuGiOxgsmYD3iM+/zIKgFeczAAACEADACLjx/4NTe+OZTnkjQrBNxMAiP0a5xM\n" +
+                "9JcbJC0BHfH5cmWowQg31ZWCHFbMkEIkRg6BiiE22v4lBF8yeF20MyilKTlqp3+7\n" +
+                "4f2zYD7pIOBMxdeE9qqOAdNDB2EV6n5B4XX/u11YxPoSNNMNTRE3sWyBotL/yxbN\n" +
+                "J0/Odt9Zkjxp8MD0IgZoZ6p8dUaBg1vQOBBQosw81L9LMlceuWfpmxxngzIhEg7S\n" +
+                "3tKKSTh22AQW0iHKLFQ9AAU26B2x52od/OsZt8YGNT7X2q7qPY24EKAl6zu60o4M\n" +
+                "SzjQFjlk3FJT2LU8iy/WN9BS8fN6B9CzWN8qspjLBJhJncs+Hb19VwIhy1M71hGo\n" +
+                "vf1eVR6YPdxaS5Gnmil57QWrkUHT8Rg9YoZI4TXdkr/L35petxkUyasesJGj0a+z\n" +
+                "Lo3HODSpaio5mXzamfZHWwbWzNEfKX2N6xbU3ELujSsHIlR62Vr+y54vF0oxZKWF\n" +
+                "y+sd/w4RCr6LfQbFPbeTSn2zZ5jsKEq3s10=\n" +
+                "=YESV\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----";
+
+        PGPPublicKeyRing cert = certFromString(CERT);
+        isTrue("BC must be able to deal with ecdsa subkeys with unknown curves", cert != null);
+    }
+
+    public void subkeyHasEddsaUknownCurveMPIEncoding() throws IOException {
+        String CERT = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "\n" +
+                "xsDNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAc0hQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+wsEOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGzsBUBF2lnPIWCwYJ\n" +
+                "KwYBBAGColpjCACWbQQxg5E2dxC/pZ3ZFQyJD1gKDrXLPJ8lZVCRrKtSo2qVcqas\n" +
+                "Zb2GNojV8LD2l+3Eq+HMsFaLnkD/Ot4S0DgwfyLPNeKPXLRBD5BrhjewD2Kd5J1P\n" +
+                "4eAX/t/X8oe/66gk2Mk2ykf8IfMPk7FsX5SjurepoH8nCzfHY5NBU9+UVOFnhLPq\n" +
+                "UgKDVdkhNdhHgxPXcYE61lRpwKjSEKBx/oRshCxlyrJcQdAth1ogGT5wAu0gZ6wl\n" +
+                "d6us2Xkt3FG2CJU2xS0Xd3EaPLRmN5hmKEQHMk/aoeVXMVIXNA5OskDcIzS7UbPQ\n" +
+                "s8DEHa38TUUezGndB6605LdRmukVsTJogj+swsE+BBgBCgByBYJdpZzyCRD7/Mgq\n" +
+                "AV5zMEcUAAAAAAAeACBzYWx0QG5vdGF0aW9ucy5zZXF1b2lhLXBncC5vcmc7yihp\n" +
+                "VMM6W5JxVjS5XFlN7/6u1zryiHBHJz/PyEh3QAKbIBYhBNGmbhojsYLJmA94jPv8\n" +
+                "yCoBXnMwAAAo0Qv/T6b7nAeu70XTUEtGi8PJ2jVdJlRfkpJLAccc2kkc4yhKX+yi\n" +
+                "umM4w87bBJhYia/d1bQCi1JdZMV7eHM6b7OuYeLyn/7a+3SdCuWp5qXKjae86+u2\n" +
+                "aUrZlwWB5puvAFg6af3pMzWn4KkH/AcEpGs79Nb9CxNWMdfKcDiUhamacYEa2JsN\n" +
+                "R16+0YVzji3t7PjLVs39GcOmL5x1LNC45z6MSbAwHatL+4SSNnfBWHQzrNy8XGeU\n" +
+                "YICMninvVaVCKCK+h+cSgDd39+TBS85qi6pqrlPUcVex3uCYI1xQyTVPvTwSfgAm\n" +
+                "kEbDMovBbEddr0fatwHtkY4JTcZJbkm59/CuwWkrTfY1NLl/Z6V+gGzvpSJcw6aH\n" +
+                "PyFybWeuFQFN4mL9urjcFlCUCfii8k51WKknK0UAq8cPwldajzrHfGWmuou4grcH\n" +
+                "jYluBe4DSZN1tysrcESzL8LJjzmZdoYp+eKtF7PtetuwF6HkAgvZmv9LteBxlTYM\n" +
+                "sntZAriceDP//L+f\n" +
+                "=vaVc\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----\n";
+
+        PGPPublicKeyRing cert = certFromString(CERT);
+        isTrue("BC must be able to deal with EdDSA subkeys with unknown curves", cert != null);
+    }
+
+    public void subkeyHasEddsaUnknownCurveOpaqueEncodingSmall() throws IOException {
+        String CERT = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "\n" +
+                "xsDNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAc0hQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+wsEOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGzsFSBF2lnPIWCwYJ\n" +
+                "KwYBBAGColpjvQJOVJxScq4+CLtil6Z8TjYbzBWwHaq86Z7bvbYPDy5pHK0ZafvZ\n" +
+                "UxlVR5u3oV5OQkdtUc+Bz32TYoGkmGAgoPOIvdXWNDsofu5LryRT0G1qmmT3yy/p\n" +
+                "m3F20/j/S2AGGR0t8+INmOZDgkDPJ0eDwLYdwtF3jUPEIKJJHYBvzQNt73o/gpZ5\n" +
+                "b/uWfpmksecRIhnKnPM75vom8IzXqENj9aqrYw1gEBoG6marAlY3cCsOwNB8XhuM\n" +
+                "F/wmvbXDs4faa+nTL84GxCZ/Vrmzmr9XPO5Bwc2dGwVpsPRkCKMndeMNRVz6iZaa\n" +
+                "GeKIhquPsRGaGB2xzexZnXy/M+q5R/p31Jz7e5P1olDxXxplBfh8PUdJU/tDSYJ5\n" +
+                "LTcxF6Yqu84/f4hOCkaWSbUDIoTCh49BVnq0Iptc2GMS42FYkRKCUxIFokk39FY0\n" +
+                "sWPg3mWoaDya1Hf4iEPSP+PPMOUYFzgTQ8JNcificKa1KQPJgt2KymG1StFMm6+e\n" +
+                "ERhIt6seA8eApsRLBdOL+mvzg4qp5guu2qL2wnef8o/DjS1VdLro6uexjtd3rJNs\n" +
+                "awbL4E/4boICQd6x3nge792es533rm9gzbt82bJ3Fb6xFDbG1OjbQakQJW7TxE3Q\n" +
+                "iduu0ZwDAjsHZjeiJmfoNgee/6W2AMEN5bwB3/E5+WDeP8cuuO9ldpvCwT4EGAEK\n" +
+                "AHIFgl2lnPIJEPv8yCoBXnMwRxQAAAAAAB4AIHNhbHRAbm90YXRpb25zLnNlcXVv\n" +
+                "aWEtcGdwLm9yZwYOAgWPDMbQ+ZQ+EvYDPmqfCvOsQZU5+0Dwc/yhRkU9ApsgFiEE\n" +
+                "0aZuGiOxgsmYD3iM+/zIKgFeczAAAGmqDACVIA5DEzDPYMHjzjhr0DqghqAdm21I\n" +
+                "1gxO4Tkdvsy4QCjoD+h0MAnOPzFMPc77JLNtkGZsnLWikoFwLWypuwK3a/OWIJV5\n" +
+                "tmfTvCe4NxKSer+b5zm2kFeY5PX0R17jQ7iyuvcHgV5giMXIsVxu8nAG0jad4DNL\n" +
+                "+hf09zVLPmLuWjKpNrj+qi1HKxAgPGMwv3utYmZRrhR3FYAtHiD4u/uUoPXNjlwK\n" +
+                "nOK6O2/YC6wo1Ko2XbX6qlGNylC1Xs77D12HeqjJTxuEnHtx/nAms3Oy9QWrkyyt\n" +
+                "JvoEjstR7pxnCbivyQYs9nzYd9b08hAMMXgO/b3FyIb8zdW7mZULgfQBIpnpeGGt\n" +
+                "7reZREz96GEAh0FME6M4yzGGRavsGqzaTwMhDHQYdEYMpUjcRcqhD4YiCoOjgwHl\n" +
+                "duOW6z6rk0en0qyaGLBeAzmjhdjvzmls4MaLxOz/BUZyVLQxnkkFn4wu6WKhlBaG\n" +
+                "Vjudp5bF+Rq7/zE+eJ8QeJ9e9auU15l2mU0=\n" +
+                "=Q07p\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----\n";
+
+        PGPPublicKeyRing cert = certFromString(CERT);
+        isTrue("BC must be able to deal with EdDSA subkeys with unknown curves", cert != null);
+    }
+
+    public void subkeyHasEcdhUnknownCurveMPIEncoding() throws IOException {
+        String CERT = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "\n" +
+                "xsDNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAc0hQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+wsEOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGzsBYBF2lnPISCwYJ\n" +
+                "KwYBBAGColpjCACWbQQxg5E2dxC/pZ3ZFQyJD1gKDrXLPJ8lZVCRrKtSo2qVcqas\n" +
+                "Zb2GNojV8LD2l+3Eq+HMsFaLnkD/Ot4S0DgwfyLPNeKPXLRBD5BrhjewD2Kd5J1P\n" +
+                "4eAX/t/X8oe/66gk2Mk2ykf8IfMPk7FsX5SjurepoH8nCzfHY5NBU9+UVOFnhLPq\n" +
+                "UgKDVdkhNdhHgxPXcYE61lRpwKjSEKBx/oRshCxlyrJcQdAth1ogGT5wAu0gZ6wl\n" +
+                "d6us2Xkt3FG2CJU2xS0Xd3EaPLRmN5hmKEQHMk/aoeVXMVIXNA5OskDcIzS7UbPQ\n" +
+                "s8DEHa38TUUezGndB6605LdRmukVsTJogj+sAwEKCcLBPgQYAQoAcgWCXaWc8gkQ\n" +
+                "+/zIKgFeczBHFAAAAAAAHgAgc2FsdEBub3RhdGlvbnMuc2VxdW9pYS1wZ3Aub3Jn\n" +
+                "kk2fbBUnrwgriBN+y99YLB9bP0hGxPKnxhSpXEh7BlECmwwWIQTRpm4aI7GCyZgP\n" +
+                "eIz7/MgqAV5zMAAAYrgL/jNsGt3f4LKUr8J/cUwE8uOmNAvt2cGPLux7Z99L9ov+\n" +
+                "zeB03uEs+sxqXyFmx8Ftssr/OtlMKBeXX7XQPgVzUdlsuZPvDYuDATgkMbvPM61E\n" +
+                "p3ktt4cQO3ObSrQnsK1hLbHyh2sER068+BaYDpM58L+YcyLIADnzaFozOgXVnFvm\n" +
+                "dR9cvR2S+j4xCDTWw6r7Cjnwp7HJoyPsOrTJcyb65QWGXkdjU604MljuRl+JRuuM\n" +
+                "9TBxEadqfLvB3rH9c49QdGU//Zm9belnd9U5Xm56dpmQ7P0JYysKbFnZbGed34JV\n" +
+                "kplPdCXx66E/O8gKsYpqYoj0xwlddXEVBDowJ1DE74wLX1aCbT4WAbmsKfPB4Bzs\n" +
+                "NCg5qdrNKlBhozZqOcuPaIqPgJTz7s7+xz2r/ZZaEZH+8/UYZybbofuRtZyfwuBZ\n" +
+                "H1L5bT4KEf0oDpIbAu8fnVc8s+npv5inri7IrEdsbsm/HR02jgsG9eSOSvGipdpz\n" +
+                "YrmhD20OVj0MhB6X3huw4Q==\n" +
+                "=wHFT\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----\n";
+
+        PGPPublicKeyRing cert = certFromString(CERT);
+        isTrue("BC must be able to deal with ECDH subkeys with unknown curves", cert != null);
+    }
+
+    public void subkeyHasEcdhUnknownCurveOpaqueEncodingSmall() throws IOException {
+        String CERT = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "\n" +
+                "xsDNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAc0hQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+wsEOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGzsFWBF2lnPISCwYJ\n" +
+                "KwYBBAGColpjvQJOVJxScq4+CLtil6Z8TjYbzBWwHaq86Z7bvbYPDy5pHK0ZafvZ\n" +
+                "UxlVR5u3oV5OQkdtUc+Bz32TYoGkmGAgoPOIvdXWNDsofu5LryRT0G1qmmT3yy/p\n" +
+                "m3F20/j/S2AGGR0t8+INmOZDgkDPJ0eDwLYdwtF3jUPEIKJJHYBvzQNt73o/gpZ5\n" +
+                "b/uWfpmksecRIhnKnPM75vom8IzXqENj9aqrYw1gEBoG6marAlY3cCsOwNB8XhuM\n" +
+                "F/wmvbXDs4faa+nTL84GxCZ/Vrmzmr9XPO5Bwc2dGwVpsPRkCKMndeMNRVz6iZaa\n" +
+                "GeKIhquPsRGaGB2xzexZnXy/M+q5R/p31Jz7e5P1olDxXxplBfh8PUdJU/tDSYJ5\n" +
+                "LTcxF6Yqu84/f4hOCkaWSbUDIoTCh49BVnq0Iptc2GMS42FYkRKCUxIFokk39FY0\n" +
+                "sWPg3mWoaDya1Hf4iEPSP+PPMOUYFzgTQ8JNcificKa1KQPJgt2KymG1StFMm6+e\n" +
+                "ERhIt6seA8eApsRLBdOL+mvzg4qp5guu2qL2wnef8o/DjS1VdLro6uexjtd3rJNs\n" +
+                "awbL4E/4boICQd6x3nge792es533rm9gzbt82bJ3Fb6xFDbG1OjbQakQJW7TxE3Q\n" +
+                "iduu0ZwDAjsHZjeiJmfoNgee/6W2AMEN5bwB3/E5+WDeP8cuuO9ldpsDAQoJwsE+\n" +
+                "BBgBCgByBYJdpZzyCRD7/MgqAV5zMEcUAAAAAAAeACBzYWx0QG5vdGF0aW9ucy5z\n" +
+                "ZXF1b2lhLXBncC5vcmffToHhPNsk5u1Dzn9L46BOCMWN8MAOIOR2ZtAgLpGXMwKb\n" +
+                "DBYhBNGmbhojsYLJmA94jPv8yCoBXnMwAACsCAwAqqJnhqjRYnbyEs30f/FsghrL\n" +
+                "uQ3TIm6OTo8/Ab6B/WrBqf8naKCmQlW4X67vhJMGFLTp6iBeOy7dfBStXmk6iZEY\n" +
+                "XwZ1BBmUCFuUOwYUPYn1nWItJOVOK68Iux+0wyT1N3ZFoN5NXoXyX8CnmBTdg3AG\n" +
+                "dcUYF7zAxQkHr4ysVGqQuHMYN6c2JCzU/JJpST0RxYl8nQSv8VWZIiYGHOp3jNNQ\n" +
+                "T+8B5Wo5lU7l7hVBinuhYfp3yJjoGtmrz8aGCkksLP49d7iJw1ueJdNucNKeKsye\n" +
+                "1xq0HgTLDKmxJOjzC8RuRDoyUkQjml1tJ+pefPbWOsSDIwA2C5nnuqei4qrLt3SD\n" +
+                "6+08HJw/cmzS6VyWD1UHg6+CjV6nJQrukY2gsVHsZeCo1XBFHex12M0ORPo2mYSm\n" +
+                "Htdk1MGl6H9n/clYfWnCU5BpuaDXjjwjGb8RML3elJXW/gwCbw3P+FZZClJlTaqO\n" +
+                "TPMq2Bh0B/4GULi9pPpUEw1SCOdPoo9dtnACNsEX\n" +
+                "=655d\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----\n";
+
+        PGPPublicKeyRing cert = certFromString(CERT);
+        isTrue("BC must be able to deal with ECDH subkeys with unknown curves", cert != null);
+    }
+
+    private int count(Iterator<?> iterator) {
+        int i = 0;
+        while (iterator.hasNext()) {
+            iterator.next();
+            i++;
+        }
+        return i;
+    }
+
+    private PGPPublicKeyRing certFromString(String string) throws IOException {
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
+        ArmoredInputStream armorIn = new ArmoredInputStream(bytesIn);
+        PGPObjectFactory objectFactory = new BcPGPObjectFactory(armorIn);
+
+        Object next = objectFactory.nextObject();
+        isTrue("Object in stream MUST NOT be null", next != null);
+        isTrue("Object in stream must be PGPPublicKeyRing", next instanceof PGPPublicKeyRing);
+        return (PGPPublicKeyRing) next;
+    }
 }


### PR DESCRIPTION
BC currently chokes when parsing OpenPGP certificates with contain subkeys with unrecognized algorithms.
As a result, the whole PGPPublicKeyRing becomes null and is therefore unusable.

This means that unfortunately BCs OpenPGP implementation is not upwards compatible to when keys with PQC subkeys are introduced. Ideally an implementation should just ignore subkeys that it does not recognize and instead try to use the other keys.

This PR changes BCs behavior to ignore unrecognizable subkeys when parsing PGPPublicKeyRing and PGPSecretKeyRing objects.
Note, that only subkeys are ignored, since a key with an unrecognizable primary key is not usable at all.

I took the test vectors from [the OpenPGP interoperability test suite](https://tests.sequoia-pgp.org/#Mock_PQ_subkey) and implemented them as unit tests.
Unfortunately there weren't any test vectors for secret keys available, but the change is similar enough as to that I have confidence in its correctness.

In any case I made an extra commit for the changes in secret key parsing.

I also added commits that ignore unsupported signatures when reading then from certs and from ObjectFactory objects.
Further, the PGPObjectFactory will no longer fail to parse PKESKs/SKESKs when there are unknown versions in the list.

This is further improving upwards compatibility.