### PR TITLE
fpe num to/from str base conversion speed up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 }
 
 plugins {
+  id "application"
   id "io.spring.nohttp" version "0.0.8"
   id "checkstyle"
   id "jacoco"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'application'
+
+dependencies {
+    implementation group: 'org.openjdk.jmh', name: 'jmh-core', version: '1.33'
+    annotationProcessor group: 'org.openjdk.jmh', name: 'jmh-generator-annprocess', version: '1.33'
+}
+application {
+    mainClass.set("org.bouncycastle.crypto.fpe.SP80038GMicroBenchmark")
+}

--- a/core/src/main/java/org/bouncycastle/crypto/fpe/FPEFF1Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/fpe/FPEFF1Engine.java
@@ -12,6 +12,7 @@ import org.bouncycastle.util.Properties;
 public class FPEFF1Engine
     extends FPEEngine
 {
+
     /**
      * Base constructor - the engine will use AES.
      */
@@ -61,11 +62,11 @@ public class FPEFF1Engine
 
         if (fpeParameters.getRadix() > 256)
         {
-            enc = toByteArray(SP80038G.encryptFF1w(baseCipher, fpeParameters.getRadix(), fpeParameters.getTweak(), toShortArray(inBuf), inOff, length / 2));
+            enc = toByteArray(SP80038G.encryptFF1w(baseCipher, fpeParameters.getRadixConverter(), fpeParameters.getTweak(), toShortArray(inBuf), inOff, length / 2));
         }
         else
         {
-            enc = SP80038G.encryptFF1(baseCipher, fpeParameters.getRadix(), fpeParameters.getTweak(), inBuf, inOff, length);
+            enc = SP80038G.encryptFF1(baseCipher, fpeParameters.getRadixConverter(), fpeParameters.getTweak(), inBuf, inOff, length);
         }
 
         System.arraycopy(enc, 0, outBuf, outOff, length);
@@ -79,11 +80,11 @@ public class FPEFF1Engine
 
         if (fpeParameters.getRadix() > 256)
         {
-            dec = toByteArray(SP80038G.decryptFF1w(baseCipher, fpeParameters.getRadix(), fpeParameters.getTweak(), toShortArray(inBuf), inOff, length / 2));
+            dec = toByteArray(SP80038G.decryptFF1w(baseCipher, fpeParameters.getRadixConverter(), fpeParameters.getTweak(), toShortArray(inBuf), inOff, length / 2));
         }
         else
         {
-            dec = SP80038G.decryptFF1(baseCipher, fpeParameters.getRadix(), fpeParameters.getTweak(), inBuf, inOff, length);
+            dec = SP80038G.decryptFF1(baseCipher, fpeParameters.getRadixConverter(), fpeParameters.getTweak(), inBuf, inOff, length);
         }
 
         System.arraycopy(dec, 0, outBuf, outOff, length);

--- a/core/src/main/java/org/bouncycastle/crypto/fpe/FPEFF3_1Engine.java
+++ b/core/src/main/java/org/bouncycastle/crypto/fpe/FPEFF3_1Engine.java
@@ -14,6 +14,7 @@ import org.bouncycastle.util.Properties;
 public class FPEFF3_1Engine
     extends FPEEngine
 {
+
     /**
      * Base constructor - the engine will use AES.
      */
@@ -67,11 +68,11 @@ public class FPEFF3_1Engine
 
         if (fpeParameters.getRadix() > 256)
         {
-            enc = toByteArray(SP80038G.encryptFF3_1w(baseCipher, fpeParameters.getRadix(), fpeParameters.getTweak(), toShortArray(inBuf), inOff, length / 2));
+            enc = toByteArray(SP80038G.encryptFF3_1w(baseCipher, fpeParameters.getRadixConverter(), fpeParameters.getTweak(), toShortArray(inBuf), inOff, length / 2));
         }
         else
         {
-            enc = SP80038G.encryptFF3_1(baseCipher, fpeParameters.getRadix(), fpeParameters.getTweak(), inBuf, inOff, length);
+            enc = SP80038G.encryptFF3_1(baseCipher, fpeParameters.getRadixConverter(), fpeParameters.getTweak(), inBuf, inOff, length);
         }
 
         System.arraycopy(enc, 0, outBuf, outOff, length);
@@ -85,11 +86,11 @@ public class FPEFF3_1Engine
 
         if (fpeParameters.getRadix() > 256)
         {
-            dec = toByteArray(SP80038G.decryptFF3_1w(baseCipher, fpeParameters.getRadix(), fpeParameters.getTweak(), toShortArray(inBuf), inOff, length / 2));
+            dec = toByteArray(SP80038G.decryptFF3_1w(baseCipher, fpeParameters.getRadixConverter(), fpeParameters.getTweak(), toShortArray(inBuf), inOff, length / 2));
         }
         else
         {
-            dec = SP80038G.decryptFF3_1(baseCipher, fpeParameters.getRadix(), fpeParameters.getTweak(), inBuf, inOff, length);
+            dec = SP80038G.decryptFF3_1(baseCipher, fpeParameters.getRadixConverter(), fpeParameters.getTweak(), inBuf, inOff, length);
         }
 
         System.arraycopy(dec, 0, outBuf, outOff, length);

--- a/core/src/main/java/org/bouncycastle/crypto/fpe/RadixConverter.java
+++ b/core/src/main/java/org/bouncycastle/crypto/fpe/RadixConverter.java
@@ -1,0 +1,183 @@
+package org.bouncycastle.crypto.fpe;
+
+import java.math.BigInteger;
+
+/**
+ * Utility class to convert decimal numbers (BigInteger) into a number in the base provided and the other way round.
+ */
+public class RadixConverter
+{
+
+    /*
+    The conversions in this class are more complex than the standard ways of converting between basis because we want to improve the performance by limiting the
+    operations on BigInteger which are not very efficient.
+    The general idea is to perform math operations on primitive long as much as we can and just work with BigInteger when necessary.
+    Converting between basis uses the fact that a number in base 'B' have a unique representation in polynomial form.
+
+    num = ... + r8B^8 + r7B^7 + r6B^6 + r5B^5 + r4B^4 + r3B^3 + r2B^2 + r1B + r0
+
+    We can compute how many digits in base 'B' can fit in a long. For example, for a radix R=2^16 the number of digits 'n' that we can fit into a long is the
+    max 'n' that still satisfies: R^n < Long.MAX_VALUE (i.e. 2^63 -1). In this case 'n' is 3. To convert 'num' from its decimal representation to base 'B'
+    representation we can write down 'num' in a polynomial form of B^3:
+
+    num = (((...)B^3 + r8B^2 + r7B + r6)B^3 + r5B^2 + r4B + r3)B^3 + (r2B^2 + r1B + r0)
+
+    B^3 would be our intermediate base. We can convert numbers in base B^3 while operating on primitive long.
+    To convert a decimal num to its representation in base B we can first build its B^3 representation and then figure out the digits in base B from the single
+    digit in base B^3. num % B^3 gives us a single digit in base B^3 which corresponds to a group of 3 digits in base B.
+
+    An equivalent way of writing the polynomial form of num would be:
+
+    num = (...)B^9 + (r8B^8 + r7B^7 + r6B^6)B^6 + (r5B^5 + r4B^4 + r3)B^3 + (r2B^2 + r1B + r0)
+
+    In this form it becomes clear that to obtain 'num' from a sequence of digits, one can group the digits in group of 3 and compute the corresponding decimal
+    number for the group in base B. We can then multiply the decimal numbers by the corresponding power of B^3 and sum up the result to obtain the decimal
+    representation of num in base B,
+     */
+    private static final double LOG_LONG_MAX_VALUE = Math.log(Long.MAX_VALUE);
+    private static final int DEFAULT_POWERS_TO_CACHE = 10;
+    // the max number of digits in base 'radix' that fits in a long
+    private final int digitsGroupLength;
+    // the total number of digits combination in a group. radix ^ digitsGroupLength
+    private final BigInteger digitsGroupSpaceSize;
+    private final int radix;
+    private final BigInteger[] digitsGroupSpacePowers;
+
+    /**
+     * @param radix                the radix to use for base conversions
+     * @param numberOfCachedPowers number of intermediate base powers to precompute and cache.
+     */
+    public RadixConverter(int radix, int numberOfCachedPowers)
+    {
+        this.radix = radix;
+        // solves radix^n < Long.MAX_VALUE to find n (maxDigitsFitsInLong)
+        this.digitsGroupLength = (int) Math.floor(LOG_LONG_MAX_VALUE / Math.log(radix));
+        this.digitsGroupSpaceSize = BigInteger.valueOf(radix).pow(digitsGroupLength);
+        this.digitsGroupSpacePowers = precomputeDigitsGroupPowers(numberOfCachedPowers, digitsGroupSpaceSize);
+    }
+
+    /**
+     * @param radix the radix to use for base conversions.
+     */
+    public RadixConverter(int radix)
+    {
+        this(radix, DEFAULT_POWERS_TO_CACHE);
+    }
+
+    public int getRadix()
+    {
+        return radix;
+    }
+
+    public void str(BigInteger number, int messageLength, short[] out)
+    {
+        if (number.signum() < 0)
+        {
+            throw new IllegalArgumentException();
+        }
+        // convert number into its representation in base 'radix'.
+        // writes leading '0' if the messageLength is greater than the number of digits required to encode in base 'radix'
+        int digitIndex = messageLength - 1;
+        do
+        {
+            if (number.equals(BigInteger.ZERO))
+            {
+                out[digitIndex--] = 0;
+                continue;
+            }
+            BigInteger[] quotientAndRemainder = number.divideAndRemainder(digitsGroupSpaceSize);
+            number = quotientAndRemainder[0];
+            digitIndex = str(quotientAndRemainder[1].longValue(), digitIndex, out);
+        } while (digitIndex >= 0);
+        if (number.signum() != 0)
+        {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private int str(long number, int digitIndex, short[] out)
+    {
+        for (int i = 0; i < digitsGroupLength && digitIndex >= 0; i++)
+        {
+            if (number == 0)
+            {
+                out[digitIndex--] = 0;
+                continue;
+            }
+            out[digitIndex--] = (short) (number % radix);
+            number = number / radix;
+        }
+        if (number != 0)
+        {
+            throw new IllegalStateException("Failed to convert decimal number");
+        }
+        return digitIndex;
+    }
+
+    public BigInteger num(short[] digits)
+    {
+        // from a sequence of digits in base 'radix' to a decimal number
+        // iterate through groups of digits right to left
+        // digitsGroupLength = 2;  digits: [22, 45, 11, 31, 24]
+        // groups are, in order of iteration: [31, 24], [45, 11], [22]
+        BigInteger currentGroupCardinality = BigInteger.ONE;
+        BigInteger res = null;
+        int indexGroup = 0;
+        int numberOfDigits = digits.length;
+        for (int groupStartDigitIndex = numberOfDigits - digitsGroupLength;
+                groupStartDigitIndex > -digitsGroupLength;
+                groupStartDigitIndex = groupStartDigitIndex - digitsGroupLength)
+        {
+            int actualDigitsInGroup = digitsGroupLength;
+            if (groupStartDigitIndex < 0)
+            {
+                // last group might contain fewer digits so adjust offsets
+                actualDigitsInGroup = digitsGroupLength + groupStartDigitIndex;
+                groupStartDigitIndex = 0;
+            }
+            int groupEndDigitIndex = Math.min(groupStartDigitIndex + actualDigitsInGroup, numberOfDigits);
+            long groupInBaseRadix = num(groupStartDigitIndex, groupEndDigitIndex, digits);
+            BigInteger bigInteger = BigInteger.valueOf(groupInBaseRadix);
+            if (indexGroup == 0)
+            {
+                res = bigInteger;
+            } else
+            {
+                currentGroupCardinality =
+                        indexGroup <= digitsGroupSpacePowers.length
+                                ? digitsGroupSpacePowers[indexGroup - 1]
+                                : currentGroupCardinality.multiply(digitsGroupSpaceSize);
+                res = res.add(bigInteger.multiply(currentGroupCardinality));
+            }
+            indexGroup++;
+        }
+        return res;
+    }
+
+    public int getDigitsGroupLength()
+    {
+        return digitsGroupLength;
+    }
+
+    private long num(int groupStartDigitIndex, int groupEndDigitIndex, short[] digits)
+    {
+        long decimalNumber = 0;
+        for (int digitIndex = groupStartDigitIndex; digitIndex < groupEndDigitIndex; digitIndex++)
+        {
+            decimalNumber = (decimalNumber * radix) + (digits[digitIndex] & 0xFFFF);
+        }
+        return decimalNumber;
+    }
+
+    private BigInteger[] precomputeDigitsGroupPowers(int numberOfCachedPowers, BigInteger digitsGroupSpaceSize)
+    {
+        BigInteger[] cachedPowers = new BigInteger[numberOfCachedPowers];
+        BigInteger currentPower = digitsGroupSpaceSize;
+        for (int i = 0; i < numberOfCachedPowers; i++)
+        {
+            cachedPowers[i] = currentPower;
+            currentPower = currentPower.multiply(digitsGroupSpaceSize);
+        }
+        return cachedPowers;
+    }
+}

--- a/core/src/main/java/org/bouncycastle/crypto/fpe/SP80038GMicroBenchmark.java
+++ b/core/src/main/java/org/bouncycastle/crypto/fpe/SP80038GMicroBenchmark.java
@@ -1,0 +1,131 @@
+package org.bouncycastle.crypto.fpe;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.bouncycastle.crypto.fpe.FPEEngine;
+import org.bouncycastle.crypto.fpe.FPEFF1Engine;
+import org.bouncycastle.crypto.params.FPEParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.util.encoders.Hex;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode({Mode.AverageTime})
+// Run a performance benchmark with JMH https://www.baeldung.com/java-microbenchmark-harness
+// The benchmark measure the avg time it takes to encrypt 100 plain texts
+// The benchmark has parameters:
+// - plainTextDigits: the number of digits (in the alphabet defined by 'radix') in the plain text
+// - radix: the radix to use
+// 100 plain texts are randomly generated (with fixed seed) during benchmark setup. Each benchmark invocation
+// encrypt the 100 texts.
+public class SP80038GMicroBenchmark
+{
+
+    private static final Random RANDOM = new Random(123);
+    private static final int NUMBER_OF_TEXTS = 100;
+
+    public static void main(String[] args) throws RunnerException
+    {
+        new Runner(new OptionsBuilder()
+                .jvmArgs("-Xmx4096m", "-Xms4096m")
+                .build()).run();
+    }
+
+    @Benchmark
+    public void encrypt(State state, Blackhole blackhole)
+    {
+        for (int i = 0; i < NUMBER_OF_TEXTS; i++)
+        {
+            byte[] plainText = state.plainTexts.get(i);
+            blackhole.consume(state.encEngine.processBlock(plainText, 0, plainText.length, state.encs.get(i), 0));
+        }
+    }
+
+    @org.openjdk.jmh.annotations.State(Scope.Benchmark)
+    public static class State
+    {
+
+        @Param({"5", "20", "50", "100"})
+        private String plainTextDigits;
+        @Param({"127", "1024", "3011"})
+        private String radix;
+        private FPEEngine encEngine;
+        private List<byte[]> plainTexts;
+        private List<byte[]> encs;
+        private final byte[] key = Hex.decode("EF4359D8D580AA4F7F036D6F04FC6A942B7E151628AED2A6");
+        private final byte[] tweak = Hex.decode("39383736353433323130");
+
+        @Setup(Level.Trial)
+        public void setUp()
+        {
+            int numberOfDigits = Integer.parseInt(plainTextDigits);
+            int r = Integer.parseInt(radix);
+            plainTexts = generateTexts(numberOfDigits, r);
+            encEngine = new FPEFF1Engine();
+            encEngine.init(true, new FPEParameters(new KeyParameter(key), r, tweak));
+            encs = generateBuffersForOutput(numberOfDigits, r);
+        }
+
+        private List<byte[]> generateBuffersForOutput(int numberOfDigits, int radix)
+        {
+            ArrayList<byte[]> outs = new ArrayList<byte[]>();
+            for (int i = 0; i < NUMBER_OF_TEXTS; i++)
+            {
+                outs.add(radix <= 256 ? new byte[numberOfDigits] : new byte[numberOfDigits * 2]);
+            }
+            return outs;
+        }
+
+        private List<byte[]> generateTexts(int numberOfDigits, int radix)
+        {
+            List<byte[]> res = new ArrayList<byte[]>();
+            for (int i = 0; i < NUMBER_OF_TEXTS; i++)
+            {
+                res.add(generateText(numberOfDigits, radix));
+            }
+            return res;
+        }
+
+        private byte[] generateText(int numberOfDigits, int radix)
+        {
+            if (radix <= 256)
+            {
+                byte[] bytes = new byte[numberOfDigits];
+                for (int i = 0; i < bytes.length; i++)
+                {
+                    bytes[i] = (byte) RANDOM.nextInt(radix);
+                }
+                return bytes;
+            } else
+            {
+                byte[] bytes = new byte[numberOfDigits * 2];
+                for (int i = 0; i < numberOfDigits; i++)
+                {
+                    int v = RANDOM.nextInt(radix);
+                    bytes[i * 2] = (byte) (v >>> 8);
+                    bytes[(i * 2) + 1] = (byte) (v);
+                }
+                return bytes;
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/bouncycastle/crypto/params/FPEParameters.java
+++ b/core/src/main/java/org/bouncycastle/crypto/params/FPEParameters.java
@@ -1,13 +1,14 @@
 package org.bouncycastle.crypto.params;
 
 import org.bouncycastle.crypto.CipherParameters;
+import org.bouncycastle.crypto.fpe.RadixConverter;
 import org.bouncycastle.util.Arrays;
 
 public final class FPEParameters
     implements CipherParameters
 {
     private final KeyParameter key;
-    private final int radix;
+    private final RadixConverter radixConverter;
     private final byte[] tweak;
     private final boolean useInverse;
 
@@ -18,8 +19,13 @@ public final class FPEParameters
 
     public FPEParameters(KeyParameter key, int radix, byte[] tweak, boolean useInverse)
     {
+        this(key, new RadixConverter(radix), tweak, useInverse);
+    }
+
+    public FPEParameters(KeyParameter key, RadixConverter radixConverter, byte[] tweak, boolean useInverse)
+    {
         this.key = key;
-        this.radix = radix;
+        this.radixConverter = radixConverter;
         this.tweak = Arrays.clone(tweak);
         this.useInverse = useInverse;
     }
@@ -31,7 +37,12 @@ public final class FPEParameters
 
     public int getRadix()
     {
-        return radix;
+        return radixConverter.getRadix();
+    }
+
+    public RadixConverter getRadixConverter()
+    {
+        return radixConverter;
     }
 
     public byte[] getTweak()

--- a/core/src/test/java/org/bouncycastle/crypto/test/RadixConverterTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/RadixConverterTest.java
@@ -1,0 +1,311 @@
+package org.bouncycastle.crypto.test;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import org.bouncycastle.crypto.fpe.RadixConverter;
+import org.bouncycastle.util.test.SimpleTest;
+
+public class RadixConverterTest extends SimpleTest
+{
+
+    public void performTest() throws Exception
+    {
+        testBaseConversionSingleDigit();
+        testBaseConversionLeadingZeros();
+        testBaseConversionMultipleDigitsInRadixRepresentation();
+        testBaseConversionDecimalNumberLargerThanMaxLong();
+        testBaseConversionLargeDecimalNumberLeadingZerosInDigitGroup();
+        testBaseConversionLargeDecimalNumberGroupWithAllZeros();
+        testBaseConversionZero();
+        testBaseConversionNoPowersCached();
+        testBaseConversionSomePowersCached();
+    }
+
+    void testBaseConversionSingleDigit()
+    {
+        RadixConversionArgument arg =
+                RadixConversionArgument.builder().setRadix(33).setNumberOfDigits(1).setDecimalNumber(new BigInteger("3")).setDigits(new short[]{3}).build();
+        runTest(arg, new RadixConverter(arg.getRadix()));
+    }
+
+    void testBaseConversionLeadingZeros()
+    {
+        RadixConversionArgument arg =
+                RadixConversionArgument.builder()
+                        .setRadix(33)
+                        .setNumberOfDigits(3)
+                        .setDecimalNumber(new BigInteger("3"))
+                        .setDigits(new short[]{0, 0, 3})
+                        .build();
+        runTest(arg, new RadixConverter(arg.getRadix()));
+    }
+
+    void testBaseConversionMultipleDigitsInRadixRepresentation()
+    {
+        int radix = 33;
+        RadixConversionArgument arg =
+                RadixConversionArgument.builder()
+                        .setRadix(radix)
+                        .setNumberOfDigits(3)
+                        .setDecimalNumber(decimalInPolynomialForm(radix, 1, 0))
+                        .setDigits(new short[]{0, 1, 0})
+                        .build();
+        runTest(arg, new RadixConverter(arg.getRadix()));
+
+        arg =
+                RadixConversionArgument.builder()
+                        .setRadix(radix)
+                        .setNumberOfDigits(3)
+                        .setDecimalNumber(decimalInPolynomialForm(radix, 1, 1))
+                        .setDigits(new short[]{0, 1, 1})
+                        .build();
+        runTest(arg, new RadixConverter(arg.getRadix()));
+
+        arg =
+                RadixConversionArgument.builder()
+                        .setRadix(radix)
+                        .setNumberOfDigits(3)
+                        .setDecimalNumber(decimalInPolynomialForm(radix, 22, 13, 4))
+                        .setDigits(new short[]{22, 13, 4})
+                        .build();
+        runTest(arg, new RadixConverter(arg.getRadix()));
+    }
+
+    void testBaseConversionDecimalNumberLargerThanMaxLong()
+    {
+        // 7 digits in base 251 is the max number that fits in a long
+        int radix = 251;
+        RadixConversionArgument arg =
+                RadixConversionArgument.builder()
+                        .setRadix(radix)
+                        .setNumberOfDigits(21)
+                        .setDecimalNumber(decimalInPolynomialForm(radix, 234, 33, 0, 45, 125, 98, 12, 34, 100, 77, 211, 9, 3, 123, 96, 55, 23, 44, 98))
+                        // two leading zero because we are asking a message length 21 when the number can be encoded in 19 bytes
+                        .setDigits(new short[]{0, 0, 234, 33, 0, 45, 125, 98, 12, 34, 100, 77, 211, 9, 3, 123, 96, 55, 23, 44, 98})
+                        .build();
+        RadixConverter radixConverter = new RadixConverter(arg.getRadix());
+        checkAtLeastNDigitGroupsForTestCase(3, arg, radixConverter);
+        runTest(arg, radixConverter);
+    }
+
+    void testBaseConversionLargeDecimalNumberLeadingZerosInDigitGroup()
+    {
+        // 7 digits in base 251 is the max number that fits in a long
+        int radix = 251;
+        RadixConversionArgument arg =
+                RadixConversionArgument.builder()
+                        .setRadix(radix)
+                        .setNumberOfDigits(19)
+                        .setDecimalNumber(decimalInPolynomialForm(radix, 234, 33, 2, 45, 125, 0, 12, 34, 100, 77, 211, 9, 0, 0, 96, 55, 23, 44, 98))
+                        .setDigits(new short[]{234, 33, 2, 45, 125, 0, 12, 34, 100, 77, 211, 9, 0, 0, 96, 55, 23, 44, 98})
+                        .build();
+        RadixConverter radixConverter = new RadixConverter(arg.getRadix());
+        checkAtLeastNDigitGroupsForTestCase(3, arg, radixConverter);
+        runTest(arg, radixConverter);
+    }
+
+    void testBaseConversionLargeDecimalNumberGroupWithAllZeros()
+    {
+        // 7 digits in base 251 is the max number that fits in a long
+        int radix = 251;
+        BigInteger decimalNumber = decimalInPolynomialForm(radix, 125, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        RadixConversionArgument arg =
+                RadixConversionArgument.builder()
+                        .setRadix(radix)
+                        .setNumberOfDigits(17)
+                        .setDecimalNumber(decimalNumber)
+                        // two leading zeros because message length is 17 but number is encoded in 15 bytes
+                        .setDigits(new short[]{0, 0, 125, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+                        .build();
+        RadixConverter radixConverter = new RadixConverter(arg.getRadix());
+        checkAtLeastNDigitGroupsForTestCase(3, arg, radixConverter);
+        runTest(arg, radixConverter);
+    }
+
+    void testBaseConversionZero()
+    {
+        // 7 digits in base 251 is the max number that fits in a long
+        int radix = 251;
+        RadixConversionArgument arg =
+                RadixConversionArgument.builder()
+                        .setRadix(radix)
+                        .setNumberOfDigits(9)
+                        .setDecimalNumber(BigInteger.ZERO)
+                        .setDigits(new short[]{0, 0, 0, 0, 0, 0, 0, 0, 0})
+                        .build();
+        RadixConverter radixConverter = new RadixConverter(arg.getRadix());
+        checkAtLeastNDigitGroupsForTestCase(2, arg, radixConverter);
+        runTest(arg, radixConverter);
+    }
+
+    void testBaseConversionNoPowersCached()
+    {
+        // 7 digits in base 251 is the max number that fits in a long
+        int radix = 251;
+        RadixConversionArgument arg =
+                RadixConversionArgument.builder()
+                        .setRadix(radix)
+                        .setNumberOfDigits(15)
+                        .setDecimalNumber(decimalInPolynomialForm(radix, 6, 200, 78, 9, 53, 90, 178, 213, 154, 65, 127, 99, 22, 13, 4))
+                        .setDigits(new short[]{6, 200, 78, 9, 53, 90, 178, 213, 154, 65, 127, 99, 22, 13, 4})
+                        .build();
+        RadixConverter radixConverter = new RadixConverter(arg.getRadix(), 0);
+        checkAtLeastNDigitGroupsForTestCase(3, arg, radixConverter);
+        runTest(arg, radixConverter);
+    }
+
+    void testBaseConversionSomePowersCached()
+    {
+        // 4 digits in base 32000 is the max number that fits in a long
+        int radix = 32000;
+        RadixConversionArgument arg =
+                RadixConversionArgument.builder()
+                        .setRadix(radix)
+                        .setNumberOfDigits(19)
+                        .setDecimalNumber(decimalInPolynomialForm(radix, 2756, 1111, 965, 0, 6, 200, 78, 9, 53, 90, 178, 213, 154, 65, 127, 99, 22, 13, 4))
+                        .setDigits(new short[]{2756, 1111, 965, 0, 6, 200, 78, 9, 53, 90, 178, 213, 154, 65, 127, 99, 22, 13, 4})
+                        .build();
+        // 2 powers cached - radix^4, (radix^4)^2
+        RadixConverter radixConverter = new RadixConverter(arg.getRadix(), 2);
+        checkAtLeastNDigitGroupsForTestCase(5, arg, radixConverter);
+        runTest(arg, radixConverter);
+    }
+
+    private void runTest(RadixConversionArgument arg, RadixConverter radixConverter)
+    {
+        short[] digits = new short[arg.getDigits().length];
+        radixConverter.str(arg.getDecimalNumber(), arg.getNumberOfDigits(), digits);
+        isTrue(
+                String.format(
+                        "digits in base %d and expected digits are different.\nActual digits: [%s]\nExpected digits: [%s]",
+                        arg.getRadix(), arrayToString(digits), arrayToString(arg.getDigits())),
+                Arrays.equals(digits, arg.getDigits()));
+        BigInteger number = radixConverter.num(digits);
+        isEquals(String.format("%s and %s are different", number, arg.getDecimalNumber()), number, arg.getDecimalNumber());
+    }
+
+    private String arrayToString(short[] array)
+    {
+        StringBuilder sb = new StringBuilder(array.length);
+        for (short el : array)
+        {
+            sb.append(el).append(", ");
+        }
+        String str = sb.toString();
+        return str.length() == 0 ? str : str.substring(0, str.length() - 1);
+    }
+
+    private BigInteger decimalInPolynomialForm(int radix, int... coefficients)
+    {
+        BigInteger r = BigInteger.valueOf(radix);
+        BigInteger result = BigInteger.ZERO;
+        for (int i = 0; i < coefficients.length; i++)
+        {
+            int coefficient = coefficients[i];
+            int exponent = coefficients.length - i - 1;
+            result = result.add(BigInteger.valueOf(coefficient).multiply(r.pow(exponent)));
+        }
+        return result;
+    }
+
+    private void checkAtLeastNDigitGroupsForTestCase(int atLeastDigitGroups, RadixConversionArgument arg, RadixConverter radixConverter)
+    {
+        int groupLength = radixConverter.getDigitsGroupLength();
+        int minDigits = (groupLength * (atLeastDigitGroups - 1)) + 1;
+        isTrue(
+                String.format(
+                        "test case is for large numbers. The number must have at least %d digits so that at least %d digits groups of length %d are found in it. Found %d digits",
+                        minDigits, atLeastDigitGroups, groupLength, arg.getDigits().length),
+                arg.getDigits().length >= minDigits);
+    }
+
+    public String getName()
+    {
+        return "RadixConverterTest";
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new RadixConverterTest());
+    }
+
+    private static class RadixConversionArgument
+    {
+
+        private final BigInteger decimalNumber;
+        private final int radix;
+        private final int numberOfDigits;
+        private final short[] digits;
+
+        private RadixConversionArgument(BigInteger decimalNumber, int radix, int numberOfDigits, short[] digits)
+        {
+            this.decimalNumber = decimalNumber;
+            this.radix = radix;
+            this.numberOfDigits = numberOfDigits;
+            this.digits = digits;
+        }
+
+        public BigInteger getDecimalNumber()
+        {
+            return decimalNumber;
+        }
+
+        public int getRadix()
+        {
+            return radix;
+        }
+
+        public int getNumberOfDigits()
+        {
+            return numberOfDigits;
+        }
+
+        public short[] getDigits()
+        {
+            return digits;
+        }
+
+        static RadixConversionArgumentBuilder builder()
+        {
+            return new RadixConversionArgumentBuilder();
+        }
+
+        static class RadixConversionArgumentBuilder
+        {
+
+            private BigInteger decimalNumber;
+            private int radix;
+            private int numberOfDigits;
+            private short[] digits;
+
+            RadixConversionArgumentBuilder setDecimalNumber(BigInteger decimalNumber)
+            {
+                this.decimalNumber = decimalNumber;
+                return this;
+            }
+
+            RadixConversionArgumentBuilder setRadix(int radix)
+            {
+                this.radix = radix;
+                return this;
+            }
+
+            RadixConversionArgumentBuilder setNumberOfDigits(int numberOfDigits)
+            {
+                this.numberOfDigits = numberOfDigits;
+                return this;
+            }
+
+            RadixConversionArgumentBuilder setDigits(short[] digits)
+            {
+                this.digits = digits;
+                return this;
+            }
+
+            RadixConversionArgument build()
+            {
+                return new RadixConversionArgument(decimalNumber, radix, numberOfDigits, digits);
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/bouncycastle/crypto/test/RegressionTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/RegressionTest.java
@@ -182,7 +182,8 @@ public class RegressionTest
             new SP80038GTest(),
             new TupleHashTest(),
             new ParallelHashTest(),
-            new CryptoServiceConstraintsTest()
+            new CryptoServiceConstraintsTest(),
+            new RadixConverterTest()
         };
 
     public static void main(String[] args)


### PR DESCRIPTION
With this pr I have changed the way conversions from decimal numbers (BigInteger) to numbers in base B (determined by a radix), and the other way round, are done in the class `SP80038G`.
The main idea is to perform math operations that occurs in base conversions (e.g. multiplication and division) on primitive longs rather than BigInteger because working on BigInteger is slower. The `RadixConverter` class explains it in details.
`RadixConverter` is used by `SP80038G` to perform the conversions. `RadixConverter` is instantiated once per fpe engine or it can be passed in as parameter, which allows the clients to instantiate an object and reuse it, therefore computing some properties only once.

The first commit introduces a benchmark in JMH that can be run to measure the performance of encryption. The commit is the first in this pr so that code can be checked out at that point to run the same benchmark without the changes in the PR. Ultimately, the benhcmark commit can be dropped before merging.

`./gradlew assemble -x test` generates the zip `core/build/distributions/core-1.70.zip` which can be unzipped and run to run the benchmark `./core-1.70/bin/core`

I ran the benchmark on a AWS `m5.2xlarge` instance and I got the results below (the benchmark score is the average time, in microseconds, it takes to encrypt 100 plainTexts). The benchmark has been run with different combinations of radix values and plainText lengths.

Results from master:
```
Benchmark                       (plainTextDigits)  (radix)  Mode  Cnt      Score    Error  Units
SP80038GMicroBenchmark.encrypt                  5      127  avgt    5    851.661 ±  0.567  us/op
SP80038GMicroBenchmark.encrypt                  5     1024  avgt    5    837.038 ±  1.123  us/op
SP80038GMicroBenchmark.encrypt                  5     3011  avgt    5    943.997 ±  0.738  us/op
SP80038GMicroBenchmark.encrypt                 20      127  avgt    5   2629.730 ±  1.836  us/op
SP80038GMicroBenchmark.encrypt                 20     1024  avgt    5   2816.844 ±  2.180  us/op
SP80038GMicroBenchmark.encrypt                 20     3011  avgt    5   3062.641 ±  4.685  us/op
SP80038GMicroBenchmark.encrypt                 50      127  avgt    5   6920.426 ± 10.851  us/op
SP80038GMicroBenchmark.encrypt                 50     1024  avgt    5   7410.721 ±  2.398  us/op
SP80038GMicroBenchmark.encrypt                 50     3011  avgt    5   7969.456 ±  8.036  us/op
SP80038GMicroBenchmark.encrypt                100      127  avgt    5  15814.771 ± 21.253  us/op
SP80038GMicroBenchmark.encrypt                100     1024  avgt    5  18064.773 ± 11.569  us/op
SP80038GMicroBenchmark.encrypt                100     3011  avgt    5  19945.093 ± 14.891  us/op
```

Results from this branch:
```
Benchmark                       (plainTextDigits)  (radix)  Mode  Cnt     Score   Error  Units
SP80038GMicroBenchmark.encrypt                  5      127  avgt    5   605.809 ± 0.396  us/op
SP80038GMicroBenchmark.encrypt                  5     1024  avgt    5   616.573 ± 0.395  us/op
SP80038GMicroBenchmark.encrypt                  5     3011  avgt    5   715.204 ± 0.546  us/op
SP80038GMicroBenchmark.encrypt                 20      127  avgt    5  1382.741 ± 1.156  us/op
SP80038GMicroBenchmark.encrypt                 20     1024  avgt    5  1566.357 ± 0.104  us/op
SP80038GMicroBenchmark.encrypt                 20     3011  avgt    5  1612.640 ± 1.028  us/op
SP80038GMicroBenchmark.encrypt                 50      127  avgt    5  2501.476 ± 2.341  us/op
SP80038GMicroBenchmark.encrypt                 50     1024  avgt    5  3482.055 ± 3.185  us/op
SP80038GMicroBenchmark.encrypt                 50     3011  avgt    5  3837.232 ± 2.442  us/op
SP80038GMicroBenchmark.encrypt                100      127  avgt    5  4978.072 ± 3.388  us/op
SP80038GMicroBenchmark.encrypt                100     1024  avgt    5  7037.240 ± 4.655  us/op
SP80038GMicroBenchmark.encrypt                100     3011  avgt    5  9435.915 ± 4.428  us/op
```

which results in the speedup in table
<img width="658" alt="Screenshot 2022-08-17 at 10 52 24" src="https://user-images.githubusercontent.com/61581269/185090107-421768cd-a71e-461d-9bbc-662b0146f930.png">

