### PR TITLE
Expose PGPOnePassSignature.isEncapsulating()

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/OnePassSignaturePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/OnePassSignaturePacket.java
@@ -14,7 +14,7 @@ public class OnePassSignaturePacket
     private int  hashAlgorithm;
     private int  keyAlgorithm;
     private long keyID;
-    private int  nested;
+    private int isEncapsulating;
     
     OnePassSignaturePacket(
         BCPGInputStream    in)
@@ -34,7 +34,7 @@ public class OnePassSignaturePacket
         keyID |= (long)in.read() << 8;
         keyID |= in.read();
         
-        nested = in.read();
+        isEncapsulating = in.read();
     }
     
     public OnePassSignaturePacket(
@@ -49,7 +49,7 @@ public class OnePassSignaturePacket
         this.hashAlgorithm = hashAlgorithm;
         this.keyAlgorithm = keyAlgorithm;
         this.keyID = keyID;
-        this.nested = (isNested) ? 0 : 1;
+        this.isEncapsulating = (isNested) ? 0 : 1;
     }
     
     /**
@@ -84,6 +84,17 @@ public class OnePassSignaturePacket
     {
         return keyID;
     }
+
+    /**
+     * Return true, if the signature is encapsulating.
+     * An encapsulating OPS is followed by additional OPS packets and is calculated over all the data between itself
+     * and its corresponding signature (it is an attestation for encapsulated signatures).
+     *
+     * @return true if encapsulating, false otherwise
+     */
+    public boolean isEncapsulating() {
+        return isEncapsulating == 1;
+    }
     
     /**
      * 
@@ -109,7 +120,7 @@ public class OnePassSignaturePacket
         pOut.write((byte)(keyID >> 8));
         pOut.write((byte)(keyID));
         
-        pOut.write(nested);
+        pOut.write(isEncapsulating);
 
         pOut.close();
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPOnePassSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPOnePassSignature.java
@@ -203,6 +203,17 @@ public class PGPOnePassSignature
         return sigPack.getKeyAlgorithm();
     }
 
+    /**
+     * Return true, if the signature is encapsulating.
+     * An encapsulating OPS is followed by additional OPS packets and is calculated over all the data between itself
+     * and its corresponding signature (it is an attestation for encapsulated signatures).
+     *
+     * @return true if encapsulating, false otherwise
+     */
+    public boolean isEncapsulating() {
+        return sigPack.isEncapsulating();
+    }
+
     public byte[] getEncoded()
         throws IOException
     {


### PR DESCRIPTION
This method exposes the nested flag of OnePassSignatures.
Since the naming was a bit confusing, I renamed the flag to isEncapsulating.
(The rfc names the flag nested, while BC currently interprets `isNested` as "being nested inside", which is the opposite of what the flag is supposed to tell).

Exposing this flag to consumers is required for consumers to verify the signature properly. An encapsulating signature needs to be updated with the encoding of subsequent, nested OPSs and their signatures.

Before this change, consumers would need to encode the signature and access the correct byte to check the flag.