### PR TITLE
typo fixed in returned string by getAlgorithmName() in XoodyakDigest

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/digests/Blake2spDigest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/Blake2spDigest.java
@@ -36,7 +36,7 @@ public class Blake2spDigest
     public Blake2spDigest(byte[] key)
     {
         param = new byte[32];
-        buffer = new byte[256];
+        buffer = new byte[512];
         init(key);
     }
 

--- a/core/src/main/java/org/bouncycastle/crypto/digests/Blake2spDigest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/Blake2spDigest.java
@@ -36,7 +36,7 @@ public class Blake2spDigest
     public Blake2spDigest(byte[] key)
     {
         param = new byte[32];
-        buffer = new byte[512];
+        buffer = new byte[256];
         init(key);
     }
 

--- a/core/src/main/java/org/bouncycastle/crypto/digests/XoodyakDigest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/XoodyakDigest.java
@@ -50,7 +50,7 @@ public class XoodyakDigest
     @Override
     public String getAlgorithmName()
     {
-        return "Xoodak Hash";
+        return "Xoodyak Hash";
     }
 
     @Override


### PR DESCRIPTION
in XoodyakDigest.java, method getAlgorithmName(), the algorithm name should be "Xoodyak Hash", not "Xoodak Hash".