### PR TITLE
Abstract core KEM functionality out of DHKEM

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/hpke/DHKEM.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/DHKEM.java
@@ -35,7 +35,7 @@ import org.bouncycastle.util.Strings;
 import org.bouncycastle.util.encoders.Hex;
 
 
-class DHKEM
+class DHKEM extends KEM
 {
     private AsymmetricCipherKeyPairGenerator kpGen;
 

--- a/core/src/main/java/org/bouncycastle/crypto/hpke/HPKE.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/HPKE.java
@@ -40,8 +40,9 @@ public class HPKE
     private final short kemId;
     private final short kdfId;
     private final short aeadId;
-    private final DHKEM dhkem;
+    private final KEM kem;
     private final HKDF hkdf;
+    private final int encSize;
 
     short Nk;
 
@@ -58,7 +59,7 @@ public class HPKE
         this.kdfId = kdfId;
         this.aeadId = aeadId;
         this.hkdf = new HKDF(kdfId);
-        this.dhkem = new DHKEM(kemId);
+        this.kem = new DHKEM(kemId);
         if (aeadId == aead_AES_GCM128)
         {
             Nk = 16;
@@ -67,25 +68,43 @@ public class HPKE
         {
             Nk = 32;
         }
+        if (kemId == HPKE.kem_P256_SHA256) {
+            encSize = 65;
+        } else if (kemId == HPKE.kem_P384_SHA348) {
+            encSize = 97;
+        } else if (kemId == HPKE.kem_P521_SHA512) {
+            encSize = 133;
+        } else if (kemId == HPKE.kem_X25519_SHA256) {
+            encSize = 32;
+        } else if (kemId == HPKE.kem_X448_SHA512) {
+            encSize = 56;
+        } else {
+            throw new IllegalArgumentException("invalid kem id");
+        }
+    }
+
+    public HPKE(byte mode, short kemId, short kdfId, short aeadId, KEM kem, int encSize)
+    {
+        this.mode = mode;
+        this.kemId = kemId;
+        this.kdfId = kdfId;
+        this.aeadId = aeadId;
+        this.hkdf = new HKDF(kdfId);
+        this.kem = kem;
+        if (aeadId == aead_AES_GCM128)
+        {
+            Nk = 16;
+        }
+        else
+        {
+            Nk = 32;
+        }
+        this.encSize = encSize;
     }
 
     public int getEncSize()
     {
-        switch (kemId)
-        {
-            case HPKE.kem_P256_SHA256:
-                return 65;
-            case HPKE.kem_P384_SHA348:
-                return 97;
-            case HPKE.kem_P521_SHA512:
-                return 133;
-            case HPKE.kem_X25519_SHA256:
-                return 32;
-            case HPKE.kem_X448_SHA512:
-                return 56;
-            default:
-                throw new IllegalArgumentException("invalid kem id");
-        }
+        return encSize;
     }
     public short getAeadId()
     {
@@ -139,32 +158,32 @@ public class HPKE
 
     public AsymmetricCipherKeyPair generatePrivateKey()
     {
-        return dhkem.GeneratePrivateKey();
+        return kem.GeneratePrivateKey();
     }
 
 
     public byte[] serializePublicKey(AsymmetricKeyParameter pk)
     {
-        return dhkem.SerializePublicKey(pk);
+        return kem.SerializePublicKey(pk);
     }
 
     public byte[] serializePrivateKey(AsymmetricKeyParameter sk)
     {
-        return dhkem.SerializePrivateKey(sk);
+        return kem.SerializePrivateKey(sk);
     }
     public AsymmetricKeyParameter deserializePublicKey(byte[] pkEncoded)
     {
-        return dhkem.DeserializePublicKey(pkEncoded);
+        return kem.DeserializePublicKey(pkEncoded);
     }
 
     public AsymmetricCipherKeyPair deserializePrivateKey(byte[] skEncoded, byte[] pkEncoded)
     {
-        return dhkem.DeserializePrivateKey(skEncoded, pkEncoded);
+        return kem.DeserializePrivateKey(skEncoded, pkEncoded);
     }
 
     public AsymmetricCipherKeyPair deriveKeyPair(byte[] ikm)
     {
-        return dhkem.DeriveKeyPair(ikm);
+        return kem.DeriveKeyPair(ikm);
     }
 
     public byte[][] sendExport(AsymmetricKeyParameter pkR, byte[] info, byte[] exporterContext, int L,
@@ -273,7 +292,7 @@ public class HPKE
 
     public HPKEContextWithEncapsulation setupBaseS(AsymmetricKeyParameter pkR, byte[] info)
     {
-        byte[][] output = dhkem.Encap(pkR); // sharedSecret, enc
+        byte[][] output = kem.Encap(pkR); // sharedSecret, enc
         HPKEContext ctx = keySchedule(mode_base, output[0], info, default_psk, default_psk_id);
 
         return new HPKEContextWithEncapsulation(ctx, output[1]);
@@ -283,7 +302,7 @@ public class HPKE
     // This should only be used to validate test vectors.
     public HPKEContextWithEncapsulation setupBaseS(AsymmetricKeyParameter pkR, byte[] info, AsymmetricCipherKeyPair kpE)
     {
-        byte[][] output = dhkem.Encap(pkR, kpE); // sharedSecret, enc
+        byte[][] output = kem.Encap(pkR, kpE); // sharedSecret, enc
         HPKEContext ctx = keySchedule(mode_base, output[0], info, default_psk, default_psk_id);
 
         return new HPKEContextWithEncapsulation(ctx, output[1]);
@@ -291,13 +310,13 @@ public class HPKE
 
     public HPKEContext setupBaseR(byte[] enc, AsymmetricCipherKeyPair skR, byte[] info)
     {
-        byte[] sharedSecret = dhkem.Decap(enc, skR);
+        byte[] sharedSecret = kem.Decap(enc, skR);
         return keySchedule(mode_base, sharedSecret, info, default_psk, default_psk_id);
     }
 
     public HPKEContextWithEncapsulation SetupPSKS(AsymmetricKeyParameter pkR, byte[] info, byte[] psk, byte[] psk_id)
     {
-        byte[][] output = dhkem.Encap(pkR); // sharedSecret, enc
+        byte[][] output = kem.Encap(pkR); // sharedSecret, enc
 
         HPKEContext ctx = keySchedule(mode_psk, output[0], info, psk, psk_id);
 
@@ -306,13 +325,13 @@ public class HPKE
 
     public HPKEContext setupPSKR(byte[] enc, AsymmetricCipherKeyPair skR, byte[] info, byte[] psk, byte[] psk_id)
     {
-        byte[] sharedSecret = dhkem.Decap(enc, skR);
+        byte[] sharedSecret = kem.Decap(enc, skR);
         return keySchedule(mode_psk, sharedSecret, info, psk, psk_id);
     }
 
     public HPKEContextWithEncapsulation setupAuthS(AsymmetricKeyParameter pkR, byte[] info, AsymmetricCipherKeyPair skS)
     {
-        byte[][] output = dhkem.AuthEncap(pkR, skS);
+        byte[][] output = kem.AuthEncap(pkR, skS);
         HPKEContext ctx = keySchedule(mode_auth, output[0], info, default_psk, default_psk_id);
 
         return new HPKEContextWithEncapsulation(ctx, output[1]);
@@ -320,13 +339,13 @@ public class HPKE
 
     public HPKEContext setupAuthR(byte[] enc, AsymmetricCipherKeyPair skR, byte[] info, AsymmetricKeyParameter pkS)
     {
-        byte[] sharedSecret = dhkem.AuthDecap(enc, skR, pkS);
+        byte[] sharedSecret = kem.AuthDecap(enc, skR, pkS);
         return keySchedule(mode_auth, sharedSecret, info, default_psk, default_psk_id);
     }
 
     public HPKEContextWithEncapsulation setupAuthPSKS(AsymmetricKeyParameter pkR, byte[] info, byte[] psk, byte[] psk_id, AsymmetricCipherKeyPair skS)
     {
-        byte[][] output = dhkem.AuthEncap(pkR, skS);
+        byte[][] output = kem.AuthEncap(pkR, skS);
         HPKEContext ctx = keySchedule(mode_auth_psk, output[0], info, psk, psk_id);
 
         return new HPKEContextWithEncapsulation(ctx, output[1]);
@@ -334,7 +353,7 @@ public class HPKE
 
     public HPKEContext setupAuthPSKR(byte[] enc, AsymmetricCipherKeyPair skR, byte[] info, byte[] psk, byte[] psk_id, AsymmetricKeyParameter pkS)
     {
-        byte[] sharedSecret = dhkem.AuthDecap(enc, skR, pkS);
+        byte[] sharedSecret = kem.AuthDecap(enc, skR, pkS);
         return keySchedule(mode_auth_psk, sharedSecret, info, psk, psk_id);
     }
 }

--- a/core/src/main/java/org/bouncycastle/crypto/hpke/KEM.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/KEM.java
@@ -1,0 +1,30 @@
+package org.bouncycastle.crypto.hpke;
+
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+
+public abstract class KEM {
+    // Generates a key pair.
+    abstract AsymmetricCipherKeyPair GeneratePrivateKey();
+
+    // Generates a key pair derived from input keying material (IKM).
+    abstract AsymmetricCipherKeyPair DeriveKeyPair(byte[] ikm);
+
+    // Encapsulates a shared secret for a given public key and returns the encapsulated key and shared secret.
+    abstract byte[][] Encap(AsymmetricKeyParameter recipientPublicKey);
+    abstract byte[][] Encap(AsymmetricKeyParameter pkR, AsymmetricCipherKeyPair kpE);
+    abstract byte[][] AuthEncap(AsymmetricKeyParameter pkR, AsymmetricCipherKeyPair kpS);
+
+    // Decapsulates the given encapsulated key using the recipient's key pair and returns the shared secret.
+    abstract byte[] Decap(byte[] encapsulatedKey, AsymmetricCipherKeyPair recipientKeyPair);
+    abstract byte[] AuthDecap(byte[] enc, AsymmetricCipherKeyPair kpR, AsymmetricKeyParameter pkS);
+
+    // Serializes a key to a byte array.
+    abstract byte[] SerializePublicKey(AsymmetricKeyParameter publicKey);
+    abstract byte[] SerializePrivateKey(AsymmetricKeyParameter key);
+
+    // Deserializes a public key from a byte array.
+    abstract AsymmetricKeyParameter DeserializePublicKey(byte[] encodedPublicKey);
+    // Deserializes a key pair from a byte array.
+    abstract AsymmetricCipherKeyPair DeserializePrivateKey(byte[] skEncoded, byte[] pkEncoded);
+}


### PR DESCRIPTION
Hi, I'd like to be able to use HPKE with alternative KEMs, but it's currently not usable because there's no public facing KEM  abstraction and HPKE currently hard codes the initial set from RFC9180. To accomplish this, I've pulled the public functions from DHKEM into the KEM abstract class, modified HPKE to use a KEM instead, and added a new constructor that doesn't require an RFC9180 KEM.