### PR TITLE
Implement Memoable Interface

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/cert/path/CertPathValidationContext.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/path/CertPathValidationContext.java
@@ -51,11 +51,22 @@ public class CertPathValidationContext
 
     public Memoable copy()
     {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
+        CertPathValidationContext c = new CertPathValidationContext(new HashSet(this.criticalExtensions));
+
+        c.handledExtensions = new HashSet(this.handledExtensions);
+        c.endEntity = this.endEntity;
+        c.index = this.index;
+
+        return c;
     }
 
     public void reset(Memoable other)
     {
-        //To change body of implemented methods use File | Settings | File Templates.
+        CertPathValidationContext c = (CertPathValidationContext) other;
+
+        this.criticalExtensions = new HashSet(c.criticalExtensions);
+        this.handledExtensions = new HashSet(c.handledExtensions);
+        this.endEntity = c.endEntity;
+        this.index = c.index;
     }
 }

--- a/pkix/src/main/java/org/bouncycastle/cert/path/validations/CertificatePoliciesValidation.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/path/validations/CertificatePoliciesValidation.java
@@ -136,11 +136,21 @@ public class CertificatePoliciesValidation
 
     public Memoable copy()
     {
-        return new CertificatePoliciesValidation(0);    // TODO:
+        CertificatePoliciesValidation v = new CertificatePoliciesValidation(0);
+
+        v.explicitPolicy = this.explicitPolicy;
+        v.policyMapping = this.policyMapping;
+        v.inhibitAnyPolicy = this.inhibitAnyPolicy;
+
+        return v;
     }
 
     public void reset(Memoable other)
     {
-        CertificatePoliciesValidation v = (CertificatePoliciesValidation)other;      // TODO:
+        CertificatePoliciesValidation v = (CertificatePoliciesValidation) other;
+
+        this.explicitPolicy = v.explicitPolicy;
+        this.policyMapping = v.policyMapping;
+        this.inhibitAnyPolicy = v.inhibitAnyPolicy;
     }
 }


### PR DESCRIPTION
I noticed that among the classes implementing the Memoable interface, `CertPathValidationContext` and `CertificatePoliciesValidation` have not implemented the interface's methods appropriately.

I have updated the `copy` and `reset` methods so that these two classes can properly implement the Memoable interface.

I would appreciate it if you could review the proposed code. If there are any areas that need modification or if you have any additional suggestions, I would be grateful for your feedback.