### PR TITLE
Extend the HPKE API

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/hpke/AEAD.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/AEAD.java
@@ -51,7 +51,7 @@ public class AEAD
             throw new IndexOutOfBoundsException("Invalid offset");
         }
         if (ptOffset + ptLength > pt.length) {
-            throw new IllegalStateException("Invalid length");
+            throw new IndexOutOfBoundsException("Invalid length");
         }
 
         CipherParameters params;

--- a/core/src/main/java/org/bouncycastle/crypto/hpke/AEAD.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/AEAD.java
@@ -88,7 +88,7 @@ public class AEAD
         throws InvalidCipherTextException
     {
         if (ctOffset < 0 || ctOffset > ct.length) {
-            throw new IllegalStateException("Invalid offset");
+            throw new IndexOutOfBoundsException("Invalid offset");
         }
         if (ctOffset + ctLength > ct.length) {
             throw new IllegalStateException("Invalid length");

--- a/core/src/main/java/org/bouncycastle/crypto/hpke/AEAD.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/AEAD.java
@@ -48,7 +48,7 @@ public class AEAD
             throws InvalidCipherTextException
     {
         if (ptOffset < 0 || ptOffset > pt.length) {
-            throw new IllegalStateException("Invalid offset");
+            throw new IndexOutOfBoundsException("Invalid offset");
         }
         if (ptOffset + ptLength > pt.length) {
             throw new IllegalStateException("Invalid length");

--- a/core/src/main/java/org/bouncycastle/crypto/hpke/AEAD.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/AEAD.java
@@ -91,7 +91,7 @@ public class AEAD
             throw new IndexOutOfBoundsException("Invalid offset");
         }
         if (ctOffset + ctLength > ct.length) {
-            throw new IllegalStateException("Invalid length");
+            throw new IndexOutOfBoundsException("Invalid length");
         }
 
         CipherParameters params;

--- a/core/src/main/java/org/bouncycastle/crypto/hpke/DHKEM.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/DHKEM.java
@@ -299,11 +299,14 @@ class DHKEM
         }
     }
 
-
     protected byte[][] Encap(AsymmetricKeyParameter pkR)
     {
+        return Encap(pkR, kpGen.generateKeyPair());// todo: can be replaced with deriveKeyPair(random)
+    }
+
+    protected byte[][] Encap(AsymmetricKeyParameter pkR, AsymmetricCipherKeyPair kpE)
+    {
         byte[][] output = new byte[2][];
-        AsymmetricCipherKeyPair kpE = kpGen.generateKeyPair();// todo: can be replaced with deriveKeyPair(random)
 
         //DH
         agreement.init(kpE.getPrivate());

--- a/core/src/main/java/org/bouncycastle/crypto/hpke/HKDF.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/HKDF.java
@@ -71,4 +71,30 @@ class HKDF
 
         return rv;
     }
+
+    protected byte[] Extract(byte[] salt, byte[] ikm)
+    {
+        if (salt == null)
+        {
+            salt = new byte[hashLength];
+        }
+
+        return kdf.extractPRK(salt, ikm);
+    }
+
+    protected byte[] Expand(byte[] prk, byte[] info, int L)
+    {
+        if (L > (1 << 16))
+        {
+            throw new IllegalArgumentException("Expand length cannot be larger than 2^16");
+        }
+
+        kdf.init(HKDFParameters.skipExtractParameters(prk, info));
+
+        byte[] rv = new byte[L];
+
+        kdf.generateBytes(rv, 0, rv.length);
+
+        return rv;
+    }
 }

--- a/core/src/main/java/org/bouncycastle/crypto/hpke/HPKE.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/HPKE.java
@@ -248,10 +248,19 @@ public class HPKE
         return ctx.open(aad, ct);
     }
 
-
     public HPKEContextWithEncapsulation setupBaseS(AsymmetricKeyParameter pkR, byte[] info)
     {
         byte[][] output = dhkem.Encap(pkR); // sharedSecret, enc
+        HPKEContext ctx = keySchedule(mode_base, output[0], info, default_psk, default_psk_id);
+
+        return new HPKEContextWithEncapsulation(ctx, output[1]);
+    }
+
+    // Variant of setupBaseS() where caller can provide their own ephemeral key pair.
+    // This should only be used to validate test vectors.
+    public HPKEContextWithEncapsulation setupBaseS(AsymmetricKeyParameter pkR, byte[] info, AsymmetricCipherKeyPair kpE)
+    {
+        byte[][] output = dhkem.Encap(pkR, kpE); // sharedSecret, enc
         HPKEContext ctx = keySchedule(mode_base, output[0], info, default_psk, default_psk_id);
 
         return new HPKEContextWithEncapsulation(ctx, output[1]);

--- a/core/src/main/java/org/bouncycastle/crypto/hpke/HPKEContext.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/HPKEContext.java
@@ -28,9 +28,31 @@ public class HPKEContext
         return aead.seal(aad, message);
     }
 
+    public byte[] seal(byte[] aad, byte[] pt, int ptOffset, int ptLength)
+        throws InvalidCipherTextException
+    {
+        return aead.seal(aad, pt, ptOffset, ptLength);
+    }
+
     public byte[] open(byte[] aad, byte[] ct)
         throws InvalidCipherTextException
     {
         return aead.open(aad, ct);
+    }
+
+    public byte[] open(byte[] aad, byte[] ct, int ctOffset, int ctLength)
+        throws InvalidCipherTextException
+    {
+        return aead.open(aad, ct, ctOffset, ctLength);
+    }
+
+    public byte[] extract(byte[] salt, byte[] ikm)
+    {
+        return hkdf.Extract(salt, ikm);
+    }
+
+    public byte[] expand(byte[] prk, byte[] info, int L)
+    {
+        return hkdf.Expand(prk, info, L);
     }
 }


### PR DESCRIPTION
Extend the HPKE API to:
 - Support encryption/decryption from byte ranges, in order to avoid copies.
 - Allow the sender to specify their ephemeral key pair, which is necessary to validate OHTTP test vectors.
 - Expose non-labeled extract and expand operations on the HKDF.
 