### PR TITLE
missing type added to CertificateRequestMessageBuilder

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/cert/crmf/CertificateRequestMessageBuilder.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/crmf/CertificateRequestMessageBuilder.java
@@ -135,10 +135,10 @@ public class CertificateRequestMessageBuilder
     }
 
     public CertificateRequestMessageBuilder addExtension(
-            ASN1ObjectIdentifier oid,
-            boolean              critical,
-            ASN1Encodable        value)
-            throws CertIOException
+        ASN1ObjectIdentifier oid,
+        boolean              critical,
+        ASN1Encodable        value)
+        throws CertIOException
     {
         CRMFUtil.addExtension(extGenerator, oid, critical, value);
 
@@ -146,9 +146,9 @@ public class CertificateRequestMessageBuilder
     }
 
     public CertificateRequestMessageBuilder addExtension(
-            ASN1ObjectIdentifier oid,
-            boolean              critical,
-            byte[]               value)
+        ASN1ObjectIdentifier oid,
+        boolean              critical,
+        byte[]               value)
     {
         extGenerator.addExtension(oid, critical, value);
 
@@ -249,7 +249,7 @@ public class CertificateRequestMessageBuilder
     }
 
     public CertificateRequestMessage build()
-            throws CRMFException
+        throws CRMFException
     {
         ASN1EncodableVector v = new ASN1EncodableVector();
 

--- a/pkix/src/main/java/org/bouncycastle/cert/crmf/CertificateRequestMessageBuilder.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/crmf/CertificateRequestMessageBuilder.java
@@ -50,6 +50,7 @@ public class CertificateRequestMessageBuilder
     private POPOPrivKey popoPrivKey;
     private ASN1Null popRaVerified;
     private PKMACValue agreeMAC;
+    private AttributeTypeAndValue[] attributeTypeAndValues;
 
     public CertificateRequestMessageBuilder(BigInteger certReqId)
     {
@@ -58,6 +59,14 @@ public class CertificateRequestMessageBuilder
         this.extGenerator = new ExtensionsGenerator();
         this.templateBuilder = new CertTemplateBuilder();
         this.controls = new ArrayList();
+        this.attributeTypeAndValues = new AttributeTypeAndValue[0];
+    }
+
+    public CertificateRequestMessageBuilder setAttributeTypeAndValues(AttributeTypeAndValue[] attributeTypeAndValues) {
+        if( attributeTypeAndValues != null) {
+            this.attributeTypeAndValues = attributeTypeAndValues;
+        }
+        return this;
     }
 
     public CertificateRequestMessageBuilder setPublicKey(SubjectPublicKeyInfo publicKey)
@@ -126,10 +135,10 @@ public class CertificateRequestMessageBuilder
     }
 
     public CertificateRequestMessageBuilder addExtension(
-        ASN1ObjectIdentifier oid,
-        boolean              critical,
-        ASN1Encodable        value)
-        throws CertIOException
+            ASN1ObjectIdentifier oid,
+            boolean              critical,
+            ASN1Encodable        value)
+            throws CertIOException
     {
         CRMFUtil.addExtension(extGenerator, oid, critical, value);
 
@@ -137,9 +146,9 @@ public class CertificateRequestMessageBuilder
     }
 
     public CertificateRequestMessageBuilder addExtension(
-        ASN1ObjectIdentifier oid,
-        boolean              critical,
-        byte[]               value)
+            ASN1ObjectIdentifier oid,
+            boolean              critical,
+            byte[]               value)
     {
         extGenerator.addExtension(oid, critical, value);
 
@@ -240,7 +249,7 @@ public class CertificateRequestMessageBuilder
     }
 
     public CertificateRequestMessage build()
