### PR TITLE
Decryption of OpenPGP messages without encrypted session key packets

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java
@@ -14,6 +14,7 @@ import org.bouncycastle.bcpg.InputStreamPacket;
 import org.bouncycastle.bcpg.Packet;
 import org.bouncycastle.bcpg.PacketTags;
 import org.bouncycastle.bcpg.PublicKeyEncSessionPacket;
+import org.bouncycastle.bcpg.SymmetricEncIntegrityPacket;
 import org.bouncycastle.bcpg.SymmetricKeyEncSessionPacket;
 import org.bouncycastle.bcpg.UnsupportedPacketVersionException;
 import org.bouncycastle.util.Iterable;
@@ -141,6 +142,15 @@ public class PGPEncryptedDataList
         PGPSessionKeyEncryptedData sessionKeyEncryptedData = new PGPSessionKeyEncryptedData(sessionKey, data);
         methods.add(sessionKeyEncryptedData);
         return sessionKeyEncryptedData;
+    }
+
+    /** Checks whether the packet is integrity protected.
+     *
+     * @return <code>true</code> if there is a modification detection code package associated with
+     * this stream
+     */
+    public boolean isIntegrityProtected() {
+        return data instanceof SymmetricEncIntegrityPacket;
     }
 
     /**

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java
@@ -129,6 +129,19 @@ public class PGPEncryptedDataList
     }
 
     /**
+     * Add a decryption method using a {@link PGPSessionKey}.
+     * This method can be used to decrypt messages which do not contain a SKESK or PKESK packet using a
+     * session key.
+     *
+     * @param sessionKey session key for message decryption
+     */
+    public void addSessionKeyDecryptionMethod(PGPSessionKey sessionKey)
+    {
+        PGPSessionKeyEncryptedData sessionKeyEncryptedData = new PGPSessionKeyEncryptedData(sessionKey, data);
+        methods.add(sessionKeyEncryptedData);
+    }
+
+    /**
      * Gets the encryption method object at the specified index.
      *
      * @param index the encryption method to obtain (0 based).

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java
@@ -134,11 +134,13 @@ public class PGPEncryptedDataList
      * session key.
      *
      * @param sessionKey session key for message decryption
+     * @return session key encrypted data
      */
