### PR TITLE
JcePBEDataDecryptorFactoryBuilder.setProvider(): Inject provider into…

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEDataDecryptorFactoryBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEDataDecryptorFactoryBuilder.java
@@ -64,6 +64,7 @@ public class JcePBEDataDecryptorFactoryBuilder
     public JcePBEDataDecryptorFactoryBuilder setProvider(Provider provider)
     {
         this.helper = new OperatorHelper(new ProviderJcaJceHelper(provider));
+        this.aeadHelper = new JceAEADUtil(helper);
 
         return this;
     }
@@ -77,6 +78,7 @@ public class JcePBEDataDecryptorFactoryBuilder
     public JcePBEDataDecryptorFactoryBuilder setProvider(String providerName)
     {
         this.helper = new OperatorHelper(new NamedJcaJceHelper(providerName));
+        this.aeadHelper = new JceAEADUtil(helper);
 
         return this;
     }


### PR DESCRIPTION
… JceAEADUtil instance

Consider a setup, where the systems SecurityProviders are not changed (i.e. there is no `Security.addProvider(new BouncyCastleProvider())` call).

It is still possible to use different providers in the Jce classes by calling `setProvider()`.
This method injects the security provider instance, so that it gets used to instantiate Ciphers etc.

In case of the `JcePBEDataDecryptorFactoryBuilder, there are two places where the provider needs to be changed when `setProvider()` is called, as code depends on it: 
* `helper` is an `OperatorHelper` that gets initialized with a `ProviderJcaJceHelper` with the given provider
* `aeadHelper` uses `helper` to provide AEAD-related functionality.

Now, when `setProvider()` is called, the `helper` is replaced with a fresh `ProviderJcaJceHelper` instance, but the `aeadHelper` still references the old `OperatorHelper` instance, which by default is a `DefaultJcaJceHelper` object.

As a result, while the user has called `setProvider()`, some OpenPGP operations using AEAD ciphers (e.g. AES/OCB/NoPadding) will fail (see https://github.com/bcgit/bc-java/issues/1390), since the JceAEADUtil `aeadHelper` uses the `DefaultJcaJceHelper` which cannot utilize the set SecurityProvider.

The patch fixes this by replacing the `JceAEADUtil` instance too when calling `setProvider()`.