### PR TITLE
Fix EDDSA_LEGACY signing/verification with Ed448 keys

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -19,6 +19,7 @@ import org.bouncycastle.bcpg.SignaturePacket;
 import org.bouncycastle.bcpg.SignatureSubpacket;
 import org.bouncycastle.bcpg.TrustPacket;
 import org.bouncycastle.math.ec.rfc8032.Ed25519;
+import org.bouncycastle.math.ec.rfc8032.Ed448;
 import org.bouncycastle.openpgp.operator.PGPContentVerifier;
 import org.bouncycastle.openpgp.operator.PGPContentVerifierBuilder;
 import org.bouncycastle.openpgp.operator.PGPContentVerifierBuilderProvider;
@@ -454,9 +455,19 @@ public class PGPSignature
             {
                 byte[] a = BigIntegers.asUnsignedByteArray(sigValues[0].getValue());
                 byte[] b = BigIntegers.asUnsignedByteArray(sigValues[1].getValue());
-                signature = new byte[Ed25519.SIGNATURE_SIZE];
-                System.arraycopy(a, 0, signature, Ed25519.PUBLIC_KEY_SIZE - a.length, a.length);
-                System.arraycopy(b, 0, signature, Ed25519.SIGNATURE_SIZE - b.length, b.length);
+                if (a.length + b.length == Ed25519.SIGNATURE_SIZE)
+                {
+                    signature = new byte[Ed25519.SIGNATURE_SIZE];
+                    System.arraycopy(a, 0, signature, Ed25519.PUBLIC_KEY_SIZE - a.length, a.length);
+                    System.arraycopy(b, 0, signature, Ed25519.SIGNATURE_SIZE - b.length, b.length);
+                }
+                else
+                {
+                    signature = new byte[Ed448.SIGNATURE_SIZE];
+                    System.arraycopy(a, 0, signature, Ed448.PUBLIC_KEY_SIZE - a.length, a.length);
+                    System.arraycopy(b, 0, signature, Ed448.SIGNATURE_SIZE - b.length, b.length);
+                }
+
             }
             else
             {

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcImplProvider.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcImplProvider.java
@@ -33,6 +33,8 @@ import org.bouncycastle.crypto.engines.IDEAEngine;
 import org.bouncycastle.crypto.engines.RFC3394WrapEngine;
 import org.bouncycastle.crypto.engines.RSABlindedEngine;
 import org.bouncycastle.crypto.engines.TwofishEngine;
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.bouncycastle.crypto.signers.DSADigestSigner;
 import org.bouncycastle.crypto.signers.DSASigner;
 import org.bouncycastle.crypto.signers.ECDSASigner;
@@ -96,6 +98,14 @@ class BcImplProvider
         case PublicKeyAlgorithmTags.ECDSA:
             return new DSADigestSigner(new ECDSASigner(), createDigest(hashAlgorithm));
         case PublicKeyAlgorithmTags.EDDSA_LEGACY:
+            if (keyParam instanceof Ed25519PrivateKeyParameters || keyParam instanceof Ed25519PublicKeyParameters)
+            {
+                return new EdDsaSigner(new Ed25519Signer(), createDigest(hashAlgorithm));
+            }
+            else
+            {
+                return new EdDsaSigner(new Ed448Signer(new byte[0]), createDigest(hashAlgorithm));
+            }
         case PublicKeyAlgorithmTags.Ed25519:
             return new EdDsaSigner(new Ed25519Signer(), createDigest(hashAlgorithm));
         case PublicKeyAlgorithmTags.Ed448:

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPContentSignerBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPContentSignerBuilder.java
@@ -95,7 +95,14 @@ public class JcaPGPContentSignerBuilder
         final PGPDigestCalculator digestCalculator = digestCalculatorProviderBuilder.build().get(hashAlgorithm);
         final PGPDigestCalculator edDigestCalculator = digestCalculatorProviderBuilder.build().get(hashAlgorithm);
         final Signature signature;
-        signature = helper.createSignature(keyAlgorithm, hashAlgorithm);
+        if (keyAlgorithm == PublicKeyAlgorithmTags.EDDSA_LEGACY && privateKey.getAlgorithm().equals("Ed448"))
+        {
+            signature = helper.createSignature(PublicKeyAlgorithmTags.Ed448, hashAlgorithm);
+        }
+        else
+        {
+            signature = helper.createSignature(keyAlgorithm, hashAlgorithm);
+        }
 
         try
         {

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPContentVerifierBuilderProvider.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPContentVerifierBuilderProvider.java
@@ -8,8 +8,6 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.security.interfaces.RSAPublicKey;
 
-import org.bouncycastle.asn1.edec.EdECObjectIdentifiers;
-import org.bouncycastle.bcpg.EdDSAPublicBCPGKey;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.bouncycastle.jcajce.io.OutputStreamFactory;
 import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
@@ -73,10 +71,18 @@ public class JcaPGPContentVerifierBuilderProvider
         public PGPContentVerifier build(final PGPPublicKey publicKey)
             throws PGPException
         {
-            final Signature signature = helper.createSignature(keyAlgorithm, hashAlgorithm);
-
             final PGPDigestCalculator digestCalculator = digestCalculatorProviderBuilder.build().get(hashAlgorithm);
             final PublicKey jcaKey = keyConverter.getPublicKey(publicKey);
+
+            final Signature signature;
+            if (keyAlgorithm == PublicKeyAlgorithmTags.EDDSA_LEGACY && jcaKey.getAlgorithm().equals("Ed448"))
+            {
+                signature = helper.createSignature(PublicKeyAlgorithmTags.Ed448, hashAlgorithm);
+            }
+            else
+            {
+                signature = helper.createSignature(keyAlgorithm, hashAlgorithm);
+            }
 
             try
             {

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/LegacyEd448KeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/LegacyEd448KeyPairTest.java
@@ -7,10 +7,17 @@ import org.bouncycastle.crypto.params.Ed448KeyGenerationParameters;
 import org.bouncycastle.jcajce.spec.EdDSAParameterSpec;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openpgp.*;
+import org.bouncycastle.openpgp.operator.PGPContentSignerBuilder;
+import org.bouncycastle.openpgp.operator.PGPContentVerifierBuilderProvider;
+import org.bouncycastle.openpgp.operator.bc.BcPGPContentSignerBuilder;
+import org.bouncycastle.openpgp.operator.bc.BcPGPContentVerifierBuilderProvider;
 import org.bouncycastle.openpgp.operator.bc.BcPGPKeyPair;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentSignerBuilder;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentVerifierBuilderProvider;
 import org.bouncycastle.openpgp.operator.jcajce.JcaPGPKeyPair;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.util.Date;
 
@@ -29,6 +36,60 @@ public class LegacyEd448KeyPairTest
     {
         testConversionOfJcaKeyPair();
         testConversionOfBcKeyPair();
+        testV4SigningVerificationWithJcaKey();
+        testV4SigningVerificationWithBcKey();
+    }
+
+    private void testV4SigningVerificationWithJcaKey()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, PGPException
+    {
+        Date date = currentTimeRounded();
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("EDDSA", new BouncyCastleProvider());
+        gen.initialize(new EdDSAParameterSpec("Ed448"));
+        KeyPair kp = gen.generateKeyPair();
+        PGPKeyPair keyPair = new JcaPGPKeyPair(PublicKeyAlgorithmTags.EDDSA_LEGACY, kp, date);
+
+        byte[] data = "Hello, World!\n".getBytes(StandardCharsets.UTF_8);
+
+        PGPContentSignerBuilder contSigBuilder = new JcaPGPContentSignerBuilder(
+                keyPair.getPublicKey().getAlgorithm(),
+                HashAlgorithmTags.SHA512)
+                .setProvider(new BouncyCastleProvider());
+        PGPSignatureGenerator sigGen = new PGPSignatureGenerator(contSigBuilder);
+        sigGen.init(PGPSignature.BINARY_DOCUMENT, keyPair.getPrivateKey());
+        sigGen.update(data);
+        PGPSignature signature = sigGen.generate();
+
+        PGPContentVerifierBuilderProvider contVerBuilder = new JcaPGPContentVerifierBuilderProvider()
+                .setProvider(new BouncyCastleProvider());
+        signature.init(contVerBuilder, keyPair.getPublicKey());
+        signature.update(data);
+        isTrue(signature.verify());
+    }
+
+    private void testV4SigningVerificationWithBcKey()
+            throws PGPException
+    {
+        Date date = currentTimeRounded();
+        Ed448KeyPairGenerator gen = new Ed448KeyPairGenerator();
+        gen.init(new Ed448KeyGenerationParameters(new SecureRandom()));
+        AsymmetricCipherKeyPair kp = gen.generateKeyPair();
+        BcPGPKeyPair keyPair = new BcPGPKeyPair(PublicKeyAlgorithmTags.EDDSA_LEGACY, kp, date);
+
+        byte[] data = "Hello, World!\n".getBytes(StandardCharsets.UTF_8);
+
+        PGPContentSignerBuilder contSigBuilder = new BcPGPContentSignerBuilder(
+                keyPair.getPublicKey().getAlgorithm(),
+                HashAlgorithmTags.SHA512);
+        PGPSignatureGenerator sigGen = new PGPSignatureGenerator(contSigBuilder);
+        sigGen.init(PGPSignature.BINARY_DOCUMENT, keyPair.getPrivateKey());
+        sigGen.update(data);
+        PGPSignature signature = sigGen.generate();
+
+        PGPContentVerifierBuilderProvider contVerBuilder = new BcPGPContentVerifierBuilderProvider();
+        signature.init(contVerBuilder, keyPair.getPublicKey());
+        signature.update(data);
+        isTrue(signature.verify());
     }
 
     private void testConversionOfJcaKeyPair()


### PR DESCRIPTION
When creating/verifying signatures made using `PublicKeyAlgorithmTags.EDDSA_LEGACY`, BC creates Signer object instances of Ed25519. While this is in line with the rfcs (EdDSALegacy is only specified for Ed25519), BC also supports key generation etc. using Ed448.
(Do we want to retain support for LEGACY_EDDSA + Ed448?)

(Update: LEGACY_EDDSA + Ed448 is defined in LibrePGP, see #1677 )

As a result, when generating/verifying signatures made using Ed448+EDDSA_LEGACY, BC tries to use Ed25519 signers, which fails.
Further, PGPSignature parses EDDSA_LEGACY signatures only as Ed25519, which means Ed448 signature result in OOB exceptions.

This PR changes the signer/verifier methods to detect, which curve is actually used when a EDDSA_LEGACY key is provided and to return an appropriate signer object accordingly.
The patch also fixes signature parsing for EDDSA_LEGACY Ed448 signatures by inspecting the length of the encoded signature values.