### PR TITLE
Expose PGPObjectFactory.nextObject(BCPGInputStream, KeyFingerprintCal…

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
@@ -81,6 +81,12 @@ public class PGPObjectFactory
     public Object nextObject()
         throws IOException
     {
+        return nextObject(this.in, this.fingerPrintCalculator);
+    }
+
+    public static Object nextObject(BCPGInputStream in, KeyFingerPrintCalculator fingerPrintCalculator)
+            throws IOException
+    {
         List l;
 
         switch (in.nextPacketTag())


### PR DESCRIPTION
…culator)

By exposing the nextObject() method as a static method, it can be used more flexibly.

The reason for this PR is, that `PGPObjectFactory` wraps any stream it gets as constructor argument into a `BCPGInputStream`, regardless of whether that stream might already be a `BCPGInputStream`.
That has the effect, that the stream that got passed into the factory is forwarded too far when parsing objects.

By exposing the `nextObject()` method statically, we have the option to avoid the wrapping, so that the stream is only read so far as needed.