### PR TITLE
OpenPGP: Switch on integrity protection by default

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPDataEncryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPDataEncryptorBuilder.java
@@ -26,7 +26,7 @@ public class BcPGPDataEncryptorBuilder
     implements PGPDataEncryptorBuilder
 {
     private SecureRandom random;
-    private boolean withIntegrityPacket;
+    private boolean withIntegrityPacket = true;
     private int encAlgorithm;
     private boolean isV5StyleAEAD = true; // TODO: change to false in 1.75
     private int aeadAlgorithm = -1;


### PR DESCRIPTION
Greetings from the 7th. OpenPGP Summit in Geneva!

This PR enables integrity protection for OpenPGP messages by default. It can of course by disabled by calling `dataEncryptorBuilder.setWithIntegrityProtection(false)`.

Generating messages without integrity protection has been discouraged for a while now, so I thought it is about time.