### PR TITLE
Turn on header parsing by default in ArmoredInputStream.Builder

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredInputStream.java
@@ -617,7 +617,7 @@ public class ArmoredInputStream
 
     public static class Builder
     {
-        private boolean hasHeaders = false;
+        private boolean hasHeaders = true;
         private boolean detectMissingCRC = false;
         private boolean ignoreCRC = false;
 
@@ -627,7 +627,7 @@ public class ArmoredInputStream
         }
 
         /**
-         * Turn on header parsing (default value false).
+         * Enable or disable header parsing (default value true).
          *
          * @param hasHeaders true if headers should be expected, false otherwise.
          * @return the current builder instance.


### PR DESCRIPTION
I noticed, that when constructing an `ArmoredInputStream` via the old constructor `ArmoredInputStream(inputStream)`, header parsing is enabled by default, while `ArmoredInputStream.builder().build(inputStream)` disables header parsing.

This PR brings the builder in line with the old constructor by enabling header parsing by default.