### PR TITLE
Fix retransmission of DTLS server flight after a retransmitted aggregated packet

### DIFF
--- a/tls/src/main/java/org/bouncycastle/tls/DTLSRecordLayer.java
+++ b/tls/src/main/java/org/bouncycastle/tls/DTLSRecordLayer.java
@@ -874,8 +874,7 @@ class DTLSRecordLayer
             {
                 recordEpoch = readEpoch;
             }
-            else if (recordType == ContentType.handshake && null != retransmitEpoch
-                && epoch == retransmitEpoch.getEpoch())
+            else if (null != retransmitEpoch && epoch == retransmitEpoch.getEpoch())
             {
                 recordEpoch = retransmitEpoch;
             }
@@ -920,8 +919,7 @@ class DTLSRecordLayer
             {
                 recordEpoch = readEpoch;
             }
-            else if (recordType == ContentType.handshake && null != retransmitEpoch
-                && epoch == retransmitEpoch.getEpoch())
+            else if (null != retransmitEpoch && epoch == retransmitEpoch.getEpoch())
             {
                 recordEpoch = retransmitEpoch;
             }

--- a/tls/src/test/java/org/bouncycastle/tls/test/AllTests.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/AllTests.java
@@ -23,6 +23,8 @@ public class AllTests
         suite.addTestSuite(BasicTlsTest.class);
         suite.addTestSuite(ByteQueueInputStreamTest.class);
         suite.addTestSuite(DTLSProtocolTest.class);
+        suite.addTestSuite(DTLSHandshakeRetransmissionTest.class);
+        suite.addTestSuite(DTLSAggregatedHandshakeRetransmissionTest.class);
         suite.addTestSuite(DTLSPSKProtocolTest.class);
         suite.addTestSuite(DTLSRawKeysProtocolTest.class);
         suite.addTestSuite(OCSPTest.class);

--- a/tls/src/test/java/org/bouncycastle/tls/test/DTLSAggregatedHandshakeRetransmissionTest.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/DTLSAggregatedHandshakeRetransmissionTest.java
@@ -1,0 +1,133 @@
+package org.bouncycastle.tls.test;
+
+import junit.framework.*;
+import org.bouncycastle.tls.*;
+import org.bouncycastle.tls.crypto.*;
+import org.bouncycastle.tls.crypto.impl.bc.*;
+import org.bouncycastle.util.*;
+
+public class DTLSAggregatedHandshakeRetransmissionTest
+    extends TestCase
+{
+    public void testClientServer() throws Exception
+    {
+        DTLSClientProtocol clientProtocol = new DTLSClientProtocol();
+        DTLSServerProtocol serverProtocol = new DTLSServerProtocol();
+
+        MockDatagramAssociation network = new MockDatagramAssociation(1500);
+
+        ServerThread serverThread = new ServerThread(serverProtocol, network.getServer());
+        serverThread.start();
+
+        DatagramTransport clientTransport = network.getClient();
+
+        clientTransport = new ServerHandshakeDropper(clientTransport, true);
+
+        clientTransport = new LoggingDatagramTransport(clientTransport, System.out);
+
+        clientTransport = new MinimalHandshakeAggregator(clientTransport, false, true);
+
+        MockDTLSClient client = new MockDTLSClient(null);
+
+        client.setHandshakeTimeoutMillis(30000); /* Test gets stuck, so we need it to time out. */
+
+        DTLSTransport dtlsClient = clientProtocol.connect(client, clientTransport);
+
+        for (int i = 1; i <= 10; ++i)
+        {
+            byte[] data = new byte[i];
+            Arrays.fill(data, (byte) i);
+            dtlsClient.send(data, 0, data.length);
+        }
+
+        byte[] buf = new byte[dtlsClient.getReceiveLimit()];
+        while (dtlsClient.receive(buf, 0, buf.length, 100) >= 0)
+        {
+        }
+
+        dtlsClient.close();
+
+        serverThread.shutdown();
+    }
+
+    static class ServerThread
+        extends Thread
+    {
+        private final DTLSServerProtocol serverProtocol;
+
+        private final DatagramTransport serverTransport;
+
+        private volatile boolean isShutdown = false;
+
+        ServerThread(DTLSServerProtocol serverProtocol, DatagramTransport serverTransport)
+        {
+            this.serverProtocol = serverProtocol;
+            this.serverTransport = serverTransport;
+        }
+
+        public void run()
+        {
+            try
+            {
+                TlsCrypto serverCrypto = new BcTlsCrypto();
+
+                DTLSRequest request = null;
+
+                // Use DTLSVerifier to require a HelloVerifyRequest cookie exchange before accepting
+                {
+                    DTLSVerifier verifier = new DTLSVerifier(serverCrypto);
+
+                    // NOTE: Test value only - would typically be the client IP address
+                    byte[] clientID = Strings.toUTF8ByteArray("MockDtlsClient");
+
+                    int receiveLimit = serverTransport.getReceiveLimit();
+                    int dummyOffset = serverCrypto.getSecureRandom().nextInt(16) + 1;
+                    byte[] buf = new byte[dummyOffset + serverTransport.getReceiveLimit()];
+
+                    do
+                    {
+                        if (isShutdown)
+                            return;
+
+                        int length = serverTransport.receive(buf, dummyOffset, receiveLimit, 100);
+                        if (length > 0)
+                        {
+                            request = verifier.verifyRequest(clientID, buf, dummyOffset, length, serverTransport);
+                        }
+                    }
+                    while (request == null);
+                }
+
+                // NOTE: A real server would handle each DTLSRequest in a new task/thread and continue accepting
+                {
+                    MockDTLSServer server = new MockDTLSServer(serverCrypto);
+                    DTLSTransport dtlsTransport = serverProtocol.accept(server, serverTransport, request);
+                    byte[] buf = new byte[dtlsTransport.getReceiveLimit()];
+                    while (!isShutdown)
+                    {
+                        int length = dtlsTransport.receive(buf, 0, buf.length, 100);
+                        if (length >= 0)
+                        {
+                            dtlsTransport.send(buf, 0, length);
+                        }
+                    }
+                    dtlsTransport.close();
+                }
+            }
+            catch (Exception e)
+            {
+                e.printStackTrace();
+            }
+        }
+
+        void shutdown()
+            throws InterruptedException
+        {
+            if (!isShutdown)
+            {
+                isShutdown = true;
+                this.join();
+            }
+        }
+    }
+}

