### PR TITLE
Do not encode PGPSignatures marked with exportable=false if forTransf…

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -599,6 +599,12 @@ public class PGPSignature
         boolean forTransfer)
         throws IOException
     {
+        // Exportable signatures MUST NOT be exported if forTransfer==true
+        if (forTransfer && (!getHashedSubPackets().isExportable() || !getUnhashedSubPackets().isExportable()))
+        {
+            return;
+        }
+
         BCPGOutputStream out;
 
         if (outStream instanceof BCPGOutputStream)


### PR DESCRIPTION
…er is true

This PR aims to make BC's OpenPGP implementation compatible with [section 5.2.3.11](https://datatracker.ietf.org/doc/html/rfc4880#section-5.2.3.11) of RFC4880:

```
   Non-exportable, or "local", certifications are signatures made by a
   user to mark a key as valid within that user's implementation only.

   Thus, when an implementation prepares a user's copy of a key for
   transport to another user (this is the process of "exporting" the
   key), any local certification signatures are deleted from the key.
```