### PR TITLE
Fix .github/workflows/codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,8 +67,8 @@ jobs:
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |
-         echo "Run, Build Application using script"
-         gradle clean build
+    #     echo "Run, Build Application using script"
+    #     gradle clean build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
The file had the `- run:` statement, which spanned across multiple lines, not completely commented out, resulting in syntax errors, which trigger emails being sent with each pushed commit.