### PR TITLE
ArmoredInputStream: Make CRC calculation optional

### DIFF
--- a/pg/src/test/java/org/bouncycastle/openpgp/test/ArmorCRCTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/ArmorCRCTest.java
@@ -1,0 +1,86 @@
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.openpgp.PGPLiteralData;
+import org.bouncycastle.openpgp.PGPObjectFactory;
+import org.bouncycastle.openpgp.bc.BcPGPObjectFactory;
+import org.bouncycastle.util.io.Streams;
+import org.bouncycastle.util.test.SimpleTest;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class ArmorCRCTest
+        extends SimpleTest {
+
+    private static final String WITHOUT_CRC = "" +
+            "-----BEGIN PGP MESSAGE-----\n" +
+            "\n" +
+            "yxR0AAAAAABIZWxsbywgV29ybGQhCg==\n" +
+            "-----END PGP MESSAGE-----\n";
+    private static final String FAULTY_CRC = "" +
+            "-----BEGIN PGP MESSAGE-----\n" +
+            "\n" +
+            "yxR0AAAAAABIZWxsbywgV29ybGQhCg==\n" +
+            "=TRA9\n" +
+            "-----END PGP MESSAGE-----";
+
+    @Override
+    public String getName() {
+        return "ArmoredOutputStreamTest";
+    }
+
+    @Override
+    public void performTest() throws Exception {
+        // TODO: Uncomment if #1425 is merged
+        // generateArmorWithoutCRCSum();
+        consumeArmorWithoutCRC();
+    }
+
+    // TODO: Uncomment if #1425 is merged
+    /*
+    private void generateArmorWithoutCRCSum() throws IOException {
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        ArmoredOutputStream armorOut = ArmoredOutputStream.builder()
+                .setComputeCRCSum(false)
+                .build(bOut);
+
+        PGPLiteralDataGenerator litGen = new PGPLiteralDataGenerator();
+        OutputStream litOut = litGen.open(armorOut, PGPLiteralDataGenerator.TEXT,
+                "", PGPLiteralData.NOW, new byte[512]);
+        litOut.write("Hello, World!\n".getBytes(StandardCharsets.UTF_8));
+        litOut.close();
+        armorOut.close();
+
+        isEquals(WITHOUT_CRC, bOut.toString());
+    }
+     */
+
+    private void consumeArmorWithoutCRC() throws IOException {
+        consumeSuccessfullyIgnoringCRCSum(WITHOUT_CRC);
+        consumeSuccessfullyIgnoringCRCSum(FAULTY_CRC);
+    }
+
+    private void consumeSuccessfullyIgnoringCRCSum(String armor) throws IOException {
+        ByteArrayInputStream bIn = new ByteArrayInputStream(armor.getBytes(StandardCharsets.UTF_8));
+        ArmoredInputStream armorIn = new ArmoredInputStream(bIn)
+                .ignoreCRCSum();
+
+        PGPObjectFactory objectFactory = new BcPGPObjectFactory(armorIn);
+        PGPLiteralData literalData = (PGPLiteralData) objectFactory.nextObject();
+        InputStream litIn = literalData.getDataStream();
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        Streams.pipeAll(litIn, bOut);
+        litIn.close();
+        armorIn.close();
+
+        isEquals("Hello, World!\n", bOut.toString());
+    }
+
+    public static void main(String[] args) {
+        runTest(new ArmorCRCTest());
+    }
+}


### PR DESCRIPTION
The [crypto-refresh-09 document states](https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-09.html#name-optional-checksum) that the CRC sum of ASCII armor is considered optional.

Really, if some new packet formats are used (SEIPDv2), the ASCII armored output MUST NOT even include a CRC sum:

> The CRC24 footer MUST NOT be generated if it can be determined by context or by the OpenPGP object being encoded that the consuming implementation accepts base64 encoded blocks without CRC24 footer. Notably:
> * An ASCII-armored Encrypted Message packet sequence that ends in an v2 SEIPD packet MUST NOT contain a CRC24 footer.
> * An ASCII-armored sequence of Signature packets that only includes v6 Signature packets MUST NOT contain a CRC24 footer.
> * An ASCII-armored Transferable Public Key packet sequence of a v6 key MUST NOT contain a CRC24 footer.
> * An ASCII-armored keyring consisting of only v6 keys MUST NOT contain a CRC24 footer.

This PR allows the user to configure `ArmoredOutputStream` objects to not calculate and include a CRC sum using `noCRCSum()`.
It also allows the user to disable CRC checksum calculation altogether when consuming armored data using and `ArmoredInputStream` by calling `ignoreCRCSum()`.

Some tests are included as well.