### PR TITLE
OpenPGP: Support for parsing v6 Signatures

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/OnePassSignaturePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/OnePassSignaturePacket.java
@@ -1,5 +1,8 @@
 package org.bouncycastle.bcpg;
 
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.io.Streams;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
@@ -9,12 +12,17 @@ import java.io.IOException;
 public class OnePassSignaturePacket 
     extends ContainedPacket
 {
-    private int  version;
-    private int  sigType;
-    private int  hashAlgorithm;
-    private int  keyAlgorithm;
-    private long keyID;
-    private int isContaining;
+    public static final int VERSION_3 = 3;
+    public static final int VERSION_6 = 6;
+
+    private final int  version;           // v3, v6
+    private final int  sigType;           // v3, v6
+    private final int  hashAlgorithm;     // v3, v6
+    private final int  keyAlgorithm;      // v3, v6
+    private final byte[] salt;            //     v6
+    private final long keyID;             // v3
+    private final byte[] keyFingerprint;  //     v6
+    private final int isContaining;       // v3, v6
     
     OnePassSignaturePacket(
         BCPGInputStream    in)
@@ -24,19 +32,80 @@ public class OnePassSignaturePacket
         sigType = in.read();
         hashAlgorithm = in.read();
         keyAlgorithm = in.read();
-        
-        keyID |= (long)in.read() << 56;
-        keyID |= (long)in.read() << 48;
-        keyID |= (long)in.read() << 40;
-        keyID |= (long)in.read() << 32;
-        keyID |= (long)in.read() << 24;
-        keyID |= (long)in.read() << 16;
-        keyID |= (long)in.read() << 8;
-        keyID |= in.read();
-        
-        isContaining = in.read();
+
+        if (version == VERSION_3)
+        {
+            long keyID = 0;
+            keyID |= (long) in.read() << 56;
+            keyID |= (long) in.read() << 48;
+            keyID |= (long) in.read() << 40;
+            keyID |= (long) in.read() << 32;
+            keyID |= (long) in.read() << 24;
+            keyID |= (long) in.read() << 16;
+            keyID |= (long) in.read() << 8;
+            keyID |= in.read();
+            this.keyID = keyID;
+
+            isContaining = in.read();
+
+            this.salt = null;
+            this.keyFingerprint = null;
+        }
+        else if (version == VERSION_6)
+        {
+            keyID = 0;
+            int expectedSaltSize = SignaturePacket.getSaltSize(hashAlgorithm);
+            int saltSize = in.read();
+            if (saltSize != expectedSaltSize)
+            {
+                Streams.drain(in);
+                throw new UnsupportedPacketVersionException("Unexpected salt size " + expectedSaltSize + ", got " + saltSize);
+            }
+
+            salt = new byte[saltSize];
+            in.readFully(salt);
+
+            keyFingerprint = new byte[32];
+            in.readFully(keyFingerprint);
+
+            isContaining = in.read();
+        }
+        else
+        {
+            Streams.drain(in);
+            throw new UnsupportedPacketVersionException("Unsupported One-Pass-Signature packet version encountered: " + version);
+        }
     }