-        throws CRMFException
+            throws CRMFException
     {
         ASN1EncodableVector v = new ASN1EncodableVector();
 
@@ -269,10 +278,7 @@ public class CertificateRequestMessageBuilder
 
         CertRequest request = CertRequest.getInstance(new DERSequence(v));
 
-        v = new ASN1EncodableVector();
-
-        v.add(request);
-
+        ProofOfPossession proofOfPossession = new ProofOfPossession();
         if (popSigner != null)
         {
             CertTemplate template = request.getCertTemplate();
@@ -292,31 +298,31 @@ public class CertificateRequestMessageBuilder
 
                     builder.setPublicKeyMac(pkmacGenerator, password);
                 }
-
-                v.add(new ProofOfPossession(builder.build(popSigner)));
+                proofOfPossession = new ProofOfPossession(builder.build(popSigner));
             }
             else
             {
                 ProofOfPossessionSigningKeyBuilder builder = new ProofOfPossessionSigningKeyBuilder(request);
-
-                v.add(new ProofOfPossession(builder.build(popSigner)));
+                proofOfPossession = new ProofOfPossession(builder.build(popSigner));
             }
         }
         else if (popoPrivKey != null)
         {
-            v.add(new ProofOfPossession(popoType, popoPrivKey));
+            proofOfPossession = new ProofOfPossession(popoType, popoPrivKey);
         }
         else if (agreeMAC != null)
         {
-            v.add(new ProofOfPossession(ProofOfPossession.TYPE_KEY_AGREEMENT,
-                    POPOPrivKey.getInstance(new DERTaggedObject(false, POPOPrivKey.agreeMAC, agreeMAC))));
+            proofOfPossession = new ProofOfPossession(ProofOfPossession.TYPE_KEY_AGREEMENT,
+                    POPOPrivKey.getInstance(new DERTaggedObject(false, POPOPrivKey.agreeMAC, agreeMAC)));
 
         }
         else if (popRaVerified != null)
         {
-            v.add(new ProofOfPossession());
+            proofOfPossession = new ProofOfPossession();
         }
 
-        return new CertificateRequestMessage(CertReqMsg.getInstance(new DERSequence(v)));
+        CertReqMsg certReqMsg = new CertReqMsg(request, proofOfPossession, attributeTypeAndValues);
+
+        return new CertificateRequestMessage(certReqMsg);
     }
 }

--- a/pkix/src/test/java/org/bouncycastle/cert/crmf/test/AllTests.java
+++ b/pkix/src/test/java/org/bouncycastle/cert/crmf/test/AllTests.java
@@ -82,7 +82,7 @@ import org.bouncycastle.operator.jcajce.JceAsymmetricKeyWrapper;
 import org.bouncycastle.util.Arrays;
 
 public class AllTests
-        extends TestCase
+    extends TestCase
 {
     private static final byte[] TEST_DATA = "Hello world!".getBytes();
     private static final String BC = BouncyCastleProvider.PROVIDER_NAME;
@@ -120,7 +120,7 @@ public class AllTests
     }
 
     public void testBasicMessage()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
 
@@ -131,8 +131,8 @@ public class AllTests
         JcaCertificateRequestMessageBuilder certReqBuild = new JcaCertificateRequestMessageBuilder(BigInteger.ONE);
 
         certReqBuild.setSubject(new X500Principal("CN=Test"))
-                .setPublicKey(kp.getPublic())
-                .setProofOfPossessionSigningKeySigner(new JcaContentSignerBuilder("SHA1withRSA").setProvider(BC).build(kp.getPrivate()));
+                    .setPublicKey(kp.getPublic())
+                    .setProofOfPossessionSigningKeySigner(new JcaContentSignerBuilder("SHA1withRSA").setProvider(BC).build(kp.getPrivate()));
 
         JcaCertificateRequestMessage certReqMsg = new JcaCertificateRequestMessage(certReqBuild.build()).setProvider(BC);
 
@@ -199,7 +199,7 @@ public class AllTests
     }
 
     public void testBasicMessageWithArchiveControl()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
 
@@ -211,11 +211,11 @@ public class AllTests
         JcaCertificateRequestMessageBuilder certReqBuild = new JcaCertificateRequestMessageBuilder(BigInteger.ONE);
 
         certReqBuild.setSubject(new X500Principal("CN=Test"))
