### PR TITLE
OpenPGPv5 AEAD: Add missing out.close() call when closing AEADOutputS…

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcUtil.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcUtil.java
@@ -466,6 +466,7 @@ class BcUtil
             throws IOException
         {
             finish();
+            out.close();
         }
 
         private void writeBlock()

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/OperatorHelper.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/OperatorHelper.java
@@ -653,6 +653,7 @@ class OperatorHelper
             throws IOException
         {
             finish();
+            out.close();
         }
 
         private void writeBlock()


### PR DESCRIPTION
…tream

I noticed that the AEADOutputStream classes do not close the underlying packet stream when getting closed. This results in truncated output packets.