--- a/tls/src/test/java/org/bouncycastle/tls/test/DTLSHandshakeRetransmissionTest.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/DTLSHandshakeRetransmissionTest.java
@@ -1,0 +1,129 @@
+package org.bouncycastle.tls.test;
+
+import junit.framework.*;
+import org.bouncycastle.tls.*;
+import org.bouncycastle.tls.crypto.*;
+import org.bouncycastle.tls.crypto.impl.bc.*;
+import org.bouncycastle.util.*;
+
+public class DTLSHandshakeRetransmissionTest
+    extends TestCase
+{
+    public void testClientServer() throws Exception
+    {
+        DTLSClientProtocol clientProtocol = new DTLSClientProtocol();
+        DTLSServerProtocol serverProtocol = new DTLSServerProtocol();
+
+        MockDatagramAssociation network = new MockDatagramAssociation(1500);
+
+        ServerThread serverThread = new ServerThread(serverProtocol, network.getServer());
+        serverThread.start();
+
+        DatagramTransport clientTransport = network.getClient();
+
+        clientTransport = new ServerHandshakeDropper(clientTransport, true);
+
+        clientTransport = new LoggingDatagramTransport(clientTransport, System.out);
+
+        MockDTLSClient client = new MockDTLSClient(null);
+
+        DTLSTransport dtlsClient = clientProtocol.connect(client, clientTransport);
+
+        for (int i = 1; i <= 10; ++i)
+        {
+            byte[] data = new byte[i];
+            Arrays.fill(data, (byte) i);
+            dtlsClient.send(data, 0, data.length);
+        }
+
+        byte[] buf = new byte[dtlsClient.getReceiveLimit()];
+        while (dtlsClient.receive(buf, 0, buf.length, 100) >= 0)
+        {
+        }
+
+        dtlsClient.close();
+
+        serverThread.shutdown();
+    }
+
+    static class ServerThread
+        extends Thread
+    {
+        private final DTLSServerProtocol serverProtocol;
+
+        private final DatagramTransport serverTransport;
+
+        private volatile boolean isShutdown = false;
+
+        ServerThread(DTLSServerProtocol serverProtocol, DatagramTransport serverTransport)
+        {
+            this.serverProtocol = serverProtocol;
+            this.serverTransport = serverTransport;
+        }
+
+        public void run()
+        {
+            try
+            {
+                TlsCrypto serverCrypto = new BcTlsCrypto();
+
+                DTLSRequest request = null;
+
+                // Use DTLSVerifier to require a HelloVerifyRequest cookie exchange before accepting
+                {
+                    DTLSVerifier verifier = new DTLSVerifier(serverCrypto);
+
+                    // NOTE: Test value only - would typically be the client IP address
+                    byte[] clientID = Strings.toUTF8ByteArray("MockDtlsClient");
+
+                    int receiveLimit = serverTransport.getReceiveLimit();
+                    int dummyOffset = serverCrypto.getSecureRandom().nextInt(16) + 1;
+                    byte[] buf = new byte[dummyOffset + serverTransport.getReceiveLimit()];
+
+                    do
+                    {
+                        if (isShutdown)
+                            return;
+
+                        int length = serverTransport.receive(buf, dummyOffset, receiveLimit, 100);
+                        if (length > 0)
+                        {
+                            request = verifier.verifyRequest(clientID, buf, dummyOffset, length, serverTransport);
+                        }
+                    }
+                    while (request == null);
+                }
+
+                // NOTE: A real server would handle each DTLSRequest in a new task/thread and continue accepting
+                {
+                    MockDTLSServer server = new MockDTLSServer(serverCrypto);
+                    DTLSTransport dtlsTransport = serverProtocol.accept(server, serverTransport, request);
+                    byte[] buf = new byte[dtlsTransport.getReceiveLimit()];
+                    while (!isShutdown)
+                    {
+                        int length = dtlsTransport.receive(buf, 0, buf.length, 100);
+                        if (length >= 0)
+                        {
+                            dtlsTransport.send(buf, 0, length);
+                        }
+                    }
+                    dtlsTransport.close();
+                }
+            }
+            catch (Exception e)
+            {
+                e.printStackTrace();
+            }
+        }
+
+        void shutdown()
+            throws InterruptedException
+        {
+            if (!isShutdown)
+            {
+                isShutdown = true;
+                this.join();
+            }
+        }
+    }
+}

