### PR TITLE
Fix faulty PGPSignature tests

### DIFF
--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPSignatureTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPSignatureTest.java
@@ -561,7 +561,7 @@ public class PGPSignatureTest
         //
         sGen = new PGPSignatureGenerator(new JcaPGPContentSignerBuilder(PublicKeyAlgorithmTags.DSA, HashAlgorithmTags.SHA1).setProvider("BC"));
 
-        sGen.init(PGPSignature.SUBKEY_BINDING, pgpPrivDSAKey);
+        sGen.init(PGPSignature.DEFAULT_CERTIFICATION, pgpPrivDSAKey);
 
         sGen.setHashedSubpackets(null);
         sGen.setUnhashedSubpackets(null);
@@ -572,7 +572,7 @@ public class PGPSignatureTest
 
         if (!sig.verifyCertification(TEST_USER_ID, secretKey.getPublicKey()))
         {
-            fail("subkey binding verification failed.");
+            fail("user-id verification failed.");
         }
 
         hashedPcks = sig.getHashedSubPackets();
@@ -605,7 +605,7 @@ public class PGPSignatureTest
         //
         sGen = new PGPSignatureGenerator(new JcaPGPContentSignerBuilder(PublicKeyAlgorithmTags.DSA, HashAlgorithmTags.SHA1).setProvider("BC"));
 
-        sGen.init(PGPSignature.SUBKEY_BINDING, pgpPrivDSAKey);
+        sGen.init(PGPSignature.DEFAULT_CERTIFICATION, pgpPrivDSAKey);
 
         hashedGen = new PGPSignatureSubpacketGenerator();
 
@@ -625,7 +625,7 @@ public class PGPSignatureTest
 
         if (!sig.verifyCertification(TEST_USER_ID, secretKey.getPublicKey()))
         {
-            fail("subkey binding verification failed.");
+            fail("user-id verification failed.");
         }
 
         hashedPcks = sig.getHashedSubPackets();


### PR DESCRIPTION
I noticed, that the `PGPSignatureTest` class contains some tests that make no sense.

In there, a subkey-binding signature is generated, but over a user-id and its primary key.
Subkey binding signature can only be generated over two keys (the primary key and its subkey), but not over user-ids.

I fixed the test and found no breakage.

The faulty test got uncovered, since in #1383 the new API sanitizes signature types during verification.