### PR TITLE
Rework the ArmoredOutputStream

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
@@ -3,7 +3,9 @@ package org.bouncycastle.bcpg;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
@@ -22,6 +24,10 @@ public class ArmoredOutputStream
     extends OutputStream
 {
     public static final String VERSION_HDR = "Version";
+    public static final String COMMENT_HDR = "Comment";
+    public static final String MESSAGE_ID_HDR = "MessageID";
+    public static final String HASH_HDR = "Hash";
+    public static final String CHARSET_HDR = "Charset";
 
     private static final byte[] encodingTable =
         {
@@ -98,7 +104,7 @@ public class ArmoredOutputStream
     }
 
     OutputStream    out;
-    byte[]           buf = new byte[3];
+    byte[]          buf = new byte[3];
     int             bufPtr = 0;
     CRC24           crc = new FastCRC24();
     int             chunkCount = 0;
@@ -162,13 +168,26 @@ public class ArmoredOutputStream
         }
     }
 
+    ArmoredOutputStream(OutputStream out, HashMap<String, List<String>> headerMap, boolean computeCRC) {
+        this(out);
+        if (!computeCRC) {
+            crc = null;
+        }
+        this.headers.clear();
+        for (String key : headerMap.keySet()) {
+            this.headers.put(key, headerMap.get(key));
+        }
+    }
+
     /**
      * Set an additional header entry. Any current value(s) under the same name will be
      * replaced by the new one. A null value will clear the entry for name.
      *
      * @param name the name of the header entry.
      * @param value the value of the header entry.
+     * @deprecated use appropriate methods in {@link Builder} instead.
      */
+    @Deprecated
     public void setHeader(
         String name,
         String value)
@@ -195,7 +214,9 @@ public class ArmoredOutputStream
 
     /**
      * Remove all headers.
+     * @deprecated use appropriate methods in {@link Builder} instead.
      */
