### PR TITLE
removed redundant throws clause in X509v3CertificateBuilder

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/cert/X509v3CertificateBuilder.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/X509v3CertificateBuilder.java
@@ -221,12 +221,10 @@ public class X509v3CertificateBuilder
      *
      * @param extension the full extension value.
      * @return this builder object.
-     * @throws CertIOException if there is an issue with the new extension value.
      * @throws IllegalArgumentException if the OID oid has already been used.
      */
     public X509v3CertificateBuilder addExtension(
         Extension extension)
-        throws CertIOException
     {
         extGenerator.addExtension(extension);
 


### PR DESCRIPTION
Resolves #1580 

`X509v3CertificateBuilder` has overloaded `addExtension` methods, which call `ExtensionsGenerator` under the hood.

If the extension is constructed from OID, critical flag and encoded extension value, `ExtensionsGenerator` may throw `CertIOException` if an `IOException` occurs during construction of the extension.

However, if `Extension` object is passed - no `IOException` can occur inside `ExtensionGenerator` and it doesn't throw `CertIOException` as well.

https://github.com/bcgit/bc-java/blob/9279d29588e52d8f0260c2ce5e730c773c247569/core/src/main/java/org/bouncycastle/asn1/x509/ExtensionsGenerator.java#L119-L134

Therefore, this checked exception `throws` clause is redundant in `X509v3CertificateBuilder`.