### PR TITLE
Throw `UnsupportedPacketVersionException` for unknown S2K identifiers

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/S2K.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/S2K.java
@@ -98,7 +98,7 @@ public class S2K
             break;
 
         default:
-            throw new IllegalStateException("Invalid S2K type: " + type);
+            throw new UnsupportedPacketVersionException("Invalid S2K type: " + type);
         }
     }
 


### PR DESCRIPTION
`IllegalStateException` was the wrong choice to throw here, sorry.
By throwing an `UnsupportedPacketVersionException` instead, unknown S2Ks can be handled gracefully, e.g. the `EncryptedDataList` [already catches this exception](https://github.com/bcgit/bc-java/blob/master/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java#L104-L111), allowing encrypted session keys with unsupported S2Ks to be skipped.