-    public void addSessionKeyDecryptionMethod(PGPSessionKey sessionKey)
+    public PGPSessionKeyEncryptedData addSessionKeyDecryptionMethod(PGPSessionKey sessionKey)
     {
         PGPSessionKeyEncryptedData sessionKeyEncryptedData = new PGPSessionKeyEncryptedData(sessionKey, data);
         methods.add(sessionKeyEncryptedData);
+        return sessionKeyEncryptedData;
     }
 
     /**

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
@@ -135,6 +135,9 @@ public class PGPObjectFactory
             return new PGPLiteralData(in);
         case PacketTags.PUBLIC_KEY_ENC_SESSION:
         case PacketTags.SYMMETRIC_KEY_ENC_SESSION:
+        case PacketTags.SYMMETRIC_KEY_ENC:
+        case PacketTags.SYM_ENC_INTEGRITY_PRO:
+        case PacketTags.AEAD_ENC_DATA:
             return new PGPEncryptedDataList(in);
         case PacketTags.ONE_PASS_SIGNATURE:
             l = new ArrayList();

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSessionKeyEncryptedData.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSessionKeyEncryptedData.java
@@ -1,0 +1,144 @@
+package org.bouncycastle.openpgp;
+
+import org.bouncycastle.bcpg.AEADEncDataPacket;
+import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.bcpg.InputStreamPacket;
+import org.bouncycastle.bcpg.SymmetricEncIntegrityPacket;
+import org.bouncycastle.openpgp.operator.PGPDataDecryptor;
+import org.bouncycastle.openpgp.operator.SessionKeyDataDecryptorFactory;
+import org.bouncycastle.util.io.TeeInputStream;
+
+import java.io.EOFException;
+import java.io.InputStream;
+
+public class PGPSessionKeyEncryptedData extends PGPEncryptedData
+{
+
+    private final PGPSessionKey sessionKey;
+
+    PGPSessionKeyEncryptedData(PGPSessionKey sessionKey, InputStreamPacket encData)
+    {
+        super(encData);
+        this.sessionKey = sessionKey;
+    }
+
+    public PGPSessionKey getSessionKey()
+    {
+        return sessionKey;
+    }
+
+    public InputStream getDataStream(
+            SessionKeyDataDecryptorFactory dataDecryptorFactory)
+            throws PGPException
+    {
+        if (encData instanceof AEADEncDataPacket)
+        {
+            AEADEncDataPacket aeadData = (AEADEncDataPacket) encData;
+
+            if (aeadData.getAlgorithm() != getAlgorithm())
+            {
+                throw new PGPException("session key and AEAD algorithm mismatch");
+            }
+
+            PGPDataDecryptor dataDecryptor = dataDecryptorFactory.createDataDecryptor(aeadData.getAEADAlgorithm(), aeadData.getIV(), aeadData.getChunkSize(), sessionKey.getAlgorithm(), sessionKey.getKey());
+
+            BCPGInputStream encIn = encData.getInputStream();
+
+            return new BCPGInputStream(dataDecryptor.getInputStream(encIn));
+        }
+        else
+        {
+            try
+            {
+                boolean withIntegrityPacket = encData instanceof SymmetricEncIntegrityPacket;
+                PGPDataDecryptor dataDecryptor = dataDecryptorFactory.createDataDecryptor(withIntegrityPacket, sessionKey.getAlgorithm(), sessionKey.getKey());
+
+                return getDataStream(withIntegrityPacket, dataDecryptor);
+            } catch (PGPException e)
+            {
+                throw e;
+            } catch (Exception e)
+            {
+                throw new PGPException("Exception creating cipher", e);
+            }
+        }
+    }
+
+    private InputStream getDataStream(
+            boolean withIntegrityPacket,
+            PGPDataDecryptor dataDecryptor)
+            throws PGPException
+    {
+        try
+        {
+            BCPGInputStream encIn = encData.getInputStream();
+            encIn.mark(dataDecryptor.getBlockSize() + 2); // iv + 2 octets checksum
+
+            encStream = new BCPGInputStream(dataDecryptor.getInputStream(encIn));
+
+            if (withIntegrityPacket)
+            {
+                truncStream = new TruncatedStream(encStream);
+
+                integrityCalculator = dataDecryptor.getIntegrityCalculator();
+
+                encStream = new TeeInputStream(truncStream, integrityCalculator.getOutputStream());
+            }
+
+            byte[] iv = new byte[dataDecryptor.getBlockSize()];
+            for (int i = 0; i != iv.length; i++)
+            {
+                int ch = encStream.read();
+
+                if (ch < 0)
+                {
+                    throw new EOFException("unexpected end of stream.");
+                }
+
+                iv[i] = (byte)ch;
+            }
+
+            int v1 = encStream.read();
+            int v2 = encStream.read();
+
+            if (v1 < 0 || v2 < 0)
+            {
+                throw new EOFException("unexpected end of stream.");
+            }
+
+
+            // Note: the oracle attack on "quick check" bytes is not deemed
+            // a security risk for PBE (see PGPPublicKeyEncryptedData)
+
+            boolean repeatCheckPassed = iv[iv.length - 2] == (byte)v1
+                    && iv[iv.length - 1] == (byte)v2;
+
+            // Note: some versions of PGP appear to produce 0 for the extra
+            // bytes rather than repeating the two previous bytes
+            boolean zeroesCheckPassed = v1 == 0 && v2 == 0;
+
+            if (!repeatCheckPassed && !zeroesCheckPassed)
+            {
+                encIn.reset();
+                throw new PGPDataValidationException("data check failed.");
+            }
+
+            return encStream;
+        }
+        catch (PGPException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new PGPException("Exception creating cipher", e);
+        }
+    }
+
+    @Override
+    public int getAlgorithm()
+    {
+        return sessionKey.getAlgorithm();
+    }
+
+}

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPSessionKeyTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPSessionKeyTest.java
@@ -291,11 +291,11 @@ public class PGPSessionKeyTest
         PGPEncryptedDataList encryptedData = (PGPEncryptedDataList) objectFactory.nextObject();
         isEquals(0, encryptedData.size()); // there is no encrypted session key packet
 
-        encryptedData.addSessionKeyDecryptionMethod(sessionKey); // Add decryption method using a session key
+        // Add decryption method using a session key
+        PGPSessionKeyEncryptedData sessionKeyEncData = encryptedData.addSessionKeyDecryptionMethod(sessionKey);
         isEquals(1, encryptedData.size());
 
         SessionKeyDataDecryptorFactory decryptorFactory = new BcSessionKeyDataDecryptorFactory(sessionKey);
-        PGPSessionKeyEncryptedData sessionKeyEncData = (PGPSessionKeyEncryptedData) encryptedData.get(0);
         InputStream decrypted = sessionKeyEncData.getDataStream(decryptorFactory);
 
         objectFactory = new BcPGPObjectFactory(decrypted);


### PR DESCRIPTION
According to [RFC4880](https://www.rfc-editor.org/rfc/rfc4880#section-11.3), a valid OpenPGP message may not necessarily include an encrypted session key:

```
   OpenPGP Message :- Encrypted Message [...]

   Encrypted Data :- Symmetrically Encrypted Data Packet |
         Symmetrically Encrypted Integrity Protected Data Packet

   Encrypted Message :- Encrypted Data | ESK Sequence, Encrypted Data.
```

(Substitution: OpenPGP Message -> Encrypted Message -> Encrypted Data)

I noticed, that BCs `PGPObjectFactory` cannot properly parse encrypted data packets if there are no encrypted session key packets (fixed in 5d9a45839a9d129cae0eee6f5dbae7ff40165a91).
With that resolved, I noticed that it is not possible to decrypt a message without any encrypted session keys using a session key, since the current implementation requires at least one PKESK/SKESK (Public/Symmetric Key Encrypted Session Key) packet.

As a solution I added the `PGPSessionKeyEncryptedData` object which allows decryption using a `PGPSessionKey`.
The user can add this manually to a `PGPEncryptedDataList` by calling `pgpEncryptedDataList.addSessionKeyDecryptionMethod(PGPSessionKey sessionKey)`.

With these patches in place, messages without encrypted session keys can be decrypted :partying_face:!

Perhaps we want to remove the session key decryption on `PGPPBEEncryptedData/PublicKeyEncryptedData` introduced in https://github.com/bcgit/bc-java/pull/1030 in favor of this for a cleaner API?