### PR TITLE
Make SExprParser honor GnuPG s-expression formatted private keys

### DIFF
--- a/pg/src/main/java/org/bouncycastle/gpg/SExprParser.java
+++ b/pg/src/main/java/org/bouncycastle/gpg/SExprParser.java
@@ -80,18 +80,25 @@ public class SExprParser
 
                 SXprUtils.skipCloseParenthesis(inputStream);
 
-                byte[] qVal;
+                byte[] qVal = null;
 
-                SXprUtils.skipOpenParenthesis(inputStream);
+                while (qVal == null)
+                {
+                    SXprUtils.skipOpenParenthesis(inputStream);
 
-                type = SXprUtils.readString(inputStream, inputStream.read());
-                if (type.equals("q"))
-                {
-                    qVal = SXprUtils.readBytes(inputStream, inputStream.read());
-                }
-                else
-                {
-                    throw new PGPException("no q value found");
+                    type = SXprUtils.readString(inputStream, inputStream.read());
+                    if (type.equals("q"))
+                    {
+                        qVal = SXprUtils.readBytes(inputStream, inputStream.read());
+                    }
+                    else if (type.equals("flags"))
+                    {
+                        SXprUtils.skipCloseParenthesis(inputStream);
+                    }
+                    else
+                    {
+                        throw new PGPException("no q value found");
+                    }
                 }
 
                 SXprUtils.skipCloseParenthesis(inputStream);


### PR DESCRIPTION
The SExpParser cannot partse GnuPG private keys if they are ed25519. 

Reason is trivial: this is how GnuPG stores them:
https://github.com/gpg/gnupg/blob/40227e42ea0f2f1cf9c9f506375446648df17e8d/common/t-ssh-utils.c#L179-L199
https://github.com/gpg/gnupg/blob/40227e42ea0f2f1cf9c9f506375446648df17e8d/agent/cvt-openpgp.c#L222-L243

And SExprParser always ends up here:
https://github.com/bcgit/bc-java/blob/bd6e70c7cad0a35fdcba055de13ef2e36f6a151b/pg/src/main/java/org/bouncycastle/gpg/SExprParser.java#L94

As it does not count for `(flags xxx)`.

Fixes #1590