### PR TITLE
IETFUtils.rDNsFromString: throw exception if unescaped equal sign is used in value

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/x500/style/IETFUtils.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x500/style/IETFUtils.java
@@ -148,6 +148,12 @@ public class IETFUtils
                 }
 
                 String               value = vTok.nextToken();
+
+                if (vTok.hasMoreTokens())
+                {
+                    throw new IllegalArgumentException("badly formatted directory string");
+                }
+
                 ASN1ObjectIdentifier oid = x500Style.attrNameToOID(attr.trim());
 
                 if (pTok.hasMoreTokens())
@@ -170,6 +176,12 @@ public class IETFUtils
                         }
 
                         value = vTok.nextToken();
+
+                        if (vTok.hasMoreTokens())
+                        {
+                            throw new IllegalArgumentException("badly formatted directory string");
+                        }
+
                         oid = x500Style.attrNameToOID(attr.trim());
 
 
@@ -196,6 +208,12 @@ public class IETFUtils
                 }
 
                 String               value = vTok.nextToken();
+
+                if (vTok.hasMoreTokens())
+                {
+                    throw new IllegalArgumentException("badly formatted directory string");
+                }
+
                 ASN1ObjectIdentifier oid = x500Style.attrNameToOID(attr.trim());
 
                 builder.addRDN(oid, unescape(value));


### PR DESCRIPTION
If a user calls IETFUtils.rDNsFromString and forgets to escape an equal sign in a value, the remaining part is omitted silently.
e.g: 
'CN=foo=bar' results in a X500Name with CN = 'foo'

With this change an IllegalArgumentException is thrown if the equal sign is not escaped:

'CN=foo=bar' -> throw IllegalArgumentException
'CN=foo\\=bar' -> results in CN = 'foo=bar'