### PR TITLE
Exclude tests

### DIFF
--- a/ant/bc+-build.xml
+++ b/ant/bc+-build.xml
@@ -986,6 +986,7 @@
             <batchtest todir="${artifacts.reports.xml.dir}" unless="testcase">
                 <fileset dir="${test.target.src.dir}">
                     <include name="**/AllTests.java" />
+                    <exclude name="${env.JUNIT_EXCLUDE_TESTS}" if="env.JUNIT_EXCLUDE_TESTS" />
                 </fileset>
             </batchtest>
         </junit>

--- a/build.gradle
+++ b/build.gradle
@@ -190,6 +190,9 @@ subprojects {
 
     filter {
       includeTestsMatching "AllTest*"
+      if (project.hasProperty('excludeTests')) {
+        excludeTestsMatching "${excludeTests}"
+      }
     }
   }
 


### PR DESCRIPTION
This is a simple pull request intended to make it easier to run the unit tests locally.

# Problem
Some unit tests take a really, really, really long time to run. It would be nice to be able to temporarily skip them during development.

# Proposed Solution
Both Ant and Gradle build scripts can now ignore unit tests that match a given pattern. Both examples below run all the unit tests *except* those in the pqc package.

## Ant
```
JUNIT_EXCLUDE_TESTS='**/pqc/**' sh build1-8+ test
```

## Gradle
```
gradle test -PexcludeTests="*pqc*"
```