### PR TITLE
Add fast CRC-24 implementation

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredInputStream.java
@@ -137,7 +137,7 @@ public class ArmoredInputStream
     boolean        start = true;
     int[]          outBuf = new int[3];
     int            bufPtr = 3;
-    CRC24          crc = new CRC24();
+    CRC24          crc = CRC24.getInstance();
     boolean        crcFound = false;
     boolean        hasHeaders = true;
     String         header = null;

--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
@@ -89,7 +89,7 @@ public class ArmoredOutputStream
     OutputStream    out;
     int[]           buf = new int[3];
     int             bufPtr = 0;
-    CRC24           crc = new CRC24();
+    CRC24           crc = CRC24.getInstance();
     int             chunkCount = 0;
     int             lastb;
 

--- a/pg/src/main/java/org/bouncycastle/bcpg/CRC24.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/CRC24.java
@@ -1,37 +1,146 @@
 package org.bouncycastle.bcpg;
 
-public class CRC24
+public abstract class CRC24
 {
+    private static boolean USE_FAST_IMPLEMENTATION = false;
+
     private static final int CRC24_INIT = 0x0b704ce;
     private static final int CRC24_POLY = 0x1864cfb;
-                                                                                
-    private int crc = CRC24_INIT;
-                                                                                
-    public CRC24()
-    {
-    }
 
-    public void update(
-        int b)
-    {
-        crc ^= b << 16;
-        for (int i = 0; i < 8; i++)
-        {
-            crc <<= 1;
-            if ((crc & 0x1000000) != 0)
-            {
-                crc ^= CRC24_POLY;
-            }
+    public abstract void update(int b);
+
+    public abstract int getValue();
+
+    public abstract void reset();
+
+    /**
+     * Return an instance of the {@link CRC24} class.
+     * If {@link #USE_FAST_IMPLEMENTATION} is set (see {@link #setUseFastImplementation(boolean)}), then a fast
+     * implementation (see {@link #fastCRC24()}) is returned, otherwise the method returns a conventional,
+     * but slower implementation (see {@link #iterativeCRC24()}).
+     *
+     * @return CRC-24 instance
+     */
+    public static CRC24 getInstance() {
+        if (USE_FAST_IMPLEMENTATION) {
+            return fastCRC24();
+        } else {
+            return iterativeCRC24();
         }
     }
 
-    public int getValue()
-    {
-        return crc;
+    /**
+     * Specify, whether to use the fast CRC-24 implementation.
+     * If set to true, {@link #getInstance()} will return the fast implementation, otherwise it will return the
+     * slow, but conventional iterative implementation.
+     *
+     * @param useFastImplementation use fast implementation
+     */
+    public static void setUseFastImplementation(boolean useFastImplementation) {
+        USE_FAST_IMPLEMENTATION = useFastImplementation;
     }
 
-    public void reset()
-    {
-        crc = CRC24_INIT;
+    /**
+     * Default, iterative CRC-24 implementation as described in RFC4880.
+     * This implementation mimics the use of a feedback shift register in software.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc4880#section-6.1">
+     *     RFC4880 §6.1. An Implementation of the CRC-24 in "C"</a>
+     *
+     * @return default CRC-24 implementation
+     */
+    public static CRC24 iterativeCRC24() {
+
+        return new CRC24() {
+
+            private int crc = CRC24_INIT;
+
+            @Override
+            public void update(
+                    int b)
+            {
+                crc ^= b << 16;
+                for (int i = 0; i < 8; i++)
+                {
+                    crc <<= 1;
+                    if ((crc & 0x1000000) != 0)
+                    {
+                        crc ^= CRC24_POLY;
+                    }
+                }
+            }
+
+            @Override
+            public int getValue()
+            {
+                return crc;
+            }
+
+            @Override
+            public void reset()
+            {
+                crc = CRC24_INIT;
+            }
+        };
     }
+
+    private static int[] TABLE = null;
+
+    /**
+     * Fast CRC-24 implementation using a lookup table to handle multiple bits at a time.
+     *
+     * Compare: Sarwate, Dilip V. "Computation of cyclic redundancy checks via table look-up."
+     * @return fast implementation
+     */
+    public static CRC24 fastCRC24() {
+        return new CRC24() {
+            private int crc = CRC24_INIT;
+
+            @Override
+            public void update(int b) {
+                // b^(crc>>16) mod 256
+                int index = (b ^ (crc >> 16)) & ~-256;
+                crc = (crc << 8) ^ getTable()[index];
+            }
+
+            @Override
+            public int getValue() {
+                return crc & 0xFFFFFF;
+            }
+
+            @Override
+            public void reset() {
+                crc = CRC24_INIT;
+            }
+        };
+    }
+
+    /**
+     * Lazily init and return the lookup table.
+     *
+     * @return lookup table
+     */
+    private static synchronized int[] getTable() {
+        if (TABLE != null) {
+            return TABLE;
+        }
+
+        TABLE = new int[256];
+        int crc = 0x800000;
+        int i = 1;
+        while (i != 256) {
+            if ((crc & 0x800000) > 0) {
+                crc = (crc << 1) ^ CRC24_POLY;
+            } else {
+                crc <<= 1;
+            }
+
+            for (int j = 0; j < i; j++) {
+                TABLE[i + j] = crc ^ TABLE[j];
+            }
+            i <<= 1;
+        }
+        return TABLE;
+    }
+
 }

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/CRC24Test.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/CRC24Test.java
@@ -1,0 +1,97 @@
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.CRC24;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.test.SimpleTest;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Random;
+
+public class CRC24Test extends SimpleTest {
+
+    private static final byte[] TEST_VECTOR_1 = "Hello, World!\n".getBytes();
+    private static final byte[] TEST_VECTOR_2 = new byte[256];
+    private static final byte[] LARGE_RANDOM = new byte[209715200]; // 200 MB
+
+    static {
+        Arrays.fill(TEST_VECTOR_2, 0, TEST_VECTOR_2.length - 1, (byte) 12);
+        new Random().nextBytes(LARGE_RANDOM);
+    }
+
+    public static void main(String[] args) {
+        runTest(new CRC24Test());
+    }
+
+    @Override
+    public String getName() {
+        return CRC24Test.class.getSimpleName();
+    }
+
+    @Override
+    public void performTest() throws Exception {
+        testDefaultImpl();
+        testFastImpl();
+
+        // performanceTest();
+    }
+
+    public void testDefaultImpl() {
+        CRC24 crc = CRC24.iterativeCRC24();
+        testCrcImplementationAgainstTestVectors(crc);
+    }
+
+    public void testFastImpl() {
+        CRC24 crc = CRC24.fastCRC24();
+        testCrcImplementationAgainstTestVectors(crc);
+    }
+
+    private void testCrcImplementationAgainstTestVectors(CRC24 crc) {
+        isEquals("CRC implementation has wrong initial value", 0x0b704ce, crc.getValue());
+
+        crc.reset();
+        isEquals("CRC implementation reset to wrong value", 0x0b704ce, crc.getValue());
+
+        crc.reset();
+        for (byte b : TEST_VECTOR_1) {
+            crc.update(b);
+        }
+        isEquals("Wrong CRC sum calculated", 0x71cee5, crc.getValue());
+
+        crc.reset();
+        for (byte b : TEST_VECTOR_2) {
+            crc.update(b);
+        }
+        isEquals("Wrong CRC sum calculated", 0x1938a3, crc.getValue());
+    }
+
+    public void performanceTest() {
+        CRC24 defaultImpl = CRC24.iterativeCRC24();
+
+        CRC24 fastImpl = CRC24.fastCRC24();
+        // "Warm up" to initialize lookup table
+        fastImpl.update(0);
+        fastImpl.reset();
+
+        Instant start = Instant.now();
+        for (byte b : LARGE_RANDOM) {
+            defaultImpl.update(b);
+        }
+        int defVal = defaultImpl.getValue();
+        Instant afterDefault = Instant.now();
+
+        for (byte b : LARGE_RANDOM) {
+            fastImpl.update(b);
+        }
+        int fastVal = fastImpl.getValue();
+        Instant afterFast = Instant.now();
+
+        isEquals("Calculated value of default and fast CRC-24 implementations diverges", defVal, fastVal);
+        Duration defDuration = Duration.between(start, afterDefault);
+        System.out.println("Default Implementation: " + defDuration.getSeconds() + "s" + defDuration.getNano());
+
+        Duration fastDuration = Duration.between(afterDefault, afterFast);
+        System.out.println("Fast Implementation: " + fastDuration.getSeconds() + "s" + fastDuration.getNano());
+
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
@@ -47,7 +47,8 @@ public class RegressionTest
         new PolicyURITest(),
         new ArmoredOutputStreamUTF8Test(),
         new UnrecognizableSubkeyParserTest(),
-        new IgnoreUnknownEncryptedSessionKeys()
+        new IgnoreUnknownEncryptedSessionKeys(),
+        new CRC24Test()
     };
 
     public static void main(String[] args)


### PR DESCRIPTION
The default CRC-24 implementation follows RFC4880, which proposes the use of
an iterative algorithm. Mimicking a feedback shift register in software is inefficient.

In 'Computation of Cyclic Redundancy Checks via Table Look-Up'
Dilip V. Sarwate proposes the use of lookup tables to speed up computation.

This PR implements such table lookup.
By calling CRC24.setUseFastImplementation(true), the user can choose to
use the fast implementation instead of the traditional one.

The fast algorithm can process 200mb of data in 3.6 seconds, compared to the iterative one which takes 4.9 seconds for the same data.