### PR TITLE
Implement OpenPGP Packet Criticality

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/AEADEncDataPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/AEADEncDataPacket.java
@@ -118,4 +118,10 @@ public class AEADEncDataPacket
     {
         return AEADUtils.getIVLength(aeadAlgorithm);
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return getType();
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/BCPGInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/BCPGInputStream.java
@@ -264,7 +264,7 @@ public class BCPGInputStream
         switch (tag)
         {
         case RESERVED:
-            return new InputStreamPacket(objStream);
+            return new ReservedPacket(objStream);
         case PUBLIC_KEY_ENC_SESSION:
             return new PublicKeyEncSessionPacket(objStream);
         case SIGNATURE:

--- a/pg/src/main/java/org/bouncycastle/bcpg/BCPGInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/BCPGInputStream.java
@@ -309,7 +309,7 @@ public class BCPGInputStream
         case EXPERIMENTAL_4:
             return new ExperimentalPacket(tag, objStream);
         default:
-            throw new IOException("unknown packet type encountered: " + tag);
+            return new UnknownPacket(tag, objStream);
         }
     }
 

--- a/pg/src/main/java/org/bouncycastle/bcpg/CompressedDataPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/CompressedDataPacket.java
@@ -28,4 +28,10 @@ public class CompressedDataPacket
     {
         return algorithm;
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return COMPRESSED_DATA;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/ExperimentalPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ExperimentalPacket.java
@@ -43,4 +43,10 @@ public class ExperimentalPacket
     {
         out.writePacket(tag, contents);
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return getTag();
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/InputStreamPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/InputStreamPacket.java
@@ -3,7 +3,7 @@ package org.bouncycastle.bcpg;
 /**
  * A block of data associated with other packets in a PGP object stream.
  */
-public class InputStreamPacket
+public abstract class InputStreamPacket
     extends Packet
 {
     private BCPGInputStream        in;

--- a/pg/src/main/java/org/bouncycastle/bcpg/LiteralDataPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/LiteralDataPacket.java
@@ -73,4 +73,10 @@ public class LiteralDataPacket
     {
         return Arrays.clone(fileName);
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return LITERAL_DATA;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/MarkerPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/MarkerPacket.java
@@ -25,4 +25,10 @@ public class MarkerPacket
     {
         out.writePacket(MARKER, marker);
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return MARKER;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/ModDetectionCodePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ModDetectionCodePacket.java
@@ -42,4 +42,10 @@ public class ModDetectionCodePacket
     {
         out.writePacket(MOD_DETECTION_CODE, digest, false);
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return MOD_DETECTION_CODE;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/OnePassSignaturePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/OnePassSignaturePacket.java
@@ -127,4 +127,10 @@ public class OnePassSignaturePacket
 
         out.writePacket(ONE_PASS_SIGNATURE, bOut.toByteArray());
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return ONE_PASS_SIGNATURE;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/Packet.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/Packet.java
@@ -2,8 +2,29 @@ package org.bouncycastle.bcpg;
 
 /**
  */
-public class Packet
+public abstract class Packet
     implements PacketTags
 {
 
+    /**
+     * Return the tag of the packet.
+     *
+     * @return packet tag
+     */
+    public abstract int getPacketTag();
+
+    /**
+     * Returns whether the packet is to be considered critical for v6 implementations.
+     * Packets with tags less or equal to 39 are critical.
+     * Tags 40 to 59 are reserved for unassigned, non-critical packets.
+     * Tags 60 to 63 are non-critical private or experimental packets.
+     *
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-09.html#name-packet-tags">
+     *     Packet Tags</a>
+     * @return true if the packet is critical, false otherwise.
+     */
+    public boolean isCritical()
+    {
+        return getPacketTag() <= 39;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/PaddingPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PaddingPacket.java
@@ -45,4 +45,10 @@ public class PaddingPacket
     {
         pOut.writePacket(PacketTags.PADDING, padding);
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return PADDING;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyEncSessionPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyEncSessionPacket.java
@@ -279,4 +279,10 @@ public class PublicKeyEncSessionPacket
 
         out.writePacket(PUBLIC_KEY_ENC_SESSION , bOut.toByteArray());
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return PUBLIC_KEY_ENC_SESSION;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
@@ -165,4 +165,10 @@ public class PublicKeyPacket
     {
         out.writePacket(PUBLIC_KEY, getEncodedContents());
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return PUBLIC_KEY;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicSubkeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicSubkeyPacket.java
@@ -37,4 +37,10 @@ public class PublicSubkeyPacket
     {
         out.writePacket(PUBLIC_SUBKEY, getEncodedContents());
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return PUBLIC_SUBKEY;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/ReservedPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ReservedPacket.java
@@ -1,0 +1,12 @@
+package org.bouncycastle.bcpg;
+
+public class ReservedPacket
+    extends InputStreamPacket
+{
+
+    public ReservedPacket(BCPGInputStream in)
+    {
+        super(in);
+    }
+
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/ReservedPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ReservedPacket.java
@@ -9,4 +9,9 @@ public class ReservedPacket
         super(in);
     }
 
+    @Override
+    public int getPacketTag()
+    {
+        return RESERVED;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
@@ -184,4 +184,10 @@ public class SecretKeyPacket
     {
         out.writePacket(SECRET_KEY, getEncodedContents());
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return SECRET_KEY;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/SecretSubkeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SecretSubkeyPacket.java
@@ -55,4 +55,10 @@ public class SecretSubkeyPacket
     {
         out.writePacket(SECRET_SUBKEY, getEncodedContents());
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return SECRET_SUBKEY;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
@@ -538,4 +538,10 @@ public class SignaturePacket
 
         return new SignaturePacket(in);
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return SIGNATURE;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/SymmetricEncDataPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SymmetricEncDataPacket.java
@@ -32,4 +32,10 @@ public class SymmetricEncDataPacket
     {
          // nothing to add
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return getType();
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/SymmetricEncIntegrityPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SymmetricEncIntegrityPacket.java
@@ -173,4 +173,10 @@ public class SymmetricEncIntegrityPacket
     {
         return Arrays.copyOf(salt, salt.length);
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return getType();
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/SymmetricKeyEncSessionPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SymmetricKeyEncSessionPacket.java
@@ -345,4 +345,10 @@ public class SymmetricKeyEncSessionPacket
 
         out.writePacket(SYMMETRIC_KEY_ENC_SESSION, bOut.toByteArray());
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return SYMMETRIC_KEY_ENC_SESSION;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/TrustPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/TrustPacket.java
@@ -45,4 +45,10 @@ public class TrustPacket
     {
         out.writePacket(TRUST, levelAndTrustAmount);
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return TRUST;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/UnknownPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/UnknownPacket.java
@@ -1,0 +1,39 @@
+package org.bouncycastle.bcpg;
+
+import org.bouncycastle.util.Arrays;
+
+import java.io.IOException;
+
+public class UnknownPacket
+        extends ContainedPacket
+{
+
+    private final int tag;
+    private final byte[] contents;
+
+    public UnknownPacket(int tag, BCPGInputStream in)
+            throws IOException
+    {
+        this.tag = tag;
+        this.contents = in.readAll();
+    }
+
+    public byte[] getContents()
+    {
+        return Arrays.clone(contents);
+    }
+
+    @Override
+    public void encode(
+            BCPGOutputStream    out)
+            throws IOException
+    {
+        out.writePacket(tag, contents);
+    }
+
+    @Override
+    public int getPacketTag()
+    {
+        return tag;
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/UserAttributePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/UserAttributePacket.java
@@ -57,4 +57,10 @@ public class UserAttributePacket
 
         out.writePacket(USER_ATTRIBUTE, bOut.toByteArray());
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return USER_ATTRIBUTE;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/UserIDPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/UserIDPacket.java
@@ -63,4 +63,10 @@ public class UserIDPacket
     {
         out.writePacket(USER_ID, idData);
     }
+
+    @Override
+    public int getPacketTag()
+    {
+        return USER_ID;
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
@@ -171,10 +171,11 @@ public class PGPObjectFactory
             return in.readPacket();
         }
 
+        int tag = in.nextPacketTag();
         UnknownPacket unknownPacket = (UnknownPacket) in.readPacket();
-        if (!throwForUnknownCriticalPackets && unknownPacket.isCritical()) {
+        if (throwForUnknownCriticalPackets && unknownPacket.isCritical()) {
             // Leave the error message intact for backwards compatibility
-            throw new IOException("unknown object in stream: " + in.nextPacketTag());
+            throw new IOException("unknown object in stream: " + tag);
         }
         return unknownPacket;
     }

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPObjectFactory.java
@@ -87,6 +87,8 @@ public class PGPObjectFactory
         {
         case -1:
             return null;
+        case PacketTags.RESERVED:
+            return in.readPacket();
         case PacketTags.SIGNATURE:
             l = new ArrayList();
 

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
@@ -51,7 +51,8 @@ public class RegressionTest
         new PGPEncryptedDataTest(),
         new PGPAeadTest(),
         new CRC24Test(),
-        new WildcardKeyIDTest()
+        new WildcardKeyIDTest(),
+        new UnknownPacketTest()
     };
 
     public static void main(String[] args)

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/UnknownPacketTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/UnknownPacketTest.java
@@ -1,0 +1,133 @@
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.bcpg.UnknownPacket;
+import org.bouncycastle.openpgp.PGPObjectFactory;
+import org.bouncycastle.openpgp.bc.BcPGPObjectFactory;
+import org.bouncycastle.util.encoders.Hex;
+import org.bouncycastle.util.test.SimpleTest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class UnknownPacketTest
+        extends SimpleTest
+{
+
+
+    @Override
+    public String getName()
+    {
+        return "UnknownPacketTest";
+    }
+
+    @Override
+    public void performTest()
+            throws Exception
+    {
+        // Test encoding
+        testUnknownCriticalPacket();
+        testUnknownNonCriticalPacket();
+
+        // Test parsing with PGPObjectFactory
+        testParseNonCriticalPacket();
+        testParseCriticalPacketWithThrowing();
+        testParseCriticalPacketWithoutThrowing();
+    }
+
+    private void testUnknownCriticalPacket()
+            throws IOException
+    {
+        int tag = 39; // within critical range
+        byte[] contents = new byte[] {0x50, 0x47, 0x50, 0x61, 0x69, 0x6e, 0x6c, 0x65, 0x73, 0x73};
+        ByteArrayInputStream bIn = new ByteArrayInputStream(contents);
+        BCPGInputStream bcIn = new BCPGInputStream(bIn);
+        UnknownPacket packet = new UnknownPacket(tag, bcIn);
+
+        isTrue(packet.isCritical());
+        testPacketEncoding(tag, contents, packet);
+    }
+
+    private void testUnknownNonCriticalPacket()
+            throws IOException
+    {
+        int tag = 44; // within non-critical range
+        byte[] contents = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
+        ByteArrayInputStream bIn = new ByteArrayInputStream(contents);
+        BCPGInputStream bcIn = new BCPGInputStream(bIn);
+        UnknownPacket packet = new UnknownPacket(tag, bcIn);
+
+        isTrue(!packet.isCritical());
+        testPacketEncoding(tag, contents, packet);
+    }
+
+    private void testPacketEncoding(int tag, byte[] contents, UnknownPacket packet)
+            throws IOException
+    {
+        byte[] encoded = packet.getEncoded();
+
+        int hdr = encodeTag(tag);
+        isEquals(hdr, encoded[0] & 0xff);
+        isEquals(contents.length, encoded[1]);
+        for (int i = 0; i < contents.length; i++)
+        {
+            isEquals(encoded[i + 2], contents[i]);
+        }
+    }
+
+    private int encodeTag(int tag)
+    {
+        int hdr = 0x80;
+        hdr |= 0x40 | tag;
+        return hdr & 0xff;
+    }
+
+    private void testParseNonCriticalPacket()
+            throws IOException
+    {
+        int tag = 44;
+        String encodedCriticalPacket = "ec0e4f70656e50475020726f636b7321"; // Tag 36
+        ByteArrayInputStream in = new ByteArrayInputStream(Hex.decode(encodedCriticalPacket));
+
+        PGPObjectFactory objectFactory = new BcPGPObjectFactory(in);
+        UnknownPacket packet = (UnknownPacket) objectFactory.nextObject();
+        isEquals(tag, packet.getPacketTag());
+        isTrue(!packet.isCritical());
+    }
+
+    private void testParseCriticalPacketWithoutThrowing()
+            throws IOException
+    {
+        int tag = 36;
+        String encodedCriticalPacket = "e40e4f70656e50475020726f636b7321"; // Tag 36
+        ByteArrayInputStream in = new ByteArrayInputStream(Hex.decode(encodedCriticalPacket));
+
+        PGPObjectFactory objectFactory = new BcPGPObjectFactory(in);
+        UnknownPacket packet = (UnknownPacket) objectFactory.nextObject();
+        isEquals(tag, packet.getPacketTag());
+        isTrue(packet.isCritical());
+    }
+
+    private void testParseCriticalPacketWithThrowing()
+    {
+        String encodedCriticalPacket = "e40e4f70656e50475020726f636b7321"; // Tag 36
+        ByteArrayInputStream in = new ByteArrayInputStream(Hex.decode(encodedCriticalPacket));
+
+        PGPObjectFactory objectFactory = new BcPGPObjectFactory(in)
+                .setThrowForUnknownCriticalPackets(true); // Enable exception throwing for unknown critical packets
+        try
+        {
+            objectFactory.nextObject();
+            fail("Expected IOException, but nothing was thrown");
+        }
+        catch (IOException e)
+        {
+            // expected
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new UnknownPacketTest());
+    }
+}


### PR DESCRIPTION
The upcoming OpenPGP v6 specification introduces the concept of [Packet Criticality](https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-09.html#packet-criticality) based on packet tags.

This PR adds support for packet criticality by adding `getPacketTag()` to the `Packet` class.
Further, it introduces a dedicated `UnknownPacket` class to improve [forwards compatibility](https://mailarchive.ietf.org/arch/msg/openpgp/QUiEKx3PQeJOXnkcvvnuHpv739M/) with future revisions of the standard, as well as a dedicated `ReservedPacket` class.