### PR TITLE
CMS: Add support for sha-1WithRSAEncryption *digest* algorithm + aliases.

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/util/MessageDigestUtils.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/util/MessageDigestUtils.java
@@ -49,6 +49,10 @@ public class MessageDigestUtils
         digestOidMap.put(NISTObjectIdentifiers.id_shake256, "SHAKE256");
         digestOidMap.put(GMObjectIdentifiers.sm3, "SM3");
         digestOidMap.put(MiscObjectIdentifiers.blake3_256, "BLAKE3-256");
+        // sha-1WithRSAEncryption (RFC 3279 2.2.1)
+        digestOidMap.put(OIWObjectIdentifiers.sha1WithRSA,  "SHA-1");
+        // sha-1WithRSASignature (RFC 8017 A.2.4)
+        digestOidMap.put(new ASN1ObjectIdentifier("1.2.840.113549.1.1.5"), "SHA-1");
 
         digestAlgIdMap.put("SHA-1", new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1, DERNull.INSTANCE));
         digestAlgIdMap.put("SHA-224", new AlgorithmIdentifier(NISTObjectIdentifiers.id_sha224));


### PR DESCRIPTION
This adds support to the CMS libraries for the `sha-1WithRSAEncryption` *digest* algorithm (OID `1.3.14.3.2.29`) and its aliases. This is not to be confused with the `SHA1withRSA` *signature* algorithm which is currently already supported.

Per [RFC 3279 2.2.1](https://datatracker.ietf.org/doc/html/rfc3279#section-2.2.1) and [RFC 8017 A.2.4](https://datatracker.ietf.org/doc/html/rfc8017#appendix-A.2.4), this digest algorithm computes the SHA-1 digest on the encoded `DigestInfo` whose `digestAlgorithm` field is set to the `id-sha1` OID.

Bouncy Castle doesn't currently recognize this digest algorithm (either for building `CMSSignedData` or verifying) and fails with

```
org.bouncycastle.cms.CMSException: can't create digest calculator: exception on setup: java.security.NoSuchAlgorithmException: no such algorithm: 1.3.14.3.2.29 for provider BC
```

In versions 1.69 and earlier, recognition for OID `1.3.14.3.2.29` in `OperatorHelper.java` was present, but the data encoding was not performed correctly (setting OID `1.3.14.3.2.29` during the data encoding step, rather than OID `1.3.14.3.2.26` as RFC 3279 requires), so the computed digest would be wrong and not verify.