### PR TITLE
PGP{OnePass}Signature: Expose constructor with BCPGInputStream arg

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPOnePassSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPOnePassSignature.java
@@ -34,7 +34,7 @@ public class PGPOnePassSignature
         return (OnePassSignaturePacket)packet;
     }
 
-    PGPOnePassSignature(
+    public PGPOnePassSignature(
         BCPGInputStream    pIn)
         throws IOException, PGPException
     {

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -66,7 +66,7 @@ public class PGPSignature
         return (SignaturePacket)packet;
     }
 
-    PGPSignature(
+    public PGPSignature(
         BCPGInputStream pIn)
         throws IOException, PGPException
     {


### PR DESCRIPTION
This is related to #1232 in some sense.
OpenPGP One-Pass-Signatures can have a flag `nested`, which if set to 1 indicates, that the next packet is another OPS which is also part of the signatures hash context.
That way, the first OPS is an attestation over the subsequent signature and its signed data.

The fact that Bouncycastle currently requires downstream users to read signature objects (OPS + Signatures) through the PGPObjectFactory (there isn't any other way that I'm aware of due to package-private constructors), is a slight problem, since the PGPObjectFactory.nextObject() method bundles together multiple signatures into lists.

This means that downstream is required to afterwards iterate over the list to manually update OPS signatures with the nested flag set with subsequent OPS packets by encoding those into a new buffer.

A cleaner approach would be to allow downstream to parse OPS and signature packets one-by-one, so that in case of a containing signature, code to update them with subsequent data packets can be applied immediately without the need to manually encode those into a buffer.
I could for example imagine a custom BCPGInputStream whose read() methods are used to update the OPS, right until its corresponding signature packet.

To accomplish this, I thought about tweaking the PGPObjectFactory.next() method to receive a boolean argument "combinePackets", which if set to false would return single signature objects instead of lists.
However, that would probably require the implemenetation to also handle single user-id, trust packet, {public/secret}{sub}key packets as well, which would lead to chaos :D

Instead, I decided to simply expose the constructors which take a BCPGInputStream as argument, so that the user can do
```
int tag = bcpgIn.nextPacketTag();
if (tag == OnePassSignature) {
    return new PGPOnePassSignature(bcpgIn);
}
...
```

What do you think? The "stream-constructor" is already exposed for many PGP* classes. Should we expose it in all classes by default to make the user independent from the PGPObjectFactory?