### PR TITLE
Sanitize boolean conversions in signature subpackets.

### DIFF
--- a/core/src/main/java/org/bouncycastle/util/Booleans.java
+++ b/core/src/main/java/org/bouncycastle/util/Booleans.java
@@ -1,0 +1,44 @@
+package org.bouncycastle.util;
+
+public class Booleans {
+
+    /**
+     * Convert the given boolean value into a one-entry byte array, where true is represented by a 1 and false is a 0.
+     * @param bool boolean value
+     * @return byte array
+     */
+    public static byte[] toByteArray(boolean bool)
+    {
+        byte[] bytes = new byte[1];
+        if (bool)
+        {
+            bytes[0] = 1;
+        }
+        return bytes;
+    }
+
+    /**
+     * Convert a one-entry byte array into a boolean.
+     * If the byte array doesn't have one entry, or if this entry is neither a 0 nor 1, this method throws an
+     * {@link IllegalArgumentException}.
+     * A 1 is translated into true, a 0 into false.
+     * @param bytes byte array
+     * @return boolean
+     */
+    public static boolean fromByteArray(byte[] bytes)
+    {
+        if (bytes.length != 1)
+        {
+            throw new IllegalArgumentException("Byte array has unexpected length. Expected length 1, got " + bytes.length);
+        }
+        if (bytes[0] == 0)
+        {
+            return false;
+        }
+        else if (bytes[0] == 1)
+        {
+            return true;
+        }
+        else throw new IllegalArgumentException("Unexpected byte value for boolean encoding: " + bytes[0]);
+    }
+}

