### PR TITLE
Fix possible bug in PGPPublicKey.removeCert()

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -969,7 +969,7 @@ public class PGPPublicKey
         PGPPublicKey returnKey = new PGPPublicKey(key);
         boolean found = false;
 
-        for (int i = 0; i < returnKey.ids.size(); i++)
+        for (int i = returnKey.ids.size() - 1; i >= 0; i--)
         {
             if (id.equals(returnKey.ids.get(i)))
             {


### PR DESCRIPTION
The method looped over a list and removed from it.
This can lead to items being skipped.
I fixed it by inverting the loop direction.

This is probably not a big deal in real-world usage, since duplicates in `returnKey.ids` are unlikely, still its probably better to fix it nonetheless.