### PR TITLE
PGPObjectFactory: Only wrap InputStream with BCPGInputStream if necessary

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/BCPGInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/BCPGInputStream.java
@@ -26,6 +26,22 @@ public class BCPGInputStream
         this.in = in;
     }
 
+    /**
+     * If the argument is a {@link BCPGInputStream}, return it.
+     * Otherwise wrap it in a {@link BCPGInputStream} and then return the result.
+     *
+     * @param in input stream
+     * @return BCPGInputStream
+     */
+    public static BCPGInputStream wrap(InputStream in)
+    {
+        if (in instanceof BCPGInputStream)
+        {
+            return (BCPGInputStream)in;
+        }
+        return new BCPGInputStream(in);
+    }
+
     public int available()
         throws IOException
     {

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRing.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRing.java
@@ -1,7 +1,6 @@
 package org.bouncycastle.openpgp;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -28,16 +27,6 @@ public abstract class PGPKeyRing
 
     PGPKeyRing()
     {
-    }
-
-    static BCPGInputStream wrap(InputStream in)
-    {
-        if (in instanceof BCPGInputStream)
-        {
-            return (BCPGInputStream)in;
-        }
-
-        return new BCPGInputStream(in);
     }
 
     static TrustPacket readOptionalTrustPacket(

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
@@ -54,7 +54,7 @@ public class PGPObjectFactory
         InputStream              in,
         KeyFingerPrintCalculator fingerPrintCalculator)
     {
-        this.in = new BCPGInputStream(in);
+        this.in = BCPGInputStream.wrap(in);
         this.fingerPrintCalculator = fingerPrintCalculator;
     }
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKeyRing.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKeyRing.java
@@ -94,7 +94,7 @@ public class PGPPublicKeyRing
     {
         this.keys = new ArrayList<PGPPublicKey>();
 
-        BCPGInputStream pIn = wrap(in);
+        BCPGInputStream pIn = BCPGInputStream.wrap(in);
 
         int initialTag = pIn.skipMarkerPackets();
         if (initialTag != PacketTags.PUBLIC_KEY && initialTag != PacketTags.PUBLIC_SUBKEY)

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKeyRing.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKeyRing.java
@@ -101,7 +101,7 @@ public class PGPSecretKeyRing
         this.keys = new ArrayList<PGPSecretKey>();
         this.extraPubKeys = new ArrayList<PGPPublicKey>();
 
-        BCPGInputStream pIn = wrap(in);
+        BCPGInputStream pIn = BCPGInputStream.wrap(in);
 
         int initialTag = pIn.skipMarkerPackets();
         if (initialTag != PacketTags.SECRET_KEY && initialTag != PacketTags.SECRET_SUBKEY)


### PR DESCRIPTION
This PR changes the constructor of the `PGPObjectFactory` class to only wrap the `InputStream` argument inside a `BCPGInputStream`, if the input stream is not a `BCPGInputStream`.

Passing in a `BCPGInputStream` will cause the `in` member of the `PGPObjectFactory` to be assigned to the argument directly.

Alternative solution to the issue described in #1227 