+    @Deprecated
     public void clearHeaders()
     {
         headers.clear();
@@ -207,7 +228,9 @@ public class ArmoredOutputStream
      *
      * @param name the name of the header entry.
      * @param value the value of the header entry.
+     * @deprecated use appropriate methods in {@link Builder} instead
      */
+    @Deprecated
     public void addHeader(
         String name,
         String value)
@@ -228,7 +251,9 @@ public class ArmoredOutputStream
 
     /**
      * Reset the headers to only contain a Version string (if one is present)
+     * @deprecated use {@link Builder#clearHeaders()} instead.
      */
+    @Deprecated
     public void resetHeaders()
     {
         List<String> versions = headers.get(VERSION_HDR);
@@ -264,43 +289,15 @@ public class ArmoredOutputStream
         sb.append(nl);
         for (int hashAlgorithm : hashAlgorithms)
         {
-            String hash;
-            switch (hashAlgorithm)
+            try
             {
-                case HashAlgorithmTags.SHA1:
-                    hash = "SHA1";
-                    break;
-                case HashAlgorithmTags.SHA256:
-                    hash = "SHA256";
-                    break;
-                case HashAlgorithmTags.SHA384:
-                    hash = "SHA384";
-                    break;
-                case HashAlgorithmTags.SHA512:
-                    hash = "SHA512";
-                    break;
-                case HashAlgorithmTags.SHA3_256:
-                    hash = "SHA3-256";
-                    break;
-                case HashAlgorithmTags.SHA3_512:
-                    hash = "SHA3-512";
-                    break;
-                case HashAlgorithmTags.MD2:
-                    hash = "MD2";
-                    break;
-                case HashAlgorithmTags.MD5:
-                    hash = "MD5";
-                    break;
-                case HashAlgorithmTags.RIPEMD160:
-                    hash = "RIPEMD160";
-                    break;
-                case HashAlgorithmTags.SHA224:
-                    hash = "SHA224";
-                    break;
-                default:
-                    throw new IOException("unknown hash algorithm tag in beginClearText: " + hashAlgorithm);
+                String hash = HashAlgorithmUtils.getHashAlgorithmName(hashAlgorithm);
+                sb.append(HASH_HDR).append(": ").append(hash).append(nl);
             }
-            sb.append("Hash: ").append(hash).append(nl);
+            catch (IllegalArgumentException e)
+            {
+                throw new IOException("unknown hash algorithm tag in beginClearText: " + hashAlgorithm, e);
+            }
         }
         sb.append(nl);
 
@@ -447,7 +444,10 @@ public class ArmoredOutputStream
 
         if (bufPtr == 3)
         {
-            crc.update3(buf, 0);
+            if (crc != null)
+            {
+                crc.update3(buf, 0);
+            }
             encode3(out, buf);
             bufPtr = 0;
             if ((++chunkCount & 0xf) == 0)
@@ -478,9 +478,12 @@ public class ArmoredOutputStream
         {
             if (bufPtr > 0)
             {
-                for (int i = 0; i < bufPtr; ++i)
+                if (crc != null)
                 {
-                    crc.update(buf[i] & 0xFF);
+                    for (int i = 0; i < bufPtr; ++i)
+                    {
+                        crc.update(buf[i] & 0xFF);
+                    }
                 }
                 encode(out, buf, bufPtr);
             }
@@ -489,15 +492,19 @@ public class ArmoredOutputStream
             {
                 out.write(nl.charAt(i));
             }
-            out.write('=');
 
-            int crcV = crc.getValue();
+            if (crc != null)
+            {
+                out.write('=');
 
-            buf[0] = (byte)(crcV >>> 16);
-            buf[1] = (byte)(crcV >>> 8);
-            buf[2] = (byte)crcV;
+                int crcV = crc.getValue();
 
-            encode3(out, buf);
+                buf[0] = (byte) (crcV >>> 16);
+                buf[1] = (byte) (crcV >>> 8);
+                buf[2] = (byte) crcV;
+
+                encode3(out, buf);
+            }
 
             for (int i = 0; i != nl.length(); i++)
             {
@@ -528,6 +535,177 @@ public class ArmoredOutputStream
 
             type = null;
             start = true;
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    static class Builder {
+
+        private final HashMap<String, List<String>> headers = new HashMap<String, List<String>>();
+        private boolean computeCRCSum = true;
+
+        public ArmoredOutputStream build(OutputStream outputStream) {
+            return new ArmoredOutputStream(outputStream, headers, computeCRCSum);
+        }
+
+        /**
+         * Set a <pre>Version:</pre> header.
+         * Note: Adding version headers to ASCII armored output is discouraged to minimize metadata.
+         *
+         * @param version version
+         * @return builder
+         */
+        public Builder setVersion(String version) {
+            return setSingletonHeader(VERSION_HDR, version);
+        }
+
+        /**
+         * Replace the <pre>Comment:</pre> header field with the given comment.
+         * If the comment contains newlines, multiple headers will be added, one for each newline.
+         * If the comment is <pre>null</pre>, then the output will contain no comments.
+         *
+         * @param comment comment
+         * @return builder
+         */
+        public Builder setComment(String comment) {
+            return replaceHeader(COMMENT_HDR, comment);
+        }
+
+        /**
+         * Replace the <pre>MessageID:</pre> header field with the given messageId.
+         *
+         * @param messageId message ID
+         * @return builder
+         */
+        public Builder setMessageId(String messageId) {
+            return replaceHeader(MESSAGE_ID_HDR, messageId);
+        }
+
+        /**
+         * Replace the <pre>Charset:</pre> header with the given value.
+         *
+         * @param charset charset
+         * @return builder
+         */
+        public Builder setCharset(String charset) {
+            return replaceHeader(CHARSET_HDR, charset);
+        }
+
+        /**
+         * Add the given value as one or more additional <pre>Comment:</pre> headers to the already present comments.
+         * If the comment contains newlines, multiple headers will be added, one for each newline.
+         * If the comment is <pre>null</pre>, this method does nothing.
+         *
+         * @param comment comment
+         * @return builder
+         */
+        public Builder addComment(String comment) {
+            return addHeader(COMMENT_HDR, comment);
+        }
+
+        /**
+         * Set and replace the given header value with a single-line header.
+         * If the value is <pre>null</pre>, this method will remove the header entirely.
+         *
+         * @param key header key
+         * @param value header value
+         * @return builder
+         */
+        private Builder setSingletonHeader(String key, String value) {
+            if (value == null || value.trim().isEmpty())
+            {
+                this.headers.remove(key);
+            }
+            else
+            {
+                String trimmed = value.trim();
+                if (trimmed.contains("\n"))
+                {
+                    throw new IllegalArgumentException("Armor header value for key " + key + " cannot contain newlines.");
+                }
+                this.headers.put(key, Collections.singletonList(value));
+            }
+            return this;
+        }
+
+        /**
+         * Add a header, splitting it into multiple headers if required (newlines).
+         *
+         * @param key key
+         * @param value value
+         * @return builder
+         */
+        private Builder addHeader(String key, String value)
+        {
+            if (value == null || value.trim().isEmpty())
+            {
+                return this;
+            }
+
+            List<String> values = headers.get(key);
+            if (values == null)
+            {
+                values = new ArrayList<>();
+                headers.put(key, values);
+            }
+
+            // handle multi-line values
+            String trimmed = value.trim();
+            for (String line : trimmed.split("\n"))
+            {
+                if (line.trim().isEmpty())
+                {
+                    continue;
+                }
+                values.add(line.trim());
+            }
+            return this;
+        }
+
+        /**
+         * Replace all header values for the given key with the given value.
+         * If the value is <pre>null</pre>, existing headers for the given key are removed.
+         * The value is split into multiple headers if it contains newlines.
+         *
+         * @param key key
+         * @param value value
+         * @return builder
+         */
+        private Builder replaceHeader(String key, String value)
+        {
+            if (value == null || value.trim().isEmpty())
+            {
+                return this;
+            }
+
+            List<String> values = new ArrayList<>();
+
+            // handle multi-line values
+            String trimmed = value.trim();
+            for (String line : trimmed.split("\n"))
+            {
+                if (line.trim().isEmpty())
+                {
+                    continue;
+                }
+                values.add(line.trim());
+            }
+
+            headers.put(key, values);
+            return this;
+        }
+
+        public Builder clearHeaders() {
+            headers.clear();
+            return this;
+        }
+
+        public Builder setComputeCRCSum(boolean computeSum) {
+            this.computeCRCSum = computeSum;
+            return this;
         }
     }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
@@ -122,7 +122,7 @@ public class ArmoredOutputStream
     String          footerStart = "-----END PGP ";
     String          footerTail = "-----";
 
-    Hashtable<String, List<String>> headers = new Hashtable<String, List<String>>();
+    final Hashtable<String, List<String>> headers = new Hashtable<String, List<String>>();
 
     /**
      * Constructs an armored output stream with {@link #resetHeaders() default headers}.
@@ -297,11 +297,7 @@ public class ArmoredOutputStream
         }
         sb.append(nl);
 
-        for (int i = 0; i != sb.length(); i++)
-        {
-            out.write(sb.charAt(i));
-        }
-
+        write(sb.toString());
         clearText = true;
         newLine = true;
         lastb = 0;
@@ -317,20 +313,10 @@ public class ArmoredOutputStream
         String value)
         throws IOException
     {
-        for (int i = 0; i != name.length(); i++)
-        {
-            out.write(name.charAt(i));
-        }
-
-        out.write(':');
-        out.write(' ');
-
-        out.write(Strings.toUTF8ByteArray(value));
-
-        for (int i = 0; i != nl.length(); i++)
-        {
-            out.write(nl.charAt(i));
-        }
+        write(name);
+        write(": ");
+        write(value);
+        write(nl);
     }
 
     public void write(
@@ -390,25 +376,10 @@ public class ArmoredOutputStream
                 type = "MESSAGE";
             }
 
-            for (int i = 0; i != headerStart.length(); i++)
-            {
-                out.write(headerStart.charAt(i));
-            }
-
-            for (int i = 0; i != type.length(); i++)
-            {
-                out.write(type.charAt(i));
-            }
-
-            for (int i = 0; i != headerTail.length(); i++)
-            {
-                out.write(headerTail.charAt(i));
-            }
-
-            for (int i = 0; i != nl.length(); i++)
-            {
-                out.write(nl.charAt(i));
-            }
+            write(headerStart);
+            write(type);
+            write(headerTail);
+            write(nl);
 
             if (headers.containsKey(VERSION_HDR))
             {
@@ -430,11 +401,7 @@ public class ArmoredOutputStream
                 }
             }
 
-            for (int i = 0; i != nl.length(); i++)
-            {
-                out.write(nl.charAt(i));
-            }
-
+            write(nl);
             start = false;
         }
 
@@ -448,10 +415,7 @@ public class ArmoredOutputStream
             bufPtr = 0;
             if ((++chunkCount & 0xf) == 0)
             {
-                for (int i = 0; i != nl.length(); i++)
-                {
-                    out.write(nl.charAt(i));
-                }
+                write(nl);
             }
         }
 
@@ -484,10 +448,7 @@ public class ArmoredOutputStream
                 encode(out, buf, bufPtr);
             }
 
-            for (int i = 0; i != nl.length(); i++)
-            {
-                out.write(nl.charAt(i));
-            }
+            write(nl);
 
             if (crc != null)
             {
@@ -502,36 +463,21 @@ public class ArmoredOutputStream
                 encode3(out, buf);
             }
 
-            for (int i = 0; i != nl.length(); i++)
-            {
-                out.write(nl.charAt(i));
-            }
-
-            for (int i = 0; i != footerStart.length(); i++)
-            {
-                out.write(footerStart.charAt(i));
-            }
-
-            for (int i = 0; i != type.length(); i++)
-            {
-                out.write(type.charAt(i));
-            }
-
-            for (int i = 0; i != footerTail.length(); i++)
-            {
-                out.write(footerTail.charAt(i));
-            }
-
-            for (int i = 0; i != nl.length(); i++)
-            {
-                out.write(nl.charAt(i));
-            }
+            write(nl);
+            write(footerStart);
+            write(type);
+            write(footerTail);
+            write(nl);
 
             out.flush();
 
             type = null;
             start = true;
         }
+    }
+
+    private void write(String string) throws IOException {
+        out.write(Strings.toUTF8ByteArray(string));
     }
 
     public static Builder builder() {

--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java
@@ -122,8 +122,6 @@ public class ArmoredOutputStream
     String          footerStart = "-----END PGP ";
     String          footerTail = "-----";
 
-    String          version = "BCPG v@RELEASE_NAME@";
-
     Hashtable<String, List<String>> headers = new Hashtable<String, List<String>>();
 
     /**
@@ -140,8 +138,6 @@ public class ArmoredOutputStream
         {
             nl = "\r\n";
         }
-
-        setHeader(VERSION_HDR, version);
     }
 
     /**

--- a/pg/src/main/java/org/bouncycastle/bcpg/HashAlgorithmUtils.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/HashAlgorithmUtils.java
@@ -1,0 +1,40 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+public class HashAlgorithmUtils implements HashAlgorithmTags {
+
+    public static String getHashAlgorithmName(int algorithmId) {
+        switch (algorithmId)
+        {
+            case MD5:
+                return "MD5";
+            case SHA1:
+                return "SHA1";
+            case RIPEMD160:
+                return "RIPEMD160";
+            case MD2:
+                return "MD2";
+            case SHA256:
+                return "SHA256";
+            case SHA384:
+                return "SHA384";
+            case SHA512:
+                return "SHA512";
+            case SHA224:
+                return "SHA224";
+            case SHA3_256:
+            case SHA3_256_OLD:
+                return "SHA3-256";
+            case SHA3_384: // OLD
+                return "SHA3-384";
+            case SHA3_512:
+            case SHA3_512_OLD:
+                return "SHA3-512";
+            case SHA3_224:
+                return "SHA3-224";
+            default:
+                throw new IllegalArgumentException("unknown hash algorithm tag:" + algorithmId);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a builder for the ArmoredOutputStream, allowing configuration of armor headers and whether to include a CRC checksum into the armored output.

This PR invalidates #1424 and parts of #1423 