### PR TITLE
OpenPGP v6 elliptic curve key formats

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/Ed25519PublicBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/Ed25519PublicBCPGKey.java
@@ -1,0 +1,20 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+public class Ed25519PublicBCPGKey
+        extends OctetArrayPublicBCPGKey
+{
+    public static final int LENGTH = 32;
+
+    public Ed25519PublicBCPGKey(BCPGInputStream in)
+            throws IOException
+    {
+        super(LENGTH, in);
+    }
+
+    public Ed25519PublicBCPGKey(byte[] key)
+    {
+        super(LENGTH, key);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/Ed25519SecretBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/Ed25519SecretBCPGKey.java
@@ -1,0 +1,20 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+public class Ed25519SecretBCPGKey
+    extends OctetArraySecretBCPGKey
+{
+    public static final int LENGTH = 32;
+
+    public Ed25519SecretBCPGKey(BCPGInputStream in)
+            throws IOException
+    {
+        super(LENGTH, in);
+    }
+
+    public Ed25519SecretBCPGKey(byte[] key)
+    {
+        super(LENGTH, key);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/Ed448PublicBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/Ed448PublicBCPGKey.java
@@ -1,0 +1,21 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+public class Ed448PublicBCPGKey
+        extends OctetArrayPublicBCPGKey
+{
+    public static final int LENGTH = 57;
+
+    public Ed448PublicBCPGKey(BCPGInputStream in)
+            throws IOException
+    {
+        super(LENGTH, in);
+    }
+
+    public Ed448PublicBCPGKey(byte[] key)
+    {
+        super(LENGTH, key);
+    }
+
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/Ed448SecretBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/Ed448SecretBCPGKey.java
@@ -1,0 +1,20 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+public class Ed448SecretBCPGKey
+        extends OctetArraySecretBCPGKey
+{
+    public static final int LENGTH = 57;
+
+    public Ed448SecretBCPGKey(BCPGInputStream in)
+            throws IOException
+    {
+        super(LENGTH, in);
+    }
+
+    public Ed448SecretBCPGKey(byte[] key)
+    {
+        super(LENGTH, key);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/OctetArrayPublicBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/OctetArrayPublicBCPGKey.java
@@ -1,0 +1,65 @@
+package org.bouncycastle.bcpg;
+
+import org.bouncycastle.util.Arrays;
+
+import java.io.IOException;
+
+/**
+ * PublicBCPGKey which is encoded as an array of octets rather than an MPI.
+ */
+public abstract class OctetArrayPublicBCPGKey
+        extends BCPGObject
+        implements BCPGKey
+{
+
+    private final byte[] key;
+
+    OctetArrayPublicBCPGKey(int length, BCPGInputStream in)
+            throws IOException
+    {
+        key = new byte[length];
+        in.readFully(key);
+    }
+
+    OctetArrayPublicBCPGKey(int length, byte[] key)
+    {
+        if (key.length != length)
+        {
+            throw new IllegalArgumentException("Unexpected key encoding length. Expected " + length + " bytes, got " + key.length);
+        }
+        this.key = new byte[length];
+        System.arraycopy(key, 0, this.key, 0, length);
+    }
+
+    /**
+     * return the standard PGP encoding of the key.
+     *
+     * @see org.bouncycastle.bcpg.BCPGKey#getEncoded()
+     */
+    @Override
+    public byte[] getEncoded()
+    {
+        try
+        {
+            return super.getEncoded();
+        }
+        catch (IOException e)
+        {
+            return null;
+        }
+    }
+
+    @Override
+    public String getFormat() {
+        return "PGP";
+    }
+
+    @Override
+    public void encode(BCPGOutputStream out) throws IOException {
+        out.write(key);
+    }
+
+    public byte[] getKey() {
+        return Arrays.clone(key);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/OctetArraySecretBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/OctetArraySecretBCPGKey.java
@@ -1,0 +1,64 @@
+package org.bouncycastle.bcpg;
+
+import org.bouncycastle.util.Arrays;
+
+import java.io.IOException;
+
+/**
+ * SecretBCPGKey which is encoded as an array of octets rather than an MPI.
+ */
+public abstract class OctetArraySecretBCPGKey
+        extends BCPGObject
+        implements BCPGKey
+{
+
+    private final byte[] key;
+
+    OctetArraySecretBCPGKey(int length, BCPGInputStream in)
+        throws IOException
+    {
+        this.key = new byte[length];
+        in.readFully(key);
+    }
+
+    OctetArraySecretBCPGKey(int length, byte[] key)
+    {
+        if (key.length != length)
+        {
+            throw new IllegalArgumentException("Unexpected key encoding length. Expected " + length + " bytes, got " + key.length);
+        }
+        this.key = new byte[length];
+        System.arraycopy(key, 0, this.key, 0, length);
+    }
+
+    @Override
+    public String getFormat()
+    {
+        return "PGP";
+    }
+
+    @Override
+    public byte[] getEncoded()
+    {
+        try
+        {
+            return super.getEncoded();
+        }
+        catch (IOException e)
+        {
+            return null;
+        }
+    }
+
+    @Override
+    public void encode(BCPGOutputStream out)
+            throws IOException
+    {
+        out.write(key);
+    }
+
+    public byte[] getKey()
+    {
+        return Arrays.clone(key);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
@@ -53,6 +53,18 @@ public class PublicKeyPacket
         case EDDSA_LEGACY:
             key = new EdDSAPublicBCPGKey(in);
             break;
+        case X25519:
+            key = new X25519PublicBCPGKey(in);
+            break;
+        case X448:
+            key = new X448PublicBCPGKey(in);
+            break;
+        case Ed25519:
+            key = new Ed25519PublicBCPGKey(in);
+            break;
+        case Ed448:
+            key = new Ed448PublicBCPGKey(in);
+            break;
         default:
             throw new IOException("unknown PGP public key algorithm encountered: " + algorithm);
         }

--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
@@ -13,6 +13,7 @@ public class PublicKeyPacket
     public static final int VERSION_3 = 3;
     public static final int VERSION_4 = 4;
     public static final int VERSION_6 = 6;
+
     private int            version;
     private long           time;
     private int            validDays;
@@ -32,6 +33,11 @@ public class PublicKeyPacket
         }
         
         algorithm = (byte)in.read();
+        if (version == VERSION_6)
+        {
+            // TODO: Use keyOctets to be able to parse unknown keys
+            long keyOctets = ((long) in.read() << 24) | ((long) in.read() << 16) | ((long) in.read() << 8) | in.read();
+        }
 
         switch (algorithm)
         {
@@ -136,6 +142,15 @@ public class PublicKeyPacket
         }
     
         pOut.write(algorithm);
+
+        if (version == VERSION_6)
+        {
+            int keyOctets = key.getEncoded().length;
+            pOut.write(keyOctets >> 24);
+            pOut.write(keyOctets >> 16);
+            pOut.write(keyOctets >> 8);
+            pOut.write(keyOctets);
+        }
     
         pOut.writeObject((BCPGObject)key);
 

--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
@@ -10,6 +10,9 @@ import java.util.Date;
 public class PublicKeyPacket 
     extends ContainedPacket implements PublicKeyAlgorithmTags
 {
+    public static final int VERSION_3 = 3;
+    public static final int VERSION_4 = 4;
+    public static final int VERSION_6 = 6;
     private int            version;
     private long           time;
     private int            validDays;
@@ -23,7 +26,7 @@ public class PublicKeyPacket
         version = in.read();
         time = ((long)in.read() << 24) | (in.read() << 16) | (in.read() << 8) | in.read();
  
-        if (version <= 3)
+        if (version <= VERSION_3)
         {
             validDays = (in.read() << 8) | in.read();
         }
@@ -82,7 +85,7 @@ public class PublicKeyPacket
         Date       time,
         BCPGKey    key)
     {
-        this.version = 4;
+        this.version = VERSION_4;
         this.time = time.getTime() / 1000;
         this.algorithm = algorithm;
         this.key = key;
@@ -126,7 +129,7 @@ public class PublicKeyPacket
         pOut.write((byte)(time >> 8));
         pOut.write((byte)time);
     
-        if (version <= 3)
+        if (version <= VERSION_3)
         {
             pOut.write((byte)(validDays >> 8));
             pOut.write((byte)validDays);

--- a/pg/src/main/java/org/bouncycastle/bcpg/X25519PublicBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/X25519PublicBCPGKey.java
@@ -1,0 +1,20 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+public class X25519PublicBCPGKey
+        extends OctetArrayPublicBCPGKey
+{
+    public static final int LENGTH = 32;
+
+    public X25519PublicBCPGKey(BCPGInputStream in)
+            throws IOException
+    {
+        super(LENGTH, in);
+    }
+
+    public X25519PublicBCPGKey(byte[] key)
+    {
+        super(LENGTH, key);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/X25519SecretBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/X25519SecretBCPGKey.java
@@ -1,0 +1,20 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+public class X25519SecretBCPGKey
+    extends OctetArraySecretBCPGKey
+{
+    public static final int LENGTH = 32;
+
+    public X25519SecretBCPGKey(BCPGInputStream in)
+            throws IOException
+    {
+        super(LENGTH, in);
+    }
+
+    public X25519SecretBCPGKey(byte[] key)
+    {
+        super(LENGTH, key);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/X448PublicBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/X448PublicBCPGKey.java
@@ -1,0 +1,20 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+public class X448PublicBCPGKey
+        extends OctetArrayPublicBCPGKey
+{
+    public static final int LENGTH = 56;
+
+    public X448PublicBCPGKey(BCPGInputStream in)
+            throws IOException
+    {
+        super(LENGTH, in);
+    }
+
+    public X448PublicBCPGKey(byte[] key)
+    {
+        super(LENGTH, key);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/X448SecretBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/X448SecretBCPGKey.java
@@ -1,0 +1,20 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+public class X448SecretBCPGKey
+    extends OctetArraySecretBCPGKey
+{
+    public static final int LENGTH = 56;
+
+    public X448SecretBCPGKey(BCPGInputStream in)
+            throws IOException
+    {
+        super(LENGTH, in);
+    }
+
+    public X448SecretBCPGKey(byte[] key)
+    {
+        super(LENGTH, key);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -58,7 +58,7 @@ public class PGPPublicKey
 
         this.fingerprint = fingerPrintCalculator.calculateFingerprint(publicPk);
 
-        if (publicPk.getVersion() <= 3)
+        if (publicPk.getVersion() <= PublicKeyPacket.VERSION_3)
         {
             RSAPublicBCPGKey rK = (RSAPublicBCPGKey)key;
 
@@ -256,7 +256,7 @@ public class PGPPublicKey
      */
     public int getValidDays()
     {
-        if (publicPk.getVersion() > 3)
+        if (publicPk.getVersion() > PublicKeyPacket.VERSION_3)
         {
             long delta = this.getValidSeconds() % (24 * 60 * 60);
             int days = (int)(this.getValidSeconds() / (24 * 60 * 60));
@@ -297,7 +297,7 @@ public class PGPPublicKey
      */
     public long getValidSeconds()
     {
-        if (publicPk.getVersion() > 3)
+        if (publicPk.getVersion() > PublicKeyPacket.VERSION_3)
         {
             if (this.isMasterKey())
             {

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -65,7 +65,7 @@ public class PGPPublicKey
             this.keyID = rK.getModulus().longValue();
             this.keyStrength = rK.getModulus().bitLength();
         }
-        else
+        else if (publicPk.getVersion() == PublicKeyPacket.VERSION_4)
         {
             this.keyID = ((long)(fingerprint[fingerprint.length - 8] & 0xff) << 56)
                 | ((long)(fingerprint[fingerprint.length - 7] & 0xff) << 48)
@@ -75,7 +75,22 @@ public class PGPPublicKey
                 | ((long)(fingerprint[fingerprint.length - 3] & 0xff) << 16)
                 | ((long)(fingerprint[fingerprint.length - 2] & 0xff) << 8)
                 | ((fingerprint[fingerprint.length - 1] & 0xff));
+        }
+        else if (publicPk.getVersion() == PublicKeyPacket.VERSION_6)
+        {
+            this.keyID = ((long) (fingerprint[0] & 0xff) << 56)
+                    | ((long)(fingerprint[1] & 0xff) << 48)
+                    | ((long)(fingerprint[2] & 0xff) << 40)
+                    | ((long) (fingerprint[3] & 0xff) << 32)
+                    | ((long) (fingerprint[4] & 0xff) << 24)
+                    | ((long) (fingerprint[5] & 0xff) << 16)
+                    | ((long) (fingerprint[6] & 0xff) << 8)
+                    | ((long) (fingerprint[7] & 0xff));
+        }
 
+        // key strength
+        if (publicPk.getVersion() >= PublicKeyPacket.VERSION_4)
+        {
             if (key instanceof RSAPublicBCPGKey)
             {
                 this.keyStrength = ((RSAPublicBCPGKey)key).getModulus().bitLength();

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -14,6 +14,8 @@ import org.bouncycastle.bcpg.BCPGObject;
 import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.bcpg.DSASecretBCPGKey;
 import org.bouncycastle.bcpg.ECSecretBCPGKey;
+import org.bouncycastle.bcpg.Ed25519SecretBCPGKey;
+import org.bouncycastle.bcpg.Ed448SecretBCPGKey;
 import org.bouncycastle.bcpg.EdSecretBCPGKey;
 import org.bouncycastle.bcpg.ElGamalSecretBCPGKey;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
@@ -29,6 +31,8 @@ import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
 import org.bouncycastle.bcpg.TrustPacket;
 import org.bouncycastle.bcpg.UserAttributePacket;
 import org.bouncycastle.bcpg.UserIDPacket;
+import org.bouncycastle.bcpg.X25519SecretBCPGKey;
+import org.bouncycastle.bcpg.X448SecretBCPGKey;
 import org.bouncycastle.gpg.SExprParser;
 import org.bouncycastle.openpgp.operator.KeyFingerPrintCalculator;
 import org.bouncycastle.openpgp.operator.PBEProtectionRemoverFactory;
@@ -666,6 +670,14 @@ public class PGPSecretKey
                 EdSecretBCPGKey edPriv = new EdSecretBCPGKey(in);
 
                 return new PGPPrivateKey(this.getKeyID(), pubPk, edPriv);
+            case PGPPublicKey.X25519:
+                return new PGPPrivateKey(this.getKeyID(), pubPk, new X25519SecretBCPGKey(in));
+            case PGPPublicKey.X448:
+                return new PGPPrivateKey(this.getKeyID(), pubPk, new X448SecretBCPGKey(in));
+            case PGPPublicKey.Ed25519:
+                return new PGPPrivateKey(this.getKeyID(), pubPk, new Ed25519SecretBCPGKey(in));
+            case PGPPublicKey.Ed448:
+                return new PGPPrivateKey(this.getKeyID(), pubPk, new Ed448SecretBCPGKey(in));
             default:
                 throw new PGPException("unknown public key algorithm encountered");
             }


### PR DESCRIPTION
This PR adds support for parsing new OpenPGP v6 key algorithms X25519, X448, Ed25519, Ed448.

Note, that while some of these algorithms were already sort of supported in OpenPGP v4 (`EDDSA_LEGACY`), v6 properly introduces them with a changed encoding wire format: https://openpgp-wg.gitlab.io/rfc4880bis/#name-public-key-algorithms

To prevent duplicated code, I also introduced `OctetArrayPublicBCPGKey` and `OctetArraySecretBCPGKey` classes, which handle the byte array length enforcing etc.