### PR TITLE
Document S2K types and usages and mark deprecated values accordingly

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/S2K.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/S2K.java
@@ -24,17 +24,34 @@ public class S2K
     private static final int EXPBIAS = 6;
 
     /**
-     * Simple key generation. A single non-salted iteration of a hash function
+     * Simple key generation. A single non-salted iteration of a hash function.
+     * This method is deprecated to use, since it can be brute-forced when used
+     * with a low-entropy string, such as those typically provided by users.
+     * Additionally, the usage of Simple S2K can lead to key and IV reuse.
+     * Therefore, in OpenPGP v6, Therefore, when generating an S2K specifier,
+     * an implementation MUST NOT use Simple S2K.
+     *
+     * @deprecated use {@link #SALTED_AND_ITERATED} or {@link #ARGON_2} instead.
      */
     public static final int SIMPLE = 0;
+
     /**
-     * Salted key generation. A single iteration of a hash function with a (unique) salt
+     * Salted key generation. A single iteration of a hash function with a (unique) salt.
+     * This method is deprecated to use, since it can be brute-forced when used
+     * with a low-entropy string, such as those typically provided by users.
+     * Therefore, in OpenPGP v6, an implementation SHOULD NOT generate a Salted S2K,
+     * unless the implementation knows that the input string is high-entropy.
+     *
+     * @deprecated use {@link #SALTED_AND_ITERATED} or {@link #ARGON_2} instead.
      */
     public static final int SALTED = 1;
+
     /**
-     * Salted and iterated key generation. Multiple iterations of a hash function, with a salt
+     * Salted and iterated key generation. Multiple iterations of a hash function, with a salt.
+     * This method MAY be used if {@link #ARGON_2} is not available.
      */
     public static final int SALTED_AND_ITERATED = 3;
+
     /**
      * Memory-hard, salted key generation using Argon2 hash algorithm.
      */

--- a/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
@@ -10,9 +10,54 @@ public class SecretKeyPacket
     extends ContainedPacket
     implements PublicKeyAlgorithmTags
 {
+    /**
+     * Unprotected.
+     */
     public static final int USAGE_NONE = 0x00;
+
+    /**
+     * Malleable CFB.
+     * Malleable-CFB-encrypted keys are vulnerable to corruption attacks
+     * that can cause leakage of secret data when the secret key is used.
+     *
+     * @see <a href="https://eprint.iacr.org/2002/076">
+     *     Klíma, V. and T. Rosa,
+     *     "Attack on Private Signature Keys of the OpenPGP Format,
+     *     PGP(TM) Programs and Other Applications Compatible with OpenPGP"</a>
+     * @see <a href="https://www.kopenpgp.com/">
+     *     Bruseghini, L., Paterson, K. G., and D. Huigens,
+     *     "Victory by KO: Attacking OpenPGP Using Key Overwriting"</a>
+     * @deprecated Use of MalleableCFB is deprecated.
+     *             For v4 keys, use {@link #USAGE_SHA1} instead.
+     *             For v6 keys use {@link #USAGE_AEAD} instead.
+     */
+    @Deprecated
     public static final int USAGE_CHECKSUM = 0xff;
+
+    /**
+     * CFB.
+     * CFB-encrypted keys are vulnerable to corruption attacks that can
+     * cause leakage of secret data when the secret key is use.
+     *
+     * @see <a href="https://eprint.iacr.org/2002/076">
+     *     Klíma, V. and T. Rosa,
+     *     "Attack on Private Signature Keys of the OpenPGP Format,
+     *     PGP(TM) Programs and Other Applications Compatible with OpenPGP"</a>
+     * @see <a href="https://www.kopenpgp.com/">
+     *     Bruseghini, L., Paterson, K. G., and D. Huigens,
+     *     "Victory by KO: Attacking OpenPGP Using Key Overwriting"</a>
+     */
     public static final int USAGE_SHA1 = 0xfe;
+
+    /**
+     * AEAD.
+     * This usage protects against above-mentioned attacks.
+     * Passphrase-protected secret key material in a v6 Secret Key or
+     * v6 Secret Subkey packet SHOULD be protected with AEAD encryption
+     * unless it will be transferred to an implementation that is known
+     * to not support AEAD.
+     * Users should migrate to AEAD with all due speed.
+     */
     public static final int USAGE_AEAD = 0xfd;
 
     private PublicKeyPacket pubKeyPacket;


### PR DESCRIPTION
This PR adds documentation about weaknesses of different S2K types and usages and marks insecure options as deprecated.