--- a/core/src/test/java/org/bouncycastle/util/utiltest/BytesTest.java
+++ b/core/src/test/java/org/bouncycastle/util/utiltest/BytesTest.java
@@ -1,0 +1,41 @@
+package org.bouncycastle.util.utiltest;
+
+import junit.framework.TestCase;
+import org.bouncycastle.util.Booleans;
+
+public class BytesTest extends TestCase {
+
+    public void testParseFalse() {
+        byte[] bFalse = Booleans.toByteArray(false);
+        assertEquals(1, bFalse.length);
+        assertEquals(0, bFalse[0]);
+        assertFalse(Booleans.fromByteArray(bFalse));
+    }
+
+    public void testParseTrue() {
+        byte[] bTrue = Booleans.toByteArray(true);
+        assertEquals(1, bTrue.length);
+        assertEquals(1, bTrue[1]);
+        assertTrue(Booleans.fromByteArray(bTrue));
+    }
+
+    public void testParseTooShort() {
+        byte[] bTooShort = new byte[0];
+        try {
+            Booleans.fromByteArray(bTooShort);
+            fail("Should throw.");
+        } catch (IllegalArgumentException e) {
+            // expected.
+        }
+    }
+
+    public void testParseTooLong() {
+        byte[] bTooLong = new byte[42];
+        try {
+            Booleans.fromByteArray(bTooLong);
+            fail("Should throw.");
+        } catch (IllegalArgumentException e) {
+            // expected.
+        }
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/Exportable.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/Exportable.java
@@ -4,7 +4,7 @@ import org.bouncycastle.bcpg.SignatureSubpacket;
 import org.bouncycastle.bcpg.SignatureSubpacketTags;
 
 /**
- * packet giving signature creation time.
+ * Signature subpacket indicating, whether the carrying signature is intended to be exportable.
  */
 public class Exportable 
     extends SignatureSubpacket

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/Exportable.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/Exportable.java
@@ -2,29 +2,14 @@ package org.bouncycastle.bcpg.sig;
 
 import org.bouncycastle.bcpg.SignatureSubpacket;
 import org.bouncycastle.bcpg.SignatureSubpacketTags;
+import org.bouncycastle.util.Booleans;
 
 /**
  * Signature subpacket indicating, whether the carrying signature is intended to be exportable.
  */
 public class Exportable 
     extends SignatureSubpacket
-{    
-    private static byte[] booleanToByteArray(
-        boolean    value)
-    {
-        byte[]    data = new byte[1];
-        
-        if (value)
-        {
-            data[0] = 1;
-            return data;
-        }
-        else
-        {
-            return data;
-        }
-    }
-    
+{
     public Exportable(
         boolean    critical,
         boolean    isLongLength,
@@ -37,11 +22,11 @@ public class Exportable
         boolean    critical,
         boolean    isExportable)
     {
-        super(SignatureSubpacketTags.EXPORTABLE, critical, false,  booleanToByteArray(isExportable));
+        super(SignatureSubpacketTags.EXPORTABLE, critical, false, Booleans.toByteArray(isExportable));
     }
     
     public boolean isExportable()
     {
-        return data[0] != 0;
+        return Booleans.fromByteArray(data);
     }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/PrimaryUserID.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/PrimaryUserID.java
@@ -2,29 +2,14 @@ package org.bouncycastle.bcpg.sig;
 
 import org.bouncycastle.bcpg.SignatureSubpacket;
 import org.bouncycastle.bcpg.SignatureSubpacketTags;
+import org.bouncycastle.util.Booleans;
 
 /**
  * Signature Subpacket indicating, whether the signed User-ID is marked as the primary user ID for the key.
  */
 public class PrimaryUserID 
     extends SignatureSubpacket
-{    
-    private static byte[] booleanToByteArray(
-        boolean    value)
-    {
-        byte[]    data = new byte[1];
-            
-        if (value)
-        {
-            data[0] = 1;
-            return data;
-        }
-        else
-        {
-            return data;
-        }
-    }
-    
+{
     public PrimaryUserID(
         boolean    critical,
         boolean    isLongLength,
@@ -37,11 +22,11 @@ public class PrimaryUserID
         boolean    critical,
         boolean    isPrimaryUserID)
     {
-        super(SignatureSubpacketTags.PRIMARY_USER_ID, critical, false, booleanToByteArray(isPrimaryUserID));
+        super(SignatureSubpacketTags.PRIMARY_USER_ID, critical, false, Booleans.toByteArray(isPrimaryUserID));
     }
     
     public boolean isPrimaryUserID()
     {
-        return data[0] != 0;
+        return Booleans.fromByteArray(data);
     }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/PrimaryUserID.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/PrimaryUserID.java
@@ -4,7 +4,7 @@ import org.bouncycastle.bcpg.SignatureSubpacket;
 import org.bouncycastle.bcpg.SignatureSubpacketTags;
 
 /**
- * packet giving whether or not the signature is signed using the primary user ID for the key.
+ * Signature Subpacket indicating, whether the signed User-ID is marked as the primary user ID for the key.
  */
 public class PrimaryUserID 
     extends SignatureSubpacket

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/Revocable.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/Revocable.java
@@ -2,29 +2,14 @@ package org.bouncycastle.bcpg.sig;
 
 import org.bouncycastle.bcpg.SignatureSubpacket;
 import org.bouncycastle.bcpg.SignatureSubpacketTags;
+import org.bouncycastle.util.Booleans;
 
 /**
  * Signature subpacket indicating, whether the carrying signature can be revoked.
  */
 public class Revocable 
     extends SignatureSubpacket
-{    
-    private static byte[] booleanToByteArray(
-        boolean    value)
-    {
-        byte[]    data = new byte[1];
-        
-        if (value)
-        {
-            data[0] = 1;
-            return data;
-        }
-        else
-        {
-            return data;
-        }
-    }
-    
+{
     public Revocable(
         boolean    critical,
         boolean    isLongLength,
@@ -37,11 +22,11 @@ public class Revocable
         boolean    critical,
         boolean    isRevocable)
     {
-        super(SignatureSubpacketTags.REVOCABLE, critical, false, booleanToByteArray(isRevocable));
+        super(SignatureSubpacketTags.REVOCABLE, critical, false, Booleans.toByteArray(isRevocable));
     }
     
     public boolean isRevocable()
     {
-        return data[0] != 0;
+        return Booleans.fromByteArray(data);
     }
 }

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/Revocable.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/Revocable.java
@@ -4,7 +4,7 @@ import org.bouncycastle.bcpg.SignatureSubpacket;
 import org.bouncycastle.bcpg.SignatureSubpacketTags;
 
 /**
- * packet giving whether or not is revocable.
+ * Signature subpacket indicating, whether the carrying signature can be revoked.
  */
 public class Revocable 
     extends SignatureSubpacket


### PR DESCRIPTION
Currently, a `PrimaryUserID` packet whose boolean value is encoded as an invalid, but non-zero value (e.g. `2`) is interpreted as `true`.
I believe, BC should detect this invalid value as the sign that something went wrong and instead throw an exception.

This PR introduces the `Bytes` utility class in the core module, which contains two methods for converting between byte arrays and booleans.
Especially the `fromByteArray()` is more strict in that it does not allow arrays with a length other than 1 and also does not allow byte values other than 0 and 1.