### PR TITLE
Add support for crypto-refresh style PreferredAEADCiphersuites signat…

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/SignatureSubpacketInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignatureSubpacketInputStream.java
@@ -14,6 +14,7 @@ import org.bouncycastle.bcpg.sig.KeyExpirationTime;
 import org.bouncycastle.bcpg.sig.KeyFlags;
 import org.bouncycastle.bcpg.sig.NotationData;
 import org.bouncycastle.bcpg.sig.PolicyURI;
+import org.bouncycastle.bcpg.sig.PreferredAEADCiphersuites;
 import org.bouncycastle.bcpg.sig.PreferredAlgorithms;
 import org.bouncycastle.bcpg.sig.PrimaryUserID;
 import org.bouncycastle.bcpg.sig.RegularExpression;
@@ -164,8 +165,9 @@ public class SignatureSubpacketInputStream
         case PREFERRED_COMP_ALGS:
         case PREFERRED_HASH_ALGS:
         case PREFERRED_SYM_ALGS:
-        case PREFERRED_AEAD_ALGORITHMS:
             return new PreferredAlgorithms(type, isCritical, isLongLength, data);
+        case PREFERRED_AEAD_ALGORITHMS:
+            return new PreferredAEADCiphersuites(isCritical, isLongLength, data);
         case KEY_FLAGS:
             return new KeyFlags(isCritical, isLongLength, data);
         case POLICY_URL:

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/PreferredAEADCiphersuites.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/PreferredAEADCiphersuites.java
@@ -1,0 +1,214 @@
+package org.bouncycastle.bcpg.sig;
+
+import org.bouncycastle.bcpg.AEADAlgorithmTags;
+import org.bouncycastle.bcpg.SignatureSubpacket;
+import org.bouncycastle.bcpg.SignatureSubpacketTags;
+import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
+
+public class PreferredAEADCiphersuites extends SignatureSubpacket
+{
+
+    private final Combination[] algorithms;
+
+    /**
+     * AES-128 + OCB is a MUST implement and is therefore implicitly supported.
+     *
+     * @see <a href="https://openpgp-wg.gitlab.io/rfc4880bis/#name-preferred-aead-ciphersuites">
+     *     Crypto-Refresh § 5.2.3.15. Preferred AEAD Ciphersuites</a>
+     */
+    private static final Combination AES_128_OCB = new Combination(SymmetricKeyAlgorithmTags.AES_128, AEADAlgorithmTags.OCB);
+
+    /**
+     * Create a new PreferredAEADAlgorithms signature subpacket from raw data.
+     *
+     * @param critical whether the subpacket is critical
+     * @param isLongLength whether the subpacket uses long length encoding
+     * @param data raw data
+     */
+    public PreferredAEADCiphersuites(boolean critical, boolean isLongLength, byte[] data)
+    {
+        super(SignatureSubpacketTags.PREFERRED_AEAD_ALGORITHMS, critical, isLongLength, requireEven(data));
+        this.algorithms = parseCombinations(data);
+    }
+
+    /**
+     * Create a new PreferredAEADAlgorithm signature subpacket.
+     *
+     * @param critical whether the subpacket is critical
+     * @param combinations list of combinations, with the most preferred option first
+     */
+    public PreferredAEADCiphersuites(boolean critical, Combination[] combinations)
+    {
+        this(critical, false, encodeCombinations(combinations));
+    }
+
+    /**
+     * Unmarshall a byte array into a list of algorithm combinations.
+     *
+     * @param data marshalled bytes
+     * @return unmarshalled list
+     */
+    private static Combination[] parseCombinations(byte[] data)
+    {
+        Combination[] algorithms = new Combination[data.length / 2];
+        for (int i = 0; i < algorithms.length; i++)
+        {
+            algorithms[i] = new Combination(
+                    data[i * 2],
+                    data[i * 2 + 1]);
+        }
+        return algorithms;
+    }
+
+    /**
+     * Marshall the list of combinations into a byte array.
+     *
+     * @param combinations list of algorithm combinations
+     * @return marshalled byte array
+     */
+    private static byte[] encodeCombinations(Combination[] combinations)
+    {
+        byte[] encoding = new byte[combinations.length * 2];
+        for (int i = 0; i < combinations.length; i++)
+        {
+            Combination combination = combinations[i];
+            encoding[i * 2] =       (byte) (combination.getSymmetricAlgorithm() & 0xff);
+            encoding[i * 2 + 1] =   (byte) (combination.getAeadAlgorithm() & 0xff);
+        }
+        return encoding;
+    }
+
+    /**
+     * Return true, if the given algorithm combination is supported (explicitly or implicitly).
+     *
+     * @param combination combination
+     * @return true, if the combination is supported, false otherwise
+     */
+    public boolean isSupported(Combination combination)
+    {
+        return contains(combination, getAlgorithms());
+    }
+
+    private static boolean contains(Combination combination, Combination[] combinations) {
+        for (Combination supported : combinations)
+        {
+            if (supported.equals(combination))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return AEAD algorithm preferences. The most preferred option comes first.
+     * This method returns the combinations as they are listed in the packet, possibly excluding implicitly supported
+     * combinations.
+     *
+     * @return explicitly supported algorithm combinations
+     */
+    public Combination[] getRawAlgorithms()
+    {
+        Combination[] copy = new Combination[algorithms.length];
+        System.arraycopy(algorithms, 0, copy, 0, algorithms.length);
+        return copy;
+    }
+
+    /**
+     * Returns AEAD algorithm preferences, including implicitly supported algorithm combinations.
+     *
+     * @return all supported algorithm combinations
+     */
+    public Combination[] getAlgorithms()
+    {
+        if (!contains(AES_128_OCB, algorithms))
+        {
+            // AES128 + OCB is MUST implement and implicitly supported
+            Combination[] withImplicitOptionAppended = new Combination[algorithms.length + 1];
+            System.arraycopy(algorithms, 0, withImplicitOptionAppended, 0, algorithms.length);
+            withImplicitOptionAppended[algorithms.length] = AES_128_OCB;
+            return withImplicitOptionAppended;
+        }
+
+        return getRawAlgorithms();
+    }
+
+    private static byte[] requireEven(byte[] encodedCombinations)
+    {
+        if (encodedCombinations.length % 2 != 0)
+        {
+            throw new IllegalArgumentException("Even number of bytes expected.");
+        }
+        return encodedCombinations;
+    }
+
+    /**
+     * Algorithm combination of a {@link SymmetricKeyAlgorithmTags} and a {@link AEADAlgorithmTags}.
+     */
+    public static class Combination
+    {
+        private final int symmetricAlgorithm;
+        private final int aeadAlgorithm;
+
+        /**
+         * Create a new algorithm combination from a {@link SymmetricKeyAlgorithmTags} and a {@link AEADAlgorithmTags}.
+         *
+         * @param symmetricAlgorithmTag symmetric algorithm tag
+         * @param aeadAlgorithmTag aead algorithm tag
+         */
+        public Combination(int symmetricAlgorithmTag, int aeadAlgorithmTag)
+        {
+            this.symmetricAlgorithm = symmetricAlgorithmTag;
+            this.aeadAlgorithm = aeadAlgorithmTag;
+        }
+
+        /**
+         * Return the symmetric algorithm tag.
+         *
+         * @return symmetric algorithm
+         */
+        public int getSymmetricAlgorithm()
+        {
+            return symmetricAlgorithm;
+        }
+
+        /**
+         * Return the AEAD algorithm tag.
+         *
+         * @return aead algorithm
+         */
+        public int getAeadAlgorithm()
+        {
+            return aeadAlgorithm;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (o == null)
+            {
+                return false;
+            }
+
+            if (this == o)
+            {
+                return true;
+            }
+
+            if (!(o instanceof Combination))
+            {
+                return false;
+            }
+
+            Combination other = (Combination) o;
+            return getSymmetricAlgorithm() == other.getSymmetricAlgorithm()
+                    && getAeadAlgorithm() == other.getAeadAlgorithm();
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return 13 * getSymmetricAlgorithm() + 17 * getAeadAlgorithm();
+        }
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPAeadTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPAeadTest.java
@@ -6,7 +6,10 @@ import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
 import org.bouncycastle.bcpg.PaddingPacket;
+import org.bouncycastle.bcpg.SignatureSubpacket;
+import org.bouncycastle.bcpg.SignatureSubpacketInputStream;
 import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
+import org.bouncycastle.bcpg.sig.PreferredAEADCiphersuites;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openpgp.PGPEncryptedData;
 import org.bouncycastle.openpgp.PGPEncryptedDataGenerator;
@@ -125,6 +128,8 @@ public class PGPAeadTest
         roundTripEncryptionDecryptionTests();
 
         paddingPacketTests();
+
+        preferredAEADAlgorithmsTests();
     }
 
     private void roundTripEncryptionDecryptionTests()
@@ -499,6 +504,66 @@ public class PGPAeadTest
 
         PGPPadding padding = (PGPPadding)factory.nextObject();
         isTrue(Arrays.areEqual(packet.getPadding(), padding.getPadding()));
+    }
+
+    private void preferredAEADAlgorithmsTests()
+        throws IOException {
+        preferredAEADAlgorithmsImplicitlySupportAES128OCB();
+        preferredAEADAlgorithmsRoundtrip();
+        preferredAEADAlgorithmsInvalidConstructor();
+    }
+
+    private void preferredAEADAlgorithmsImplicitlySupportAES128OCB()
+    {
+        PreferredAEADCiphersuites.Combination implicit = new PreferredAEADCiphersuites.Combination(
+                SymmetricKeyAlgorithmTags.AES_128, AEADAlgorithmTags.OCB);
+
+        PreferredAEADCiphersuites preferences = new PreferredAEADCiphersuites(false,
+                new PreferredAEADCiphersuites.Combination[0]);
+
+        isTrue(preferences.isSupported(implicit));
+        isTrue(Arrays.areEqual(new PreferredAEADCiphersuites.Combination[0], preferences.getRawAlgorithms()));
+        isTrue(Arrays.areEqual(new PreferredAEADCiphersuites.Combination[] {implicit}, preferences.getAlgorithms()));
+    }
+
+    private void preferredAEADAlgorithmsRoundtrip()
+        throws IOException
+    {
+        PreferredAEADCiphersuites preferences = new PreferredAEADCiphersuites(false, new PreferredAEADCiphersuites.Combination[]
+                {
+                        new PreferredAEADCiphersuites.Combination(SymmetricKeyAlgorithmTags.AES_256, AEADAlgorithmTags.OCB),
+                        new PreferredAEADCiphersuites.Combination(SymmetricKeyAlgorithmTags.AES_256, AEADAlgorithmTags.GCM),
+                        new PreferredAEADCiphersuites.Combination(SymmetricKeyAlgorithmTags.CAMELLIA_256, AEADAlgorithmTags.OCB)
+                });
+        isTrue(Arrays.areEqual(new byte[] {0x09, 0x02, 0x09, 0x03, 0x0d, 0x02}, preferences.getData()));
+
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        BCPGOutputStream bcpgOut = new BCPGOutputStream(bOut);
+
+        preferences.encode(bcpgOut);
+
+        ByteArrayInputStream bIn = new ByteArrayInputStream(bOut.toByteArray());
+        SignatureSubpacketInputStream subpacketIn = new SignatureSubpacketInputStream(bIn);
+        SignatureSubpacket subpacket = subpacketIn.readPacket();
+        assert subpacket != null;
+        assert subpacket instanceof PreferredAEADCiphersuites;
+
+        PreferredAEADCiphersuites parsed = (PreferredAEADCiphersuites) subpacket;
+        isTrue(Arrays.areEqual(preferences.getRawAlgorithms(), parsed.getRawAlgorithms()));
+    }
+
+    private void preferredAEADAlgorithmsInvalidConstructor()
+    {
+        // odd number of data bytes
+        try
+        {
+            new PreferredAEADCiphersuites(false, false, new byte[] {0x09, 0x02, 0x09});
+            fail("Odd number of data bytes must throw.");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // expected
+        }
     }
 
     public static void main(String[] args)


### PR DESCRIPTION
…ure subpacket

This PR adds support for the Preferred AEAD Ciphersuites subpacket [as defined](https://openpgp-wg.gitlab.io/rfc4880bis/#name-preferred-aead-ciphersuites) by the crypto-refresh document.

This packet lists supported combinations of symmetric algorithms and AEAD algorithms.