-                .setPublicKey(kp.getPublic());
+                    .setPublicKey(kp.getPublic());
 
         certReqBuild.addControl(new JcaPKIArchiveControlBuilder(kp.getPrivate(), new X500Principal("CN=Test"))
-                .addRecipientGenerator(new JceKeyTransRecipientInfoGenerator(cert).setProvider(BC))
-                .build(new JceCMSContentEncryptorBuilder(new ASN1ObjectIdentifier(CMSEnvelopedDataGenerator.AES128_CBC)).setProvider(BC).build()));
+            .addRecipientGenerator(new JceKeyTransRecipientInfoGenerator(cert).setProvider(BC))
+            .build(new JceCMSContentEncryptorBuilder(new ASN1ObjectIdentifier(CMSEnvelopedDataGenerator.AES128_CBC)).setProvider(BC).build()));
 
         JcaCertificateRequestMessage certReqMsg = new JcaCertificateRequestMessage(certReqBuild.build()).setProvider(BC);
 
@@ -227,7 +227,7 @@ public class AllTests
     }
 
     public void testECBasicMessageWithArchiveControl()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("EC", BC);
 
@@ -240,16 +240,16 @@ public class AllTests
         JcaCertificateRequestMessageBuilder certReqBuild = new JcaCertificateRequestMessageBuilder(BigInteger.ONE);
 
         certReqBuild.setSubject(new X500Principal("CN=Test"))
-                .setPublicKey(clientKp.getPublic());
+                    .setPublicKey(clientKp.getPublic());
 
         certReqBuild.addControl(new JcaPKIArchiveControlBuilder(clientKp.getPrivate(), new X500Principal("CN=Test"))
-                .addRecipientGenerator(new JceKeyAgreeRecipientInfoGenerator(
+            .addRecipientGenerator(new JceKeyAgreeRecipientInfoGenerator(
                         CMSAlgorithm.ECCDH_SHA256KDF,
                         clientKp.getPrivate(), serverKp.getPublic(),
                         CMSAlgorithm.AES256_WRAP)
                         .addRecipient(serverCert)
                         .setProvider(BC))
-                .build(new JceCMSContentEncryptorBuilder(new ASN1ObjectIdentifier(CMSEnvelopedDataGenerator.AES128_CBC)).setProvider(BC).build()));
+            .build(new JceCMSContentEncryptorBuilder(new ASN1ObjectIdentifier(CMSEnvelopedDataGenerator.AES128_CBC)).setProvider(BC).build()));
 
         JcaCertificateRequestMessage certReqMsg = new JcaCertificateRequestMessage(certReqBuild.build()).setProvider(BC);
 
@@ -261,7 +261,7 @@ public class AllTests
     }
 
     private void checkCertReqMsgWithArchiveControl(KeyPair kp, X509Certificate cert, JcaCertificateRequestMessage certReqMsg)
-            throws CRMFException, CMSException, IOException
+        throws CRMFException, CMSException, IOException
     {
         PKIArchiveControl archiveControl = (PKIArchiveControl)certReqMsg.getControl(CRMFObjectIdentifiers.id_regCtrl_pkiArchiveOptions);
 
@@ -303,7 +303,7 @@ public class AllTests
     }
 
     public void testProofOfPossessionWithoutSender()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
 
@@ -315,12 +315,12 @@ public class AllTests
         JcaCertificateRequestMessageBuilder certReqBuild = new JcaCertificateRequestMessageBuilder(BigInteger.ONE);
 
         certReqBuild.setPublicKey(kp.getPublic())
-                .setAuthInfoPKMAC(new PKMACBuilder(new JcePKMACValuesCalculator()), "fred".toCharArray())
-                .setProofOfPossessionSigningKeySigner(new JcaContentSignerBuilder("SHA1withRSA").setProvider(BC).build(kp.getPrivate()));
+                    .setAuthInfoPKMAC(new PKMACBuilder(new JcePKMACValuesCalculator()), "fred".toCharArray())
+                    .setProofOfPossessionSigningKeySigner(new JcaContentSignerBuilder("SHA1withRSA").setProvider(BC).build(kp.getPrivate()));
 
         certReqBuild.addControl(new JcaPKIArchiveControlBuilder(kp.getPrivate(), new X500Principal("CN=test"))
-                .addRecipientGenerator(new JceKeyTransRecipientInfoGenerator(cert).setProvider(BC))
-                .build(new JceCMSContentEncryptorBuilder(new ASN1ObjectIdentifier(CMSEnvelopedDataGenerator.AES128_CBC)).setProvider(BC).build()));
+            .addRecipientGenerator(new JceKeyTransRecipientInfoGenerator(cert).setProvider(BC))
+            .build(new JceCMSContentEncryptorBuilder(new ASN1ObjectIdentifier(CMSEnvelopedDataGenerator.AES128_CBC)).setProvider(BC).build()));
 
         JcaCertificateRequestMessage certReqMsg = new JcaCertificateRequestMessage(certReqBuild.build().getEncoded()).setProvider(BC);
 
