### PR TITLE
Add javadoc for PGPPBEEncryptedData.getAlgorithm() and getSymmetricAl…

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPBEEncryptedData.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPBEEncryptedData.java
@@ -42,6 +42,12 @@ public class PGPPBEEncryptedData
         return keyData.getVersion();
     }
 
+    /**
+     * Symmetric-key algorithm used by this object to protect the session key
+     * ({@link #getSymmetricAlgorithm(PBEDataDecryptorFactory)} with.
+     *
+     * @return password-based encryption algorithm identifier ({@link SymmetricKeyAlgorithmTags})
+     */
     public int getAlgorithm()
     {
         return keyData.getEncAlgorithm();
@@ -51,8 +57,7 @@ public class PGPPBEEncryptedData
      * Return the symmetric key algorithm required to decrypt the data protected by this object.
      *
      * @param dataDecryptorFactory decryptor factory to use to recover the session data.
-     * @return the identifier of the {@link SymmetricKeyAlgorithmTags encryption algorithm} used to
-     * encrypt this object.
+     * @return session key algorithm identifier ({@link SymmetricKeyAlgorithmTags})
      * @throws PGPException if the session data cannot be recovered.
      */
     public int getSymmetricAlgorithm(


### PR DESCRIPTION
…gorithm()

From the previous javadoc, it was not totally clear, for which purpose the algorithm would be used.
I tried to improve that with this PR.

Should we maybe rename `getAlgorithm()` to something along the lines of `getKeyEncapsulationAlgorithm()` (although KEMs are usually using asymmetric algorithms)?