### PR TITLE
ArmoredOutputStream: Do not include a Version: header by default

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
@@ -116,7 +116,7 @@ public class ArmoredOutputStream
     String          footerStart = "-----END PGP ";
     String          footerTail = "-----";
 
-    String          version = "BCPG v@RELEASE_NAME@";
+    String          version = null;
 
     Hashtable<String, List<String>> headers = new Hashtable<String, List<String>>();
 

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/ArmoredOutputStreamUTF8Test.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/ArmoredOutputStreamUTF8Test.java
@@ -45,7 +45,7 @@ public class ArmoredOutputStreamUTF8Test
         isEquals("Comment was not properly encoded. Expected: " + utf8WithUmlauts + ", Actual: " + comment, comment, utf8WithUmlauts);
 
         // round-tripped comment from ascii armor input stream
-        isEquals(headers[1].substring("Comment: ".length()), utf8WithUmlauts);
+        isEquals(headers[0].substring("Comment: ".length()), utf8WithUmlauts);
     }
 
     private String findComment(byte[] armoredOutputUTF8)


### PR DESCRIPTION
The [crypto-refresh-09 document states](https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-09.html#section-6.2.2.1) that in order to minimize metadata, implementations SHOULD NOT include a `Version:` header when forming ASCII armor.
This PR changes BCs default behavior to not include a version header by default.