-    
+
+    public static OnePassSignaturePacket createVersion3Packet(
+            int sigType,
+            int hashAlgorithm,
+            int keyAlgorithm,
+            long keyID,
+            boolean isNested)
+    {
+        return new OnePassSignaturePacket(sigType, hashAlgorithm, keyAlgorithm, keyID, isNested);
+    }
+
+    public static OnePassSignaturePacket createVersion6Packet(
+            int sigType,
+            int hashAlgorithm,
+            int keyAlgorithm,
+            byte[] salt,
+            byte[] keyFingerprint,
+            boolean isNested)
+    {
+        return new OnePassSignaturePacket(sigType, hashAlgorithm, keyAlgorithm, salt, keyFingerprint, isNested);
+    }
+
+    /**
+     * Create an OPS packet of version {@link #VERSION_3}.
+     * @param sigType signature type
+     * @param hashAlgorithm hash algorithm identifier
+     * @param keyAlgorithm public key algorithm identifier
+     * @param keyID key id
+     * @param isNested is nested flag
+     */
     public OnePassSignaturePacket(
         int        sigType,
         int        hashAlgorithm,
@@ -44,14 +113,55 @@ public class OnePassSignaturePacket
         long       keyID,
         boolean    isNested)
     {
-        this.version = 3;
-        this.sigType = sigType;
+        this(VERSION_3, sigType, hashAlgorithm, keyAlgorithm, null, keyID, null, isNested);
+    }
+
+    /**
+     * Create an OPS packet of version {@link #VERSION_6}.
+     *
+     * @param sigType signature type
+     * @param hashAlgorithm hash algorithm identifier
+     * @param keyAlgorithm public key algorithm identifier
+     * @param salt salt
+     * @param keyFingerprint key fingerprint
+     * @param isNested is nested flag
+     */
+    public OnePassSignaturePacket(
+            int sigType,
+            int hashAlgorithm,
+            int keyAlgorithm,
+            byte[] salt,
+            byte[] keyFingerprint,
+            boolean isNested)
+    {
+        this(VERSION_6, sigType, hashAlgorithm, keyAlgorithm, salt, 0, keyFingerprint, isNested);
+    }
+
+    public OnePassSignaturePacket(
+            int version,
+            int signatureType,
+            int hashAlgorithm,
+            int keyAlgorithm,
+            byte[] salt,
+            long keyID,
+            byte[] keyFingerprint,
+            boolean isNested)
+    {
+        this.version = version;
+        this.sigType = signatureType;
         this.hashAlgorithm = hashAlgorithm;
         this.keyAlgorithm = keyAlgorithm;
         this.keyID = keyID;
-        this.isContaining = (isNested) ? 0 : 1;
+        this.keyFingerprint = keyFingerprint;
+        this.salt = salt;
+        this.isContaining = isNested ? 0 : 1;
     }
