### PR TITLE
Fix PGPSessionKey.toString()

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSessionKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSessionKey.java
@@ -30,7 +30,7 @@ public class PGPSessionKey
 
     public String toString()
     {
-        return algorithm + ":" + sessionKey;
+        return algorithm + ":" + Hex.toHexString(sessionKey).toUpperCase();
     }
 
     public static PGPSessionKey fromAsciiRepresentation(String ascii)

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPSessionKeyTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPSessionKeyTest.java
@@ -262,6 +262,6 @@ public class PGPSessionKeyTest
         PGPSessionKey sessionKey = PGPSessionKey.fromAsciiRepresentation(sessionKeyString);
         isEquals(9, sessionKey.getAlgorithm());
         isEquals("FCA4BEAF687F48059CACC14FB019125CD57392BAB7037C707835925CBF9F7BCD", Hex.toHexString(sessionKey.getKey()).toUpperCase());
-        //isEquals(sessionKeyString, sessionKey.toString());
+        isEquals(sessionKeyString, sessionKey.toString());
     }
 }


### PR DESCRIPTION
Calling .toString() on the raw array `sessionKey` produces output which is not helpful.

I'm pretty sure in my original implementation I had `toString()` call `Hex.toHexString()` in place. Was this changed for a reason?