@@ -341,7 +341,7 @@ public class AllTests
 
         certReqMsg = new JcaCertificateRequestMessage(certReqBuild.build()).setProvider(BC);
 
-        // check that internal check on popo signing is working okay
+                // check that internal check on popo signing is working okay
         try
         {
             certReqMsg.isValidSigningKeyPOP(new JcaContentVerifierProviderBuilder().setProvider(BC).build(kp.getPublic()));
@@ -358,7 +358,7 @@ public class AllTests
     }
 
     public void testEncryptedValueWithKey()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
 
@@ -382,7 +382,7 @@ public class AllTests
     }
 
     public void testBcEncryptedValueWithKey()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
 
@@ -391,12 +391,12 @@ public class AllTests
         KeyPair kp = kGen.generateKeyPair();
 
         BcEncryptedValueBuilder build = new BcEncryptedValueBuilder(new BcRSAAsymmetricKeyWrapper(
-                new AlgorithmIdentifier(PKCSObjectIdentifiers.rsaEncryption, DERNull.INSTANCE),
-                PublicKeyFactory.createKey(SubjectPublicKeyInfo.getInstance(kp.getPublic().getEncoded()))),
-                new BcCRMFEncryptorBuilder(CMSAlgorithm.AES128_CBC).build());
+            new AlgorithmIdentifier(PKCSObjectIdentifiers.rsaEncryption, DERNull.INSTANCE),
+            PublicKeyFactory.createKey(SubjectPublicKeyInfo.getInstance(kp.getPublic().getEncoded()))),
+            new BcCRMFEncryptorBuilder(CMSAlgorithm.AES128_CBC).build());
 
         EncryptedValue value = build.build(
-                PrivateKeyFactory.createKey(PrivateKeyInfo.getInstance(kp.getPrivate().getEncoded())));
+            PrivateKeyFactory.createKey(PrivateKeyInfo.getInstance(kp.getPrivate().getEncoded())));
 
         ValueDecryptorGenerator decGen = new JceAsymmetricValueDecryptorGenerator(kp.getPrivate()).setProvider(BC);
 
@@ -410,7 +410,7 @@ public class AllTests
     }
 
     public void testProofOfPossessionWithSender()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
 
@@ -422,12 +422,12 @@ public class AllTests
         JcaCertificateRequestMessageBuilder certReqBuild = new JcaCertificateRequestMessageBuilder(BigInteger.ONE);
 
         certReqBuild.setPublicKey(kp.getPublic())
-                .setAuthInfoSender(new X500Principal("CN=Test"))
-                .setProofOfPossessionSigningKeySigner(new JcaContentSignerBuilder("SHA1withRSA").setProvider(BC).build(kp.getPrivate()));
+                    .setAuthInfoSender(new X500Principal("CN=Test"))
+                    .setProofOfPossessionSigningKeySigner(new JcaContentSignerBuilder("SHA1withRSA").setProvider(BC).build(kp.getPrivate()));
 
         certReqBuild.addControl(new JcaPKIArchiveControlBuilder(kp.getPrivate(), new X500Principal("CN=test"))
-                .addRecipientGenerator(new JceKeyTransRecipientInfoGenerator(cert).setProvider(BC))
-                .build(new JceCMSContentEncryptorBuilder(new ASN1ObjectIdentifier(CMSEnvelopedDataGenerator.AES128_CBC)).setProvider(BC).build()));
+                                      .addRecipientGenerator(new JceKeyTransRecipientInfoGenerator(cert).setProvider(BC))
+                                      .build(new JceCMSContentEncryptorBuilder(new ASN1ObjectIdentifier(CMSEnvelopedDataGenerator.AES128_CBC)).setProvider(BC).build()));
 
         JcaCertificateRequestMessage certReqMsg = new JcaCertificateRequestMessage(certReqBuild.build().getEncoded());
 