--- a/tls/src/test/java/org/bouncycastle/tls/test/FilteredDatagramTransport.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/FilteredDatagramTransport.java
@@ -1,0 +1,88 @@
+package org.bouncycastle.tls.test;
+
+import org.bouncycastle.tls.*;
+
+import java.io.*;
+
+public class FilteredDatagramTransport
+    implements DatagramTransport
+{
+
+    private final DatagramTransport transport;
+
+    private final FilterPredicate allowReceiving, allowSending;
+
+    public FilteredDatagramTransport(DatagramTransport transport, FilterPredicate allowReceiving, FilterPredicate allowSending)
+    {
+        this.transport = transport;
+        this.allowReceiving = allowReceiving;
+        this.allowSending = allowSending;
+    }
+
+    public int getReceiveLimit()
+        throws IOException
+    {
+        return transport.getReceiveLimit();
+    }
+
+    public int getSendLimit()
+        throws IOException
+    {
+        return transport.getSendLimit();
+    }
+
+    public int receive(byte[] buf, int off, int len, int waitMillis)
+        throws IOException
+    {
+        long endMillis = System.currentTimeMillis() + waitMillis;
+        for (; ; )
+        {
+            int length = transport.receive(buf, off, len, waitMillis);
+            if (length < 0 || allowReceiving.allowPacket(buf, off, len))
+            {
+                return length;
+            }
+
+            System.out.println("PACKET FILTERED (" + length + " byte packet not received)");
+
+            long now = System.currentTimeMillis();
+            if (now >= endMillis)
+            {
+                return -1;
+            }
+
+            waitMillis = (int)(endMillis - now);
+        }
+    }
+
+    public void send(byte[] buf, int off, int len)
+        throws IOException
+    {
+        if (!allowSending.allowPacket(buf, off, len))
+        {
+            System.out.println("PACKET FILTERED (" + len + " byte packet not sent)");
+        }
+        else
+        {
+            transport.send(buf, off, len);
+        }
+    }
+
+    public void close()
+        throws IOException
+    {
+        transport.close();
+    }
+
+    static FilterPredicate ALWAYS_ALLOW = new FilterPredicate() {
+        @Override
+        public boolean allowPacket(byte[] buf, int off, int len)
+        {
+            return true;
+        }
+    };
+
+    interface FilterPredicate {
+        boolean allowPacket(byte[] buf, int off, int len);
+    }
+}

