### PR TITLE
ConcatenationKDFGenerator#generateBytes changes according to NIST SP 800-56C Rev. 2

### DIFF
--- a/core/src/test/java/org/bouncycastle/crypto/test/ConcatenationKDFTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/test/ConcatenationKDFTest.java
@@ -28,6 +28,7 @@ public class ConcatenationKDFTest
         implSHA1Test();
         implSHA256Test();
         implSHA512Test();
+        implKDFPositiveLenTest();
     }
 
     private void implSHA1Test()
@@ -67,10 +68,10 @@ public class ConcatenationKDFTest
         Random random = new Random();
         ConcatenationKDFGenerator kdf = new ConcatenationKDFGenerator(digest);
 
-        for (int count = 0; count <= expectedBytes.length; ++count)
+        for (int count = 1; count <= expectedBytes.length; ++count)
         {
             Arrays.fill(output, (byte)0);
-            int outputPos = random.nextInt(16); 
+            int outputPos = random.nextInt(16);
 
             kdf.init(new KDFParameters(sharedSecretBytes, otherInfoBytes));
             kdf.generateBytes(output, outputPos, count);
@@ -79,6 +80,41 @@ public class ConcatenationKDFTest
             {
                 fail("ConcatenationKDF (" + digest.getAlgorithmName() + ") failed for count of " + count);
             }
+        }
+    }
+
+    private void implKDFPositiveLenTest()
+    {
+        String sharedSecret = "e65b1905878b95f68b5535bd3b2b1013";
+        String otherInfo = "830221b1730d9176f807d407";
+        byte[] sharedSecretBytes = Hex.decodeStrict(sharedSecret);
+        byte[] otherInfoBytes = Hex.decodeStrict(otherInfo);
+        byte[] output = new byte[2048];
+        int len = 0;
+
+        ConcatenationKDFGenerator kdf = new ConcatenationKDFGenerator(new SHA512Digest());
+        kdf.init(new KDFParameters(sharedSecretBytes, otherInfoBytes));
+        try {
+            kdf.generateBytes(output, 0, len);
+            fail("ConcatenationKDF must ignore the len parameter with value zero");
+        } catch (IllegalArgumentException iae) {
+            isEquals(
+                "Expect valid ConcatenationKDF error message",
+                "len must be greater than 0",
+                iae.getMessage()
+            );
+        }
+
+        len = -1;
+        try {
+            kdf.generateBytes(output, 0, len);
+            fail("ConcatenationKDF must ignore the len parameter with negative value");
+        } catch (IllegalArgumentException iae) {
+            isEquals(
+                "Expect valid ConcatenationKDF error message",
+                "len must be greater than 0",
+                iae.getMessage()
+            );
         }
     }
 


### PR DESCRIPTION
[SP 800-56A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-56a/rev-2/archive/2013-06-05) is superseded by [SP 800-56A Rev. 3](https://csrc.nist.gov/publications/detail/sp/800-56a/rev-3/final). SP 800-56A Rev. 3 doesn't include the **The Single-step Key-Derivation Function** section anymore and the change-log states that
> 34. Moved all key-derivation methods to SP 800-56C. Inserted a new section (Section 5.8.1) to describe how to call a key-derivation method and reorganized Section 5.8.

Following [SP 800-56C Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-56c/rev-2/final) this PR implements the changes and adds a conditional check for `len > 0`. It also brings the algorithm more in line with how it is written in SP 800-56C. A new test that checks for the new changes is also added. Related tests run successfully.