@@ -450,7 +450,7 @@ public class AllTests
     }
 
     public void testProofOfPossessionWithTemplate()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
 
@@ -462,13 +462,13 @@ public class AllTests
         JcaCertificateRequestMessageBuilder certReqBuild = new JcaCertificateRequestMessageBuilder(BigInteger.ONE);
 
         certReqBuild.setPublicKey(kp.getPublic())
-                .setSubject(new X500Principal("CN=Test"))
-                .setAuthInfoSender(new X500Principal("CN=Test"))
-                .setProofOfPossessionSigningKeySigner(new JcaContentSignerBuilder("SHA1withRSA").setProvider(BC).build(kp.getPrivate()));
+                    .setSubject(new X500Principal("CN=Test"))
+                    .setAuthInfoSender(new X500Principal("CN=Test"))
+                    .setProofOfPossessionSigningKeySigner(new JcaContentSignerBuilder("SHA1withRSA").setProvider(BC).build(kp.getPrivate()));
 
         certReqBuild.addControl(new JcaPKIArchiveControlBuilder(kp.getPrivate(), new X500Principal("CN=test"))
-                .addRecipientGenerator(new JceKeyTransRecipientInfoGenerator(cert).setProvider(BC))
-                .build(new JceCMSContentEncryptorBuilder(new ASN1ObjectIdentifier(CMSEnvelopedDataGenerator.AES128_CBC)).setProvider(BC).build()));
+                                      .addRecipientGenerator(new JceKeyTransRecipientInfoGenerator(cert).setProvider(BC))
+                                      .build(new JceCMSContentEncryptorBuilder(new ASN1ObjectIdentifier(CMSEnvelopedDataGenerator.AES128_CBC)).setProvider(BC).build()));
 
         JcaCertificateRequestMessage certReqMsg = new JcaCertificateRequestMessage(certReqBuild.build().getEncoded());
 
@@ -478,7 +478,7 @@ public class AllTests
     }
 
     public void testKeySizes()
-            throws Exception
+        throws Exception
     {
         verifyKeySize(NISTObjectIdentifiers.id_aes128_CBC, 128);
         verifyKeySize(NISTObjectIdentifiers.id_aes192_CBC, 192);
@@ -492,7 +492,7 @@ public class AllTests
     }
 
     private void verifyKeySize(ASN1ObjectIdentifier oid, int keySize)
-            throws Exception
+        throws Exception
     {
         JceCRMFEncryptorBuilder encryptorBuilder = new JceCRMFEncryptorBuilder(oid).setProvider(BC);
 
@@ -502,7 +502,7 @@ public class AllTests
     }
 
     public void testEncryptedValue()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
 
@@ -523,7 +523,7 @@ public class AllTests
     }
 
     public void testEncryptedValueOAEP1()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
 
@@ -535,11 +535,11 @@ public class AllTests
         AlgorithmIdentifier sha256 = new AlgorithmIdentifier(NISTObjectIdentifiers.id_sha256, DERNull.INSTANCE);
 
         JcaEncryptedValueBuilder build = new JcaEncryptedValueBuilder(new JceAsymmetricKeyWrapper(
-                new AlgorithmIdentifier(PKCSObjectIdentifiers.id_RSAES_OAEP,
-                        new RSAESOAEPparams(sha256, new AlgorithmIdentifier(PKCSObjectIdentifiers.id_mgf1, sha256),
-                                RSAESOAEPparams.DEFAULT_P_SOURCE_ALGORITHM)),
-                cert.getPublicKey()).setProvider(BC),
-                new JceCRMFEncryptorBuilder(CMSAlgorithm.AES128_CBC).setProvider(BC).build());
+            new AlgorithmIdentifier(PKCSObjectIdentifiers.id_RSAES_OAEP,
+                new RSAESOAEPparams(sha256, new AlgorithmIdentifier(PKCSObjectIdentifiers.id_mgf1, sha256),
+                    RSAESOAEPparams.DEFAULT_P_SOURCE_ALGORITHM)),
+            cert.getPublicKey()).setProvider(BC),
+            new JceCRMFEncryptorBuilder(CMSAlgorithm.AES128_CBC).setProvider(BC).build());
 
         EncryptedValue value = build.build(cert);
         ValueDecryptorGenerator decGen = new JceAsymmetricValueDecryptorGenerator(kp.getPrivate()).setProvider(BC);