--- a/tls/src/test/java/org/bouncycastle/tls/test/MinimalHandshakeAggregator.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/MinimalHandshakeAggregator.java
@@ -1,0 +1,149 @@
+package org.bouncycastle.tls.test;
+
+import org.bouncycastle.tls.*;
+
+import java.io.*;
+
+import static java.lang.Math.min;
+
+/**
+ * A very minimal and stupid class to aggregate DTLS handshake messages.  Only sufficient for unit tests.
+ */
+public class MinimalHandshakeAggregator
+    implements DatagramTransport
+{
+
+    private final DatagramTransport transport;
+
+    private final boolean aggregateReceiving, aggregateSending;
+
+    byte[] receiveBuf, sendBuf;
+
+    private byte[] addToBuf(byte[] baseBuf, byte[] buf, int off, int len)
+    {
+        byte[] ret = new byte[baseBuf.length + len];
+        System.arraycopy(baseBuf, 0, ret, 0, baseBuf.length);
+        System.arraycopy(buf, off, ret, baseBuf.length, len);
+        return ret;
+    }
+
+    private void addToReceiveBuf(byte[] buf, int off, int len)
+    {
+        receiveBuf = addToBuf(receiveBuf, buf, off, len);
+    }
+
+    private void resetReceiveBuf()
+    {
+        receiveBuf = new byte[0];
+    }
+
+    private void addToSendBuf(byte[] buf, int off, int len)
+    {
+        sendBuf = addToBuf(sendBuf, buf, off, len);
+    }
+
+    private void resetSendBuf()
+    {
+        sendBuf = new byte[0];
+    }
+
+    /** Whether the buffered aggregated data should be flushed after this packet.
+     * This is done on the end of the first flight - ClientHello and ServerHelloDone - and anything that is
+     * Epoch 1.
+     */
+    private boolean flushAfterThisPacket(byte[] buf, int off, int len)
+    {
+        int epoch = TlsUtils.readUint16(buf, off + 3);
+        if (epoch > 0)
+        {
+            return true;
+        }
+        short contentType = TlsUtils.readUint8(buf, off);
+        if (ContentType.handshake != contentType)
+        {
+            return false;
+        }
+        short msgType = TlsUtils.readUint8(buf, off + 13);
+        switch (msgType) {
+        case HandshakeType.client_hello:
+        case HandshakeType.server_hello_done:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    public MinimalHandshakeAggregator(DatagramTransport transport, boolean aggregateReceiving, boolean aggregateSending)
+    {
+        this.transport = transport;
+        this.aggregateReceiving = aggregateReceiving;
+        this.aggregateSending = aggregateSending;
+        resetReceiveBuf();
+        resetSendBuf();
+    }
+
+    public int getReceiveLimit()
+        throws IOException
+    {
+        return transport.getReceiveLimit();
+    }
+
+    public int getSendLimit()
+        throws IOException
+    {
+        return transport.getSendLimit();
+    }
+
+    public int receive(byte[] buf, int off, int len, int waitMillis)
+        throws IOException
+    {
+        long endMillis = System.currentTimeMillis() + waitMillis;
+        for (; ; )
+        {
+            int length = transport.receive(buf, off, len, waitMillis);
+            if (length < 0 || !aggregateReceiving)
+            {
+                return length;
+            }
+
+            addToReceiveBuf(buf, off, length);
+
+            if (flushAfterThisPacket(buf, off, length)) {
+                System.arraycopy(receiveBuf, 0, buf, off, min(len, receiveBuf.length));
+                resetReceiveBuf();
+                return length;
+            }
+
+            long now = System.currentTimeMillis();
+            if (now >= endMillis)
+            {
+                return -1;
+            }
+
+            waitMillis = (int)(endMillis - now);
+        }
+    }
+
+    public void send(byte[] buf, int off, int len)
+        throws IOException
+    {
+        if (!aggregateSending)
+        {
+            transport.send(buf, off, len);
+            return;
+        }
+        addToSendBuf(buf, off, len);
+
+        if (flushAfterThisPacket(buf, off, len))
+        {
+            transport.send(sendBuf, 0, sendBuf.length);
+            resetSendBuf();
+        }
+    }
+
+    public void close()
+        throws IOException
+    {
+        transport.close();
+    }
+}

--- a/tls/src/test/java/org/bouncycastle/tls/test/MinimalHandshakeAggregator.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/MinimalHandshakeAggregator.java
@@ -19,6 +19,8 @@ public class MinimalHandshakeAggregator
 
     byte[] receiveBuf, sendBuf;
 
+    int receiveRecordCount, sendRecordCount;
+
     private byte[] addToBuf(byte[] baseBuf, byte[] buf, int off, int len)
     {
         byte[] ret = new byte[baseBuf.length + len];
@@ -30,21 +32,25 @@ public class MinimalHandshakeAggregator
     private void addToReceiveBuf(byte[] buf, int off, int len)
     {
         receiveBuf = addToBuf(receiveBuf, buf, off, len);
+        receiveRecordCount++;
     }
 
     private void resetReceiveBuf()
     {
         receiveBuf = new byte[0];
+        receiveRecordCount = 0;
     }
 
     private void addToSendBuf(byte[] buf, int off, int len)
     {
         sendBuf = addToBuf(sendBuf, buf, off, len);
+        sendRecordCount++;
     }
 
     private void resetSendBuf()
     {
         sendBuf = new byte[0];
+        sendRecordCount = 0;
     }
 
     /** Whether the buffered aggregated data should be flushed after this packet.
@@ -109,6 +115,10 @@ public class MinimalHandshakeAggregator
             addToReceiveBuf(buf, off, length);
 
             if (flushAfterThisPacket(buf, off, length)) {
+                if (receiveRecordCount > 1)
+                {
+                    System.out.println("RECEIVING " + receiveRecordCount + " RECORDS IN " + length + " BYTE PACKET");
+                }
                 System.arraycopy(receiveBuf, 0, buf, off, min(len, receiveBuf.length));
                 resetReceiveBuf();
                 return length;
@@ -136,6 +146,10 @@ public class MinimalHandshakeAggregator
 
         if (flushAfterThisPacket(buf, off, len))
         {
+            if (sendRecordCount > 1)
+            {
+                System.out.println("SENDING " + sendRecordCount + " RECORDS IN " + sendBuf.length + " BYTE PACKET");
+            }
             transport.send(sendBuf, 0, sendBuf.length);
             resetSendBuf();
         }

--- a/tls/src/test/java/org/bouncycastle/tls/test/MockDTLSClient.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/MockDTLSClient.java
@@ -30,6 +30,8 @@ class MockDTLSClient
 {
     TlsSession session;
 
+    private int handshakeTimeoutMillis = 0;
+
     MockDTLSClient(TlsSession session)
     {
         super(new BcTlsCrypto());
@@ -40,6 +42,16 @@ class MockDTLSClient
     public TlsSession getSessionToResume()
     {
         return this.session;
+    }
+
+    public int getHandshakeTimeoutMillis()
+    {
+        return handshakeTimeoutMillis;
+    }
+
+    public void setHandshakeTimeoutMillis(int millis)
+    {
+        handshakeTimeoutMillis = millis;
     }
 
     public void notifyAlertRaised(short alertLevel, short alertDescription, String message, Throwable cause)

--- a/tls/src/test/java/org/bouncycastle/tls/test/ServerHandshakeDropper.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/ServerHandshakeDropper.java
@@ -1,0 +1,59 @@
+package org.bouncycastle.tls.test;
+
+import org.bouncycastle.tls.*;
+
+/** This is a [Transport] wrapper which causes the first retransmission of the second flight of a server
+ * handshake to be dropped. */
+public class ServerHandshakeDropper extends FilteredDatagramTransport
+{
+    public ServerHandshakeDropper(DatagramTransport transport, boolean dropOnReceive)
+    {
+        super(transport,
+            dropOnReceive ? new DropFirstServerFinalFlight() : ALWAYS_ALLOW,
+            dropOnReceive ? ALWAYS_ALLOW : new DropFirstServerFinalFlight()
+        );
+    }
+
+    /** This drops the first instance of DTLS packets that either begin with a ChangeCipherSpec, or handshake in
+     * epoch 1.  This is the server's final flight of the handshake.  It will test whether the client properly
+     * retransmits its second flight, and the server properly retransmits the dropped flight.
+     */
+    private static class DropFirstServerFinalFlight implements FilteredDatagramTransport.FilterPredicate {
+
+        boolean sawChangeCipherSpec = false;
+        boolean sawEpoch1Handshake = false;
+
+        private boolean isChangeCipherSpec(byte[] buf, int off, int len)
+        {
+            short contentType = TlsUtils.readUint8(buf, off);
+            return (ContentType.change_cipher_spec == contentType);
+        }
+
+        private boolean isEpoch1Handshake(byte[] buf, int off, int len)
+        {
+            short contentType = TlsUtils.readUint8(buf, off);
+            if (ContentType.handshake != contentType)
+            {
+                return false;
+            }
+
+            int epoch = TlsUtils.readUint16(buf, off + 3);
+            return (1 == epoch);
+        }
+
+        @Override
+        public boolean allowPacket(byte[] buf, int off, int len)
+        {
+            if (!sawChangeCipherSpec && isChangeCipherSpec(buf, off, len))
+            {
+                sawChangeCipherSpec = true;
+                return false;
+            }
+            if (!sawEpoch1Handshake && isEpoch1Handshake(buf, off, len)) {
+                sawEpoch1Handshake = true;
+                return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This fixes the issue described in https://github.com/bcgit/bc-java/issues/1489, and adds unit tests.

The records parsed here, and handed to record processing, are still a subset of the records that were parsed prior to commit 2307836, so this should be safe.