-    
+
+    public int getVersion()
+    {
+        return version;
+    }
+
     /**
      * Return the signature type.
      * @return the signature type
@@ -76,13 +186,42 @@ public class OnePassSignaturePacket
     {
         return hashAlgorithm;
     }
+
+    /**
+     * Return the salt of the signature.
+     * Only for {@link #VERSION_6}, returns <pre>null</pre> otherwise.
+     *
+     * @return salt
+     */
+    public byte[] getSalt() {
+        if (salt != null) {
+            return Arrays.clone(salt);
+        }
+        return null;
+    }
     
     /**
+     * Return the key-id of the issuing key.
+     * Only for {@link #VERSION_3}. Signatures of version {@link #VERSION_6} use {@link #getKeyFingerprint()} instead.
+     *
      * @return long
      */
     public long getKeyID()
     {
         return keyID;
+    }
+
+    /**
+     * Return the v6 fingerprint of the issuing key.
+     * Only for {@link #VERSION_6}. Signatures of version {@link #VERSION_3} use {@link #getKeyID()} instead.
+     *
+     * @return 32 byte array
+     */
+    public byte[] getKeyFingerprint() {
+        if (keyFingerprint != null) {
+            return Arrays.clone(keyFingerprint);
+        }
+        return null;
     }
 
     /**
@@ -112,14 +251,28 @@ public class OnePassSignaturePacket
         pOut.write(hashAlgorithm);
         pOut.write(keyAlgorithm);
 
-        pOut.write((byte)(keyID >> 56));
-        pOut.write((byte)(keyID >> 48));
-        pOut.write((byte)(keyID >> 40));
-        pOut.write((byte)(keyID >> 32));
-        pOut.write((byte)(keyID >> 24));
-        pOut.write((byte)(keyID >> 16));
-        pOut.write((byte)(keyID >> 8));
-        pOut.write((byte)(keyID));
+        if (version == VERSION_3)
+        {
+            pOut.write((byte) (keyID >> 56));
+            pOut.write((byte) (keyID >> 48));
+            pOut.write((byte) (keyID >> 40));
+            pOut.write((byte) (keyID >> 32));
+            pOut.write((byte) (keyID >> 24));
+            pOut.write((byte) (keyID >> 16));
+            pOut.write((byte) (keyID >> 8));
+            pOut.write((byte) (keyID));
+        }
+        else if (version == VERSION_6)
+        {
+            pOut.write(salt.length);
+            pOut.write(salt);
+
+            pOut.write(keyFingerprint);
+        }
+        else
+        {
+            throw new UnsupportedPacketVersionException("Unsupported One-Pass-Signature version encountered: " + version);
+        }
         
         pOut.write(isContaining);
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPOnePassSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPOnePassSignature.java
@@ -183,9 +183,19 @@ public class PGPOnePassSignature
         return verifier.verify(pgpSig.getSignature());
     }
 
+    public int getVersion()
+    {
+        return sigPack.getVersion();
+    }
+
     public long getKeyID()
     {
         return sigPack.getKeyID();
+    }
+
+    public byte[] getKeyFingerprint()
+    {
+        return sigPack.getKeyFingerprint();
     }
 
     public int getSignatureType()
@@ -201,6 +211,11 @@ public class PGPOnePassSignature
     public int getKeyAlgorithm()
     {
         return sigPack.getKeyAlgorithm();
+    }
+
+    public byte[] getSalt()
+    {
+        return sigPack.getSalt();
     }
 
     /**

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -18,6 +18,7 @@ import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.bouncycastle.bcpg.SignaturePacket;
 import org.bouncycastle.bcpg.SignatureSubpacket;
 import org.bouncycastle.bcpg.TrustPacket;
+import org.bouncycastle.bcpg.UnsupportedPacketVersionException;
 import org.bouncycastle.bcpg.UserAttributeSubpacket;
 import org.bouncycastle.openpgp.operator.PGPContentVerifier;
 import org.bouncycastle.openpgp.operator.PGPContentVerifierBuilder;
@@ -703,7 +704,12 @@ public class PGPSignature
     public static PGPSignature join(PGPSignature sig1, PGPSignature sig2)
         throws PGPException
     {
-        if (!isSignatureEncodingEqual(sig1, sig2))
+        if (sig1.getVersion() < SignaturePacket.VERSION_4)
+        {
+            throw new UnsupportedPacketVersionException("Cannot merge signatures with versions other than 4, 5, 6.");
+        }
+
+        if (sig1.getVersion() != sig2.getVersion() || !isSignatureEncodingEqual(sig1, sig2))
         {
             throw new IllegalArgumentException("These are different signatures.");
         }
@@ -734,17 +740,19 @@ public class PGPSignature
         }
 
         SignatureSubpacket[] unhashed = (SignatureSubpacket[])merged.toArray(new SignatureSubpacket[0]);
+
         return new PGPSignature(
-            new SignaturePacket(
-                sig1.getSignatureType(),
-                sig1.getKeyID(),
-                sig1.getKeyAlgorithm(),
-                sig1.getHashAlgorithm(),
-                sig1.getHashedSubPackets().packets,
-                unhashed,
-                sig1.getDigestPrefix(),
-                sig1.sigPck.getSignature()
-            )
+                new SignaturePacket(
+                        sig1.getVersion(),
+                        sig1.getSignatureType(),
+                        sig1.getKeyID(),
+                        sig1.getKeyAlgorithm(),
+                        sig1.getHashAlgorithm(),
+                        sig1.sigPck.getHashedSubPackets(),
+                        unhashed,
+                        sig1.getDigestPrefix(),
+                        sig1.sigPck.getSalt(),
+                        sig1.sigPck.getSignature())
         );
     }
 }

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -129,6 +129,17 @@ public class PGPSignature
     }
 
     /**
+     * Return the salt associated with this signature.
+     * Only for {@link SignaturePacket#VERSION_6} signatures.
+     *
+     * @return salt
+     */
+    public byte[] getSalt()
+    {
+        return sigPck.getSalt();
+    }
+
+    /**
      * Return the digest prefix of the signature.
      *
      * @return digest prefix

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureGenerator.java
@@ -184,7 +184,7 @@ public class PGPSignatureGenerator
         boolean    isNested)
         throws PGPException
     {
-        return new PGPOnePassSignature(new OnePassSignaturePacket(sigType, contentSigner.getHashAlgorithm(), contentSigner.getKeyAlgorithm(), contentSigner.getKeyID(), isNested));
+        return new PGPOnePassSignature(OnePassSignaturePacket.createVersion3Packet(sigType, contentSigner.getHashAlgorithm(), contentSigner.getKeyAlgorithm(), contentSigner.getKeyID(), isNested));
     }
     
     /**

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPV3SignatureGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPV3SignatureGenerator.java
@@ -151,7 +151,7 @@ public class PGPV3SignatureGenerator
         boolean isNested)
         throws PGPException
     {
-        return new PGPOnePassSignature(new OnePassSignaturePacket(sigType, contentSigner.getHashAlgorithm(), contentSigner.getKeyAlgorithm(), contentSigner.getKeyID(), isNested));
+        return new PGPOnePassSignature(OnePassSignaturePacket.createVersion3Packet(sigType, contentSigner.getHashAlgorithm(), contentSigner.getKeyAlgorithm(), contentSigner.getKeyID(), isNested));
     }
     
     /**


### PR DESCRIPTION
This PR adds initial support for the new v6 signature + one-pass-signature packet format.

It only focusses on the wire format, so there is no code yet related to generating or verifying such signatures.