@@ -552,7 +552,7 @@ public class AllTests
     }
 
     public void testEncryptedValueOAEP2()
-            throws Exception
+        throws Exception
     {
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
 
@@ -562,9 +562,9 @@ public class AllTests
         X509Certificate cert = makeV1Certificate(kp, "CN=Test", kp, "CN=Test");
 
         JcaEncryptedValueBuilder build = new JcaEncryptedValueBuilder(new JceAsymmetricKeyWrapper(
-                new OAEPParameterSpec("SHA-256", "MGF1", new MGF1ParameterSpec("SHA-256"), new PSource.PSpecified(new byte[2])),
-                cert.getPublicKey()).setProvider(BC),
-                new JceCRMFEncryptorBuilder(CMSAlgorithm.AES128_CBC).setProvider(BC).build());
+            new OAEPParameterSpec("SHA-256", "MGF1", new MGF1ParameterSpec("SHA-256"), new PSource.PSpecified(new byte[2])),
+            cert.getPublicKey()).setProvider(BC),
+            new JceCRMFEncryptorBuilder(CMSAlgorithm.AES128_CBC).setProvider(BC).build());
 
         EncryptedValue value = build.build(cert);
 
@@ -582,7 +582,7 @@ public class AllTests
     }
 
     private void encryptedValueParserTest(EncryptedValue value, ValueDecryptorGenerator decGen, X509Certificate cert)
-            throws Exception
+        throws Exception
     {
         EncryptedValueParser  parser = new EncryptedValueParser(value);
 
@@ -592,7 +592,7 @@ public class AllTests
     }
 
     public void testEncryptedValuePassphrase()
-            throws Exception
+        throws Exception
     {
         char[] passphrase = PASSPHRASE.toCharArray();
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
@@ -614,7 +614,7 @@ public class AllTests
     }
 
     public void testEncryptedValuePassphraseWithPadding()
-            throws Exception
+        throws Exception
     {
         char[] passphrase = PASSPHRASE.toCharArray();
         KeyPairGenerator kGen = KeyPairGenerator.getInstance("RSA", BC);
@@ -637,7 +637,7 @@ public class AllTests
     }
 
     private void encryptedValuePassphraseParserTest(EncryptedValue value, EncryptedValuePadder padder, ValueDecryptorGenerator decGen, X509Certificate cert)
-            throws Exception
+        throws Exception
     {
         EncryptedValueParser  parser = new EncryptedValueParser(value, padder);
 
@@ -645,7 +645,7 @@ public class AllTests
     }
 
     private static X509Certificate makeV1Certificate(KeyPair subKP, String _subDN, KeyPair issKP, String _issDN)
-            throws GeneralSecurityException, IOException, OperatorCreationException
+        throws GeneralSecurityException, IOException, OperatorCreationException
     {
 
         PublicKey subPub  = subKP.getPublic();
@@ -653,12 +653,12 @@ public class AllTests
         PublicKey  issPub  = issKP.getPublic();
 
         X509v1CertificateBuilder v1CertGen = new JcaX509v1CertificateBuilder(
-                new X500Name(_issDN),
-                BigInteger.valueOf(System.currentTimeMillis()),
-                new Date(System.currentTimeMillis()),
-                new Date(System.currentTimeMillis() + (1000L * 60 * 60 * 24 * 100)),
-                new X500Name(_subDN),
-                subPub);
+            new X500Name(_issDN),
+            BigInteger.valueOf(System.currentTimeMillis()),
+            new Date(System.currentTimeMillis()),
+            new Date(System.currentTimeMillis() + (1000L * 60 * 60 * 24 * 100)),
+            new X500Name(_subDN),
+            subPub);
 
         JcaContentSignerBuilder signerBuilder = null;
 


### PR DESCRIPTION
Although the CertReqMsg class supports the AttributeTypeAndValue array, it is missing in the CertificateRequestMessageBuilder.
This PR adds the option to provide an 'AttributeTypeAndValue' array to the CertificateRequestMessageBuilder.