### PR TITLE
Separate PGPSignature and its verification state

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -50,7 +50,6 @@ public class PGPSignature
     public static final int THIRD_PARTY_CONFIRMATION = 0x50;
 
     private SignaturePacket sigPck;
-    private int signatureType;
     private TrustPacket trustPck;
 
     private Verification verification;
@@ -76,7 +75,6 @@ public class PGPSignature
         SignaturePacket sigPacket)
     {
         sigPck = sigPacket;
-        signatureType = sigPck.getSignatureType();
         trustPck = null;
     }
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -31,6 +31,11 @@ import org.bouncycastle.util.Strings;
  */
 public class PGPSignature
 {
+    public static final int VERSION_3 = 3;
+    public static final int VERSION_4 = 4;
+    public static final int VERSION_5 = 5;
+    public static final int VERSION_6 = 6;
+
     public static final int BINARY_DOCUMENT = 0x00;
     public static final int CANONICAL_TEXT_DOCUMENT = 0x01;
     public static final int STAND_ALONE = 0x02;
@@ -85,6 +90,10 @@ public class PGPSignature
         this(sigPacket);
 
         this.trustPck = trustPacket;
+    }
+
+    public SignaturePacket getSignaturePacket() {
+        return sigPck;
     }
 
     /**

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPUserAttributeSubpacketVector.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPUserAttributeSubpacketVector.java
@@ -53,7 +53,7 @@ public class PGPUserAttributeSubpacketVector implements UserDataPacket
         return (ImageAttribute)p;
     }
     
-    UserAttributeSubpacket[] toSubpacketArray()
+    public UserAttributeSubpacket[] toSubpacketArray()
     {
         return packets;
     }

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PGPSignatureVerifier.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PGPSignatureVerifier.java
@@ -1,0 +1,19 @@
+package org.bouncycastle.openpgp.operator;
+
+import org.bouncycastle.openpgp.PGPException;
+
+import java.io.IOException;
+
+/**
+ * Verify the correctness of an OpenPGP signature.
+ */
+public interface PGPSignatureVerifier {
+
+    /**
+     * Return <pre>true</pre> if the signature is correct, <pre>false</pre> otherwise.
+     * @return whether signature is correct
+     * @throws PGPException
+     * @throws IOException
+     */
+    boolean verify() throws PGPException, IOException;
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PGPSignatureVerifierBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PGPSignatureVerifierBuilder.java
@@ -1,0 +1,446 @@
+package org.bouncycastle.openpgp.operator;
+
+import org.bouncycastle.bcpg.BCPGOutputStream;
+import org.bouncycastle.bcpg.PacketTags;
+import org.bouncycastle.bcpg.SignaturePacket;
+import org.bouncycastle.bcpg.UserAttributeSubpacket;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPRuntimeOperationException;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.PGPUserAttributeSubpacketVector;
+import org.bouncycastle.util.Strings;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Build signature verifiers for OpenPGP signatures.
+ */
+public class PGPSignatureVerifierBuilder {
+
+    private final PGPSignature signature;
+    private final PGPPublicKey signingKey;
+    private final PGPContentVerifierBuilderProvider verifierBuilderProvider;
+
+    public PGPSignatureVerifierBuilder(PGPSignature signature,
+                                        PGPPublicKey signingKey,
+                                        PGPContentVerifierBuilderProvider verifierBuilderProvider) {
+        this.signature = signature;
+        this.signingKey = signingKey;
+        this.verifierBuilderProvider = verifierBuilderProvider;
+    }
+
+    /**
+     * Instantiate a signature verifier for a {@link PGPSignature#DIRECT_KEY} signature.
+     *
+     * @param signedKey key over which the signature was made.
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier directKeySignature(PGPPublicKey signedKey)
+            throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.DIRECT_KEY) {
+            throw new PGPException("Signature is not a direct-key signature.");
+        }
+
+        return keySignature(signedKey);
+    }
+
+    /**
+     * Instantiate a signature verifier for a {@link PGPSignature#SUBKEY_BINDING} signature.
+     *
+     * @param primaryKey primary (master) key
+     * @param subKey subkey
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier subkeyBindingSignature(PGPPublicKey primaryKey, PGPPublicKey subKey)
+            throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.SUBKEY_BINDING) {
+            throw new PGPException("Signature is not a subkey binding signature.");
+        }
+
+        return keyBindingSignature(primaryKey, subKey);
+    }
+
+    /**
+     * Instantiate a signature verifier for a {@link PGPSignature#PRIMARYKEY_BINDING} signature.
+     *
+     * @param primaryKey primary (master) key
+     * @param subKey subkey
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier primaryKeyBindingSignature(PGPPublicKey primaryKey, PGPPublicKey subKey)
+            throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.PRIMARYKEY_BINDING) {
+            throw new PGPException("Signature is not a primary key binding signature.");
+        }
+
+        return keyBindingSignature(primaryKey, subKey);
+    }
+
+    /**
+     * Instantiate a signature verifier for a {@link PGPSignature#KEY_REVOCATION} signature.
+     * Note: To verify subkey revocations, use {@link #subKeyRevocationSignature(PGPPublicKey, PGPPublicKey)} instead.
+     *
+     * @param key revoked key
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier keyRevocationSignature(PGPPublicKey key) throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.KEY_REVOCATION) {
+            throw new PGPException("Signature is not a key revocation signature.");
+        }
+
+        return keySignature(key);
+    }
+
+    /**
+     * Instantiate a signature verifier for a {@link PGPSignature#SUBKEY_REVOCATION} signature.
+     * @param primaryKey primary (master) key
+     * @param subKey revoked subkey
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier subKeyRevocationSignature(PGPPublicKey primaryKey, PGPPublicKey subKey)
+            throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.SUBKEY_REVOCATION) {
+            throw new PGPException("Signature is not a sub-key revocation signature.");
+        }
+
+        return keyBindingSignature(primaryKey, subKey);
+    }
+
+    /**
+     * Instantiate a signature verifier for user-id certifications.
+     *
+     * @param userId user-id
+     * @param signedKey key that the user-id is bound to
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier userIdSignature(byte[] userId, PGPPublicKey signedKey)
+            throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.DEFAULT_CERTIFICATION
+                && signature.getSignatureType() != PGPSignature.NO_CERTIFICATION
+                && signature.getSignatureType() != PGPSignature.CASUAL_CERTIFICATION
+                && signature.getSignatureType() != PGPSignature.POSITIVE_CERTIFICATION) {
+            throw new PGPException("Signature is not a certification signature.");
+        }
+
+        return userIdSignature(signedKey, userId);
+    }
+
+    /**
+     * Instantiate a signature verifier for user-id certifications.
+     *
+     * @param userId user-id
+     * @param signedKey key that the user-id is bound to
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier userIdSignature(String userId, PGPPublicKey signedKey)
+            throws PGPException {
+        return userIdSignature(toBytes(userId), signedKey);
+    }
+
+    /**
+     * Instantiate a signature verifier for user-attribute certifications.
+     *
+     * @param userAttributes user-attributes
+     * @param signedKey key that the user-attributes are bound to
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier userAttributesSignature(PGPUserAttributeSubpacketVector userAttributes, PGPPublicKey signedKey)
+            throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.DEFAULT_CERTIFICATION
+                && signature.getSignatureType() != PGPSignature.NO_CERTIFICATION
+                && signature.getSignatureType() != PGPSignature.CASUAL_CERTIFICATION
+                && signature.getSignatureType() != PGPSignature.POSITIVE_CERTIFICATION) {
+            throw new PGPException("Signature is not a certification signature.");
+        }
+
+        return userAttributesSignature(signedKey, toBytes(userAttributes));
+    }
+
+    /**
+     * Instantiate a signature verifier for a {@link PGPSignature#THIRD_PARTY_CONFIRMATION} signature.
+     *
+     * @param confirmedSignature the signature that is being confirmed
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier thirdPartyConfirmationSignature(PGPSignature confirmedSignature)
+            throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.THIRD_PARTY_CONFIRMATION) {
+            throw new PGPException("Signature is not a third-party confirmation signature.");
+        }
+
+        return thirdPartyConfirmationSignature(toBytes(confirmedSignature));
+    }
+
+    /**
+     * Instantiate a signature verifier for a {@link PGPSignature#TIMESTAMP} signature.
+     *
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier timestampSignature() throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.TIMESTAMP) {
+            throw new PGPException("Signature is not a timestampt signature.");
+        }
+
+        return new PGPSignatureVerifier() {
+            @Override
+            public boolean verify() throws PGPException {
+                VersionedPGPSignatureVerifier signatureVerifier = getVerifier();
+                return signatureVerifier.verify();
+            }
+        };
+    }
+
+    /**
+     * Instantiate a signature verifier for a message signature
+     * ({@link PGPSignature#BINARY_DOCUMENT} or {@link PGPSignature#CANONICAL_TEXT_DOCUMENT}).
+     *
+     * @param message data the signature is made over
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier messageSignature(byte[] message) throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.CANONICAL_TEXT_DOCUMENT
+                && signature.getSignatureType() != PGPSignature.BINARY_DOCUMENT) {
+            throw new PGPException("Signature is nether of type CANONICAL_TEXT_DOCUMENT, nor of type BINARY_DOCUMENT.");
+        }
+
+        return new PGPSignatureVerifier() {
+            @Override
+            public boolean verify() throws PGPException {
+                VersionedPGPSignatureVerifier signatureVerifier = getVerifier();
+                signatureVerifier.update(message);
+                return signatureVerifier.verify();
+            }
+        };
+    }
+
+    /**
+     * Instantiate a signature verifier for a message signature
+     * ({@link PGPSignature#BINARY_DOCUMENT} or {@link PGPSignature#CANONICAL_TEXT_DOCUMENT}).
+     *
+     * @param messageIn input stream containing the data the signature is made over
+     * @return signature verifier
+     * @throws PGPException
+     */
+    public PGPSignatureVerifier messageSignature(InputStream messageIn) throws PGPException {
+        if (signature.getSignatureType() != PGPSignature.CANONICAL_TEXT_DOCUMENT
+                && signature.getSignatureType() != PGPSignature.BINARY_DOCUMENT) {
+            throw new PGPException("Signature is nether of type CANONICAL_TEXT_DOCUMENT, nor of type BINARY_DOCUMENT.");
+        }
+
+        return new PGPSignatureVerifier() {
+            @Override
+            public boolean verify() throws PGPException, IOException {
+                VersionedPGPSignatureVerifier signatureVerifier = getVerifier();
+                byte[] buf = new byte[8192];
+                int r;
+                while ((r = messageIn.read(buf)) != -1) {
+                    signatureVerifier.update(buf, 0, r);
+                }
+                return signatureVerifier.verify();
+            }
+        };
+    }
+
+    private VersionedPGPSignatureVerifier getVerifier() throws PGPException {
+        PGPContentVerifierBuilder verifierBuilder = verifierBuilderProvider.get(
+                signature.getKeyAlgorithm(), signature.getHashAlgorithm());
+
+        PGPContentVerifier contentVerifier = verifierBuilder.build(signingKey);
+
+        return VersionedPGPSignatureVerifier.getVerifier(
+                signature, contentVerifier);
+    }
+
+    private PGPSignatureVerifier keyBindingSignature(PGPPublicKey primaryKey, PGPPublicKey subKey) {
+        return new PGPSignatureVerifier() {
+            @Override
+            public boolean verify() throws PGPException {
+                VersionedPGPSignatureVerifier signatureVerifier = getVerifier();
+                signatureVerifier.updateWithPublicKey(toBytes(primaryKey));
+                signatureVerifier.updateWithPublicKey(toBytes(subKey));
+                return signatureVerifier.verify();
+            }
+        };
+    }
+
+    private PGPSignatureVerifier keySignature(PGPPublicKey key) {
+        return new PGPSignatureVerifier() {
+            @Override
+            public boolean verify() throws PGPException {
+                VersionedPGPSignatureVerifier signatureVerifier = getVerifier();
+                signatureVerifier.updateWithPublicKey(toBytes(key));
+                return signatureVerifier.verify();
+            }
+        };
+    }
+
+    private PGPSignatureVerifier userIdSignature(PGPPublicKey key, byte[] userData) {
+        return new PGPSignatureVerifier() {
+            @Override
+            public boolean verify() throws PGPException {
+                VersionedPGPSignatureVerifier signatureVerifier = getVerifier();
+                signatureVerifier.updateWithPublicKey(toBytes(key));
+                signatureVerifier.updateWithUserId(userData);
+                return signatureVerifier.verify();
+            }
+        };
+    }
+
+    private PGPSignatureVerifier userAttributesSignature(PGPPublicKey key, byte[] userAttributes) {
+        return new PGPSignatureVerifier() {
+            @Override
+            public boolean verify() throws PGPException {
+                VersionedPGPSignatureVerifier signatureVerifier = getVerifier();
+                signatureVerifier.updateWithPublicKey(toBytes(key));
+                signatureVerifier.updateWithUserAttributes(userAttributes);
+                return signatureVerifier.verify();
+            }
+        };
+    }
+
+    private PGPSignatureVerifier thirdPartyConfirmationSignature(byte[] confirmedSignature) {
+        return new PGPSignatureVerifier() {
+            @Override
+            public boolean verify() throws PGPException {
+                VersionedPGPSignatureVerifier signatureVerifier = getVerifier();
+                signatureVerifier.updateWithThirdPartySignature(confirmedSignature);
+                return signatureVerifier.verify();
+            }
+        };
+    }
+
+    private static byte[] toBytes(PGPPublicKey key) {
+        try {
+            return key.getPublicKeyPacket().getEncodedContents();
+        } catch (IOException e) {
+            throw new PGPRuntimeOperationException("exception preparing key.", e);
+        }
+    }
+
+    private static byte[] toBytes(String userId) {
+        return Strings.toUTF8ByteArray(userId);
+    }
+
+    private static byte[] toBytes(PGPUserAttributeSubpacketVector userAttributes) {
+        try {
+            ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+            UserAttributeSubpacket[] packets = userAttributes.toSubpacketArray();
+            for (int i = 0; i != packets.length; i++) {
+                packets[i].encode(bOut);
+            }
+            return bOut.toByteArray();
+        } catch (IOException e) {
+            throw new PGPRuntimeOperationException("cannot encode subpacket array", e);
+        }
+    }
+
+    private static byte[] toBytes(PGPSignature signature) {
+        try {
+            return encodeSignatureWithoutUnhashedData(signature);
+        } catch (IOException e) {
+            throw new PGPRuntimeOperationException("cannot encode signature", e);
+        }
+    }
+
+    private static byte[] encodeSignatureWithoutUnhashedData(PGPSignature signature) throws IOException {
+        SignaturePacket packet = signature.getSignaturePacket();
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        BCPGOutputStream pOut = new BCPGOutputStream(bOut);
+
+        int version = packet.getVersion();
+        pOut.write(version);
+
+        if (version == 3 || version == 2)
+        {
+            pOut.write(5); // the length of the next block
+
+            long    time = packet.getCreationTime() / 1000;
+
+            pOut.write(packet.getSignatureType());
+            pOut.write((byte)(time >> 24));
+            pOut.write((byte)(time >> 16));
+            pOut.write((byte)(time >> 8));
+            pOut.write((byte)time);
+
+            long keyID = packet.getKeyID();
+            pOut.write((byte)(keyID >> 56));
+            pOut.write((byte)(keyID >> 48));
+            pOut.write((byte)(keyID >> 40));
+            pOut.write((byte)(keyID >> 32));
+            pOut.write((byte)(keyID >> 24));
+            pOut.write((byte)(keyID >> 16));
+            pOut.write((byte)(keyID >> 8));
+            pOut.write((byte)(keyID));
+
+            pOut.write(packet.getKeyAlgorithm());
+            pOut.write(packet.getHashAlgorithm());
+        }
+        else if (version == 4)
+        {
+            pOut.write(packet.getSignatureType());
+            pOut.write(packet.getKeyAlgorithm());
+            pOut.write(packet.getHashAlgorithm());
+
+            ByteArrayOutputStream    sOut = new ByteArrayOutputStream();
+
+            for (int i = 0; i != packet.getHashedSubPackets().length; i++)
+            {
+                packet.getHashedSubPackets()[i].encode(sOut);
+            }
+
+            byte[]                   data = sOut.toByteArray();
+
+            pOut.write(data.length >> 8);
+            pOut.write(data.length);
+            pOut.write(data);
+
+            // Do not include unhashed data
+            pOut.write(0);
+            pOut.write(0);
+        }
+        else
+        {
+            throw new IOException("unknown version: " + version);
+        }
+
+        pOut.write(packet.getFingerPrint());
+
+        if (packet.getSignature() != null)
+        {
+            for (int i = 0; i != packet.getSignature().length; i++)
+            {
+                pOut.writeObject(packet.getSignature()[i]);
+            }
+        }
+        else
+        {
+            pOut.write(packet.getSignatureBytes());
+        }
+
+        pOut.close();
+
+        ByteArrayOutputStream sigOut = new ByteArrayOutputStream();
+        byte[] sigEncoding = bOut.toByteArray();
+
+        // We need the old format
+        BCPGOutputStream bSigOut = new BCPGOutputStream(sigOut, PacketTags.SIGNATURE, sigEncoding.length, true);
+        bSigOut.write(sigEncoding);
+        bSigOut.close();
+
+        return sigOut.toByteArray();
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/VersionedPGPSignatureVerifier.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/VersionedPGPSignatureVerifier.java
@@ -1,0 +1,370 @@
+package org.bouncycastle.openpgp.operator;
+
+import org.bouncycastle.bcpg.UnsupportedPacketVersionException;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPRuntimeOperationException;
+import org.bouncycastle.openpgp.PGPSignature;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * OpenPGP signature-verifier that allows different data-encoding schemes for different signature versions.
+ */
+abstract class VersionedPGPSignatureVerifier {
+
+    protected final PGPContentVerifier contentVerifier;
+    protected final OutputStream sigOut;
+    protected byte lastb;
+    protected final PGPSignature signature;
+
+    VersionedPGPSignatureVerifier(PGPContentVerifier contentVerifier, PGPSignature signature) {
+        this.signature = signature;
+        this.contentVerifier = contentVerifier;
+        sigOut = contentVerifier.getOutputStream();
+        lastb = 0;
+    }
+
+    /**
+     * Get a signature verifier instance for the given signature.
+     *
+     * @param signature OpenPGP signature to verify
+     * @param contentVerifier OpenPGP content verifier
+     * @return versioned signature verifier
+     */
+    static VersionedPGPSignatureVerifier getVerifier(PGPSignature signature, PGPContentVerifier contentVerifier) {
+        switch (signature.getVersion()) {
+            case PGPSignature.VERSION_3:
+                return new VersionedPGPSignatureVerifier.V3(contentVerifier, signature);
+
+            case PGPSignature.VERSION_4:
+                return new VersionedPGPSignatureVerifier.V4(contentVerifier, signature);
+
+            case PGPSignature.VERSION_5:
+                return new VersionedPGPSignatureVerifier.V5(contentVerifier, signature);
+
+            case PGPSignature.VERSION_6:
+                return new VersionedPGPSignatureVerifier.V6(contentVerifier, signature);
+
+            default:
+                throw new UnsupportedPacketVersionException("Unsupported PGP signature version: " + signature);
+        }
+    }
+
+    /**
+     * Update the signature verifier with public key data.
+     *
+     * @param key encoded public key
+     */
+    abstract void updateWithPublicKey(byte[] key);
+
+    /**
+     * Update the signature verifier with user-id data.
+     *
+     * @param rawUserId UTF8 encoded user-id
+     */
+    abstract void updateWithUserId(byte[] rawUserId);
+
+    /**
+     * Update the signature verifier with user-attribute data.
+     *
+     * @param userAttributesBytes encoded user-attributes
+     */
+    abstract void updateWithUserAttributes(byte[] userAttributesBytes);
+
+    /**
+     * Update the signature verifier with a third-party signature.
+     *
+     * @param confirmedSignature encoded signature which gets confirmed.
+     */
+    abstract void updateWithThirdPartySignature(byte[] confirmedSignature);
+
+    /**
+     * Update the signature verifier with a 4-octet-length-prefixed byte array.
+     *
+     * @param data bytes
+     */
+    void updateWith4OctetsLengthAndData(byte[] data) {
+        this.update((byte)(data.length >> 24));
+        this.update((byte)(data.length >> 16));
+        this.update((byte)(data.length >> 8));
+        this.update((byte)(data.length));
+        this.update(data);
+    }
+
+    /**
+     * Signature verifier for version 3 signatures.
+     */
+    static class V3 extends VersionedPGPSignatureVerifier {
+
+        V3(PGPContentVerifier contentVerifier, PGPSignature signature) {
+            super(contentVerifier, signature);
+        }
+
+        @Override
+        void updateWithPublicKey(byte[] keyBody) {
+            throw new UnsupportedPacketVersionException("OpenPGP v3 does not specify key-signatures.");
+        }
+
+        @Override
+        void updateWithUserId(byte[] rawUserId) {
+            this.update(rawUserId);
+        }
+
+        @Override
+        void updateWithUserAttributes(byte[] idBytes) {
+            this.update(idBytes);
+        }
+
+        @Override
+        void updateWithThirdPartySignature(byte[] confirmedSignature) {
+            throw new UnsupportedPacketVersionException("OpenPGP v3 does not specify third-party confirmation signatures.");
+        }
+    }
+
+    /**
+     * Signature verifier for version 4 signature.
+     */
+    static class V4 extends VersionedPGPSignatureVerifier {
+
+        V4(PGPContentVerifier contentVerifier, PGPSignature signature) {
+            super(contentVerifier, signature);
+        }
+
+        @Override
+        void updateWithPublicKey(byte[] keyBody) {
+            this.update((byte) 0x99);
+            this.update((byte) (keyBody.length >> 8));
+            this.update((byte) (keyBody.length));
+            this.update(keyBody);
+        }
+
+        @Override
+        void updateWithUserId(byte[] idBytes) {
+            this.update((byte) 0xb4);
+            updateWith4OctetsLengthAndData(idBytes);
+        }
+
+        @Override
+        void updateWithUserAttributes(byte[] idBytes) {
+            this.update((byte) 0xd1);
+            updateWith4OctetsLengthAndData(idBytes);
+        }
+
+        @Override
+        void updateWithThirdPartySignature(byte[] confirmedSignature) {
+            this.update((byte) 0x88);
+            updateWith4OctetsLengthAndData(confirmedSignature);
+        }
+    }
+
+    /**
+     * Signature verifier for version 5 signatures.
+     */
+    static class V5 extends VersionedPGPSignatureVerifier {
+
+        V5(PGPContentVerifier contentVerifier, PGPSignature signature) {
+            super(contentVerifier, signature);
+        }
+
+        @Override
+        void updateWithPublicKey(byte[] keyBody) {
+            this.update((byte) 0x9a);
+            updateWith4OctetsLengthAndData(keyBody);
+        }
+
+        @Override
+        void updateWithUserId(byte[] idBytes) {
+            this.update((byte) 0xb4);
+            updateWith4OctetsLengthAndData(idBytes);
+        }
+
+        @Override
+        void updateWithUserAttributes(byte[] idBytes) {
+            this.update((byte) 0xd1);
+            updateWith4OctetsLengthAndData(idBytes);
+        }
+
+        @Override
+        void updateWithThirdPartySignature(byte[] confirmedSignature) {
+            this.update((byte) 0x88);
+            updateWith4OctetsLengthAndData(confirmedSignature);
+        }
+    }
+
+    /**
+     * Signature verifier for version 6 signatures.
+     */
+    static class V6 extends VersionedPGPSignatureVerifier {
+
+        V6(PGPContentVerifier contentVerifier, PGPSignature signature) {
+            super(contentVerifier, signature);
+        }
+
+        @Override
+        void updateWithPublicKey(byte[] keyBody) {
+            // this.update(signature.getSalt());
+            this.update((byte) 0x9b);
+            updateWith4OctetsLengthAndData(keyBody);
+        }
+
+        @Override
+        void updateWithUserId(byte[] idBytes) {
+            this.update((byte) 0xb4);
+            updateWith4OctetsLengthAndData(idBytes);
+        }
+
+        @Override
+        void updateWithUserAttributes(byte[] idBytes) {
+            this.update((byte) 0xd1);
+            updateWith4OctetsLengthAndData(idBytes);
+        }
+
+        @Override
+        void updateWithThirdPartySignature(byte[] confirmedSignature) {
+            // this.update(signature.getSalt());
+            this.update((byte) 0x88);
+            updateWith4OctetsLengthAndData(confirmedSignature);
+        }
+    }
+
+    /**
+     * Update the verifier with a single byte.
+     * If the signature type is {@link PGPSignature#CANONICAL_TEXT_DOCUMENT}, line endings need to be converted
+     * to <pre>CR-LF</pre>, which this method takes care of.
+     *
+     * @param b byte
+     */
+    void update(
+            byte b)
+    {
+        if (signature.getSignatureType() != PGPSignature.CANONICAL_TEXT_DOCUMENT) {
+            byteUpdate(b);
+            return;
+        }
+
+        if (b == '\r')
+        {
+            byteUpdate((byte)'\r');
+            byteUpdate((byte)'\n');
+        }
+        else if (b == '\n')
+        {
+            if (lastb != '\r')
+            {
+                byteUpdate((byte)'\r');
+                byteUpdate((byte)'\n');
+            }
+        }
+        else
+        {
+            byteUpdate(b);
+        }
+
+        lastb = b;
+    }
+
+    /**
+     * Update the signature verifier with an array of bytes.
+     *
+     * @param bytes bytes
+     */
+    void update(
+            byte[] bytes)
+    {
+        this.update(bytes, 0, bytes.length);
+    }
+
+    /**
+     * Update the signature verifier with an array of bytes.
+     *
+     * @param bytes bytes
+     * @param off offset
+     * @param length length
+     */
+    void update(
+            byte[] bytes,
+            int off,
+            int length)
+    {
+        if (signature.getSignatureType() != PGPSignature.CANONICAL_TEXT_DOCUMENT) {
+            blockUpdate(bytes, off, length);
+            return;
+        }
+
+        int finish = off + length;
+
+        for (int i = off; i != finish; i++)
+        {
+            this.update(bytes[i]);
+        }
+    }
+
+    /**
+     * Update the signature verifier with a single byte without taking care for converted line endings.
+     *
+     * @param b byte
+     */
+    void byteUpdate(byte b)
+    {
+        try
+        {
+            sigOut.write(b);
+        }
+        catch (IOException e)
+        {
+            throw new PGPRuntimeOperationException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Update the signature verifier with an array of bytes without taking care for converted line endings.
+     *
+     * @param block bytes
+     * @param off offset
+     * @param len length
+     */
+    void blockUpdate(byte[] block, int off, int len)
+    {
+        try
+        {
+            sigOut.write(block, off, len);
+        }
+        catch (IOException e)
+        {
+            throw new PGPRuntimeOperationException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Update the signature verifier with the signatures trailer and finalize the verification by checking for
+     * signature correctness.
+     *
+     * @return <pre>true</pre> if the signature is correct, <pre>false</pre> otherwise
+     * @throws PGPException
+     */
+    boolean verify()
+            throws PGPException
+    {
+        addTrailer();
+
+        return contentVerifier.verify(signature.getSignature());
+    }
+
+    /**
+     * Update the signature verifier with the signatures trailer and close the verifier stream.
+     */
+    private void addTrailer()
+    {
+        try
+        {
+            sigOut.write(signature.getSignatureTrailer());
+
+            sigOut.close();
+        }
+        catch (IOException e)
+        {
+            throw new PGPRuntimeOperationException(e.getMessage(), e);
+        }
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/MultiThreadedSignatureVerificationTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/MultiThreadedSignatureVerificationTest.java
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2023 DenBond7, Paul Schaub <vanitasvitae@fsfe.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.bouncycastle.openpgp.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPSecretKeyRing;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
+import org.bouncycastle.openpgp.operator.bc.BcPGPContentVerifierBuilderProvider;
+import org.bouncycastle.util.test.SimpleTest;
+
+public class MultiThreadedSignatureVerificationTest
+        extends SimpleTest {
+
+    private static final String PRIVATE_KEY = "-----BEGIN PGP PRIVATE KEY BLOCK-----\n" +
+            "Version: PGPainless\n" +
+            "\n" +
+            "lIYEYIq7phYJKwYBBAHaRw8BAQdAat45rrh+gvQwWwJw5eScq3Pdxt/8d+lWNVSm\n" +
+            "kImXcRP+CQMCvWfx3mzDdd5g6c59LcPqADK0p70/7ZmTkp3ZC1YViTprg4tQt/PF\n" +
+            "QJL+VPCG+BF9bWyFcfxKe+KAnXRTWml5O6xrv6ZkiNmAxoYyO1shzLQWZGVmYXVs\n" +
+            "dEBmbG93Y3J5cHQudGVzdIh4BBMWCgAgBQJgirumAhsDBRYCAwEABAsJCAcFFQoJ\n" +
+            "CAsCHgECGQEACgkQIl+AI8INCVcysgD/cu23M07rImuV5gIl98uOnSIR+QnHUD/M\n" +
+            "I34b7iY/iTQBALMIsqO1PwYl2qKwmXb5lSoMj5SmnzRRE2RwAFW3AiMCnIsEYIq7\n" +
+            "phIKKwYBBAGXVQEFAQEHQA8q7iPr+0OXqBGBSAL6WNDjzHuBsG7uiu5w8l/A6v8l\n" +
+            "AwEIB/4JAwK9Z/HebMN13mCOF6Wy/9oZK4d0DW9cNLuQDeRVZejxT8oFMm7G8iGw\n" +
+            "CGNjIWWcQSvctBZtHwgcMeplCW7tmzkD3Nq/ty50lCwQQd6gZSXMiHUEGBYKAB0F\n" +
+            "AmCKu6YCGwwFFgIDAQAECwkIBwUVCgkICwIeAQAKCRAiX4Ajwg0JV+sbAQCv4LVM\n" +
+            "0+AN54ivWa4vPRyYOfSQ1FqsipkYLJce+xwUeAD+LZpEVCypFtGWQVdeSJVxIHx3\n" +
+            "k40IfHsK0fGgR+NrRAw=\n" +
+            "=osuI\n" +
+            "-----END PGP PRIVATE KEY BLOCK-----";
+
+    private static final PGPSecretKeyRing secretKeyRing;
+
+    static {
+        try {
+            secretKeyRing = readSecretKeyRing(PRIVATE_KEY);
+        } catch (IOException | PGPException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void performTest() throws Exception {
+        testBindingSignatureVerificationInThreads();
+    }
+
+    static PGPSecretKeyRing readSecretKeyRing(String armored) throws IOException, PGPException {
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(armored.getBytes(StandardCharsets.UTF_8));
+        ArmoredInputStream armorIn = new ArmoredInputStream(bytesIn);
+        return new PGPSecretKeyRing(armorIn, new BcKeyFingerprintCalculator());
+    }
+
+    public void testBindingSignatureVerificationInThreads() throws InterruptedException {
+        AtomicInteger atomicInteger = new AtomicInteger();
+        int numberOfThreads = 10;
+        int numberOfAttempts = 1000;
+        ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        for (int i = 0; i < numberOfThreads; i++) {
+            service.submit(() -> {
+                for (int j = 0; j < numberOfAttempts; j++) {
+                    try {
+                        isTrue(verifyBinding());
+                        atomicInteger.incrementAndGet();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        fail(e.getMessage());
+                    }
+                }
+                latch.countDown();
+            });
+        }
+
+        isTrue(latch.await(300, TimeUnit.SECONDS));
+        isEquals(numberOfThreads * numberOfAttempts, atomicInteger.get());
+        service.shutdown();
+    }
+
+    private static boolean verifyBinding() throws IOException, PGPException {
+        long keyId = Long.parseLong("4F1458BD22B7BB53", 16);
+        PGPPublicKey subKey = secretKeyRing.getPublicKey(keyId);
+        PGPPublicKey primaryKey = secretKeyRing.getPublicKey();
+        PGPSignature bindingSig = subKey.getKeySignatures().next();
+        PGPSignature.Verification verification = bindingSig.safeInit(new BcPGPContentVerifierBuilderProvider(), primaryKey);
+        return verification.verifyCertification(primaryKey, subKey);
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+
+    public static void main(String[] args) {
+        runTest(new MultiThreadedSignatureVerificationTest());
+    }
+}


### PR DESCRIPTION
As discussed in #1379, attempting to do multi-threaded operations on keys might result in race conditions during parallel signature verification of the same signature.

This PR separates out the state of a signature verification and allows to acquire per-thread verification objects for each signature.

This PR is fully backwards compatible.