### PR TITLE
Specify UTF-8 encoding in bc+-build.xml

### DIFF
--- a/ant/bc+-build.xml
+++ b/ant/bc+-build.xml
@@ -119,7 +119,7 @@
                 <mkdir dir="${build.dir}/@{target}/classes" />
                 <mkdir dir="${artifacts.dir}/@{target}" />
 
-                <javac source="${bc.javac.source}" target="${bc.javac.target}"
+                <javac encoding="UTF-8" source="${bc.javac.source}" target="${bc.javac.target}"
                     srcdir="${artifacts.dir}/@{target}/src"
                     destdir="${build.dir}/@{target}/classes"
                     memoryMaximumSize="512m"
@@ -156,7 +156,7 @@
                 <mkdir dir="${build.dir}/@{target}/classes" />
                 <mkdir dir="${artifacts.dir}/@{target}" />
 
-                <javac source="${bc.javac.source}" target="${bc.javac.target}"
+                <javac encoding="UTF-8" source="${bc.javac.source}" target="${bc.javac.target}"
                     srcdir="${artifacts.dir}/@{target}/src"
                     destdir="${build.dir}/@{target}/classes"
                     memoryMaximumSize="512m"
@@ -312,7 +312,7 @@
              </fileset>
         </copy>
 
-        <javac source="${bc.javac.source}" target="${bc.javac.target}"
+        <javac encoding="UTF-8" source="${bc.javac.source}" target="${bc.javac.target}"
             srcdir="${lcrypto.target.src.dir}"
             destdir="${lcrypto.target.classes.dir}"
 	    memoryMaximumSize="512m"


### PR DESCRIPTION
If the default is set to ASCII, this fails to build.