### PR TITLE
docs: add link to Extension

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/x509/X509Extensions.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/X509Extensions.java
@@ -15,7 +15,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERSequence;
 
 /**
- * @deprecated use {@link Extensions}
+ * @deprecated use {@link Extension} and  {@link Extensions}
  */
 public class X509Extensions
     extends ASN1Object


### PR DESCRIPTION
Add a link to Extension because the known ASN1ObjectIdentifiers are located there, hence Extension and Extensions replace X509Extensions.