### PR TITLE
Versioned key conversion

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
@@ -112,7 +112,9 @@ public class PublicKeyPacket
      * @param algorithm
      * @param time
      * @param key
+     * @deprecated use versioned {@link #PublicKeyPacket(int, int, Date, BCPGKey)} instead
      */
+    @Deprecated
     public PublicKeyPacket(
         int algorithm,
         Date time,

--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicSubkeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicSubkeyPacket.java
@@ -31,7 +31,9 @@ public class PublicSubkeyPacket
      * @param algorithm
      * @param time
      * @param key
+     * @deprecated use versioned {@link #PublicSubkeyPacket(int, int, Date, BCPGKey)} instead
      */
+    @Deprecated
     public PublicSubkeyPacket(
         int       algorithm,
         Date      time,

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRingGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRingGenerator.java
@@ -268,7 +268,7 @@ public class PGPKeyRingGenerator
             // replace the public key packet structure with a public subkey one.
             PGPPublicKey pubSubKey = new PGPPublicKey(keyPair.getPublicKey(), null, subSigs);
 
-            pubSubKey.publicPk = new PublicSubkeyPacket(pubSubKey.getAlgorithm(), pubSubKey.getCreationTime(), pubSubKey.publicPk.getKey());
+            pubSubKey.publicPk = new PublicSubkeyPacket(pubSubKey.getVersion(), pubSubKey.getAlgorithm(), pubSubKey.getCreationTime(), pubSubKey.publicPk.getKey());
 
             keys.add(new PGPSecretKey(keyPair.getPrivateKey(), pubSubKey, checksumCalculator, keyEncryptor));
         }

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -99,13 +99,13 @@ public class PGPSecretKey
         if (isMasterKey && !(pubKey.isEncryptionKey() && pubPacket.getAlgorithm() != PublicKeyAlgorithmTags.RSA_GENERAL))
         {
             PGPPublicKey mstKey = new PGPPublicKey(pubKey);
-            mstKey.publicPk = new PublicKeyPacket(pubPacket.getAlgorithm(), pubPacket.getTime(), pubPacket.getKey());
+            mstKey.publicPk = new PublicKeyPacket(pubPacket.getVersion(), pubPacket.getAlgorithm(), pubPacket.getTime(), pubPacket.getKey());
             return mstKey;
         }
         else
         {
             PGPPublicKey subKey = new PGPPublicKey(pubKey);
-            subKey.publicPk = new PublicSubkeyPacket(pubPacket.getAlgorithm(), pubPacket.getTime(), pubPacket.getKey());
+            subKey.publicPk = new PublicSubkeyPacket(pubPacket.getVersion(), pubPacket.getAlgorithm(), pubPacket.getTime(), pubPacket.getKey());
             return subKey;
         }
     }
@@ -316,7 +316,7 @@ public class PGPSecretKey
         // replace the public key packet structure with a public subkey one.
         PGPPublicKey pubSubKey = new PGPPublicKey(keyPair.getPublicKey(), null, subSigs);
 
-        pubSubKey.publicPk = new PublicSubkeyPacket(pubSubKey.getAlgorithm(), pubSubKey.getCreationTime(), pubSubKey.publicPk.getKey());
+        pubSubKey.publicPk = new PublicSubkeyPacket(pubSubKey.getVersion(), pubSubKey.getAlgorithm(), pubSubKey.getCreationTime(), pubSubKey.publicPk.getKey());
 
         this.pub = pubSubKey;
         this.secret = buildSecretKeyPacket(false, keyPair.getPrivateKey(), keyPair.getPublicKey(), keyEncryptor, checksumCalculator);

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -159,11 +159,11 @@ public class PGPSecretKey
 
                 return generateSecretKeyPacket(isMasterKey, pubKey.publicPk, encAlgorithm, s2kUsage, s2k, iv, encData);
             }
-            else
+            else if (pubKey.getVersion() != PublicKeyPacket.VERSION_6)
             {
                 pOut.write(checksum(null, keyData, keyData.length));
-                return generateSecretKeyPacket(isMasterKey, pubKey.publicPk, encAlgorithm, bOut.toByteArray());
             }
+            return generateSecretKeyPacket(isMasterKey, pubKey.publicPk, encAlgorithm, bOut.toByteArray());
         }
         catch (PGPException e)
         {

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPKeyConverter.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPKeyConverter.java
@@ -91,13 +91,21 @@ public class BcPGPKeyConverter
      * @param pubKey    actual public key to associate.
      * @param time      date of creation.
      * @throws PGPException on key creation problem.
+     * @deprecated use versioned {@link #getPGPPublicKey(int, int, PGPAlgorithmParameters, AsymmetricKeyParameter, Date)} instead
      */
+    @Deprecated
     public PGPPublicKey getPGPPublicKey(int algorithm, PGPAlgorithmParameters algorithmParameters, AsymmetricKeyParameter pubKey, Date time)
+        throws PGPException
+    {
+        return getPGPPublicKey(PublicKeyPacket.VERSION_4, algorithm, algorithmParameters, pubKey, time);
+    }
+
+    public PGPPublicKey getPGPPublicKey(int version, int algorithm, PGPAlgorithmParameters algorithmParameters, AsymmetricKeyParameter pubKey, Date time)
         throws PGPException
     {
         BCPGKey bcpgKey = getPublicBCPGKey(algorithm, algorithmParameters, pubKey);
 
-        return new PGPPublicKey(new PublicKeyPacket(algorithm, time, bcpgKey), new BcKeyFingerprintCalculator());
+        return new PGPPublicKey(new PublicKeyPacket(version, algorithm, time, bcpgKey), new BcKeyFingerprintCalculator());
     }
 
     public AsymmetricKeyParameter getPrivateKey(PGPPrivateKey privKey)

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPKeyPair.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPGPKeyPair.java
@@ -2,6 +2,7 @@ package org.bouncycastle.openpgp.operator.bc;
 
 import java.util.Date;
 
+import org.bouncycastle.bcpg.PublicKeyPacket;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.openpgp.PGPAlgorithmParameters;
@@ -13,10 +14,17 @@ import org.bouncycastle.openpgp.PGPPublicKey;
 public class BcPGPKeyPair
     extends PGPKeyPair
 {
+    @Deprecated
     private static PGPPublicKey getPublicKey(int algorithm, PGPAlgorithmParameters parameters, AsymmetricKeyParameter pubKey, Date date)
         throws PGPException
     {
-        return new BcPGPKeyConverter().getPGPPublicKey(algorithm, parameters, pubKey, date);
+        return getPublicKey(PublicKeyPacket.VERSION_4, algorithm, parameters, pubKey, date);
+    }
+
+    private static PGPPublicKey getPublicKey(int version, int algorithm, PGPAlgorithmParameters parameters, AsymmetricKeyParameter pubKey, Date date)
+            throws PGPException
+    {
+        return new BcPGPKeyConverter().getPGPPublicKey(version, algorithm, parameters, pubKey, date);
     }
 
     private static PGPPrivateKey getPrivateKey(PGPPublicKey pub, AsymmetricKeyParameter privKey)
@@ -25,17 +33,31 @@ public class BcPGPKeyPair
         return new BcPGPKeyConverter().getPGPPrivateKey(pub, privKey);
     }
 
+    @Deprecated
     public BcPGPKeyPair(int algorithm, AsymmetricCipherKeyPair keyPair, Date date)
-        throws PGPException
+            throws PGPException
     {
-        this.pub = getPublicKey(algorithm, null, keyPair.getPublic(), date);
+        this(PublicKeyPacket.VERSION_4, algorithm, keyPair, date);
+    }
+
+    public BcPGPKeyPair(int version, int algorithm, AsymmetricCipherKeyPair keyPair, Date date)
+            throws PGPException
+    {
+        this.pub = getPublicKey(version, algorithm, null, keyPair.getPublic(), date);
         this.priv = getPrivateKey(this.pub, keyPair.getPrivate());
     }
 
+    @Deprecated
     public BcPGPKeyPair(int algorithm, PGPAlgorithmParameters parameters, AsymmetricCipherKeyPair keyPair, Date date)
-        throws PGPException
+            throws PGPException
     {
-        this.pub = getPublicKey(algorithm, parameters, keyPair.getPublic(), date);
+        this(PublicKeyPacket.VERSION_4, algorithm, parameters, keyPair, date);
+    }
+
+    public BcPGPKeyPair(int version, int algorithm, PGPAlgorithmParameters parameters, AsymmetricCipherKeyPair keyPair, Date date)
+            throws PGPException
+    {
+        this.pub = getPublicKey(version, algorithm, parameters, keyPair.getPublic(), date);
         this.priv = getPrivateKey(this.pub, keyPair.getPrivate());
     }
 }

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPKeyConverter.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPKeyConverter.java
@@ -141,13 +141,35 @@ public class JcaPGPKeyConverter
      * @param pubKey              actual public key to associate.
      * @param time                date of creation.
      * @throws PGPException on key creation problem.
+     * @deprecated use versioned {@link #getPGPPublicKey(int, int, PublicKey, Date)} instead.
      */
+    @Deprecated
     public PGPPublicKey getPGPPublicKey(int algorithm, PGPAlgorithmParameters algorithmParameters, PublicKey pubKey, Date time)
         throws PGPException
     {
+        return getPGPPublicKey(PublicKeyPacket.VERSION_4, algorithm, algorithmParameters, pubKey, time);
+    }
+
+    /**
+     * Create a PGPPublicKey from the passed in JCA one.
+     * <p>
+     * Note: the time passed in affects the value of the key's keyID, so you probably only want
+     * to do this once for a JCA key, or make sure you keep track of the time you used.
+     * </p>
+     *
+     * @param version             key version
+     * @param algorithm           asymmetric algorithm type representing the public key.
+     * @param algorithmParameters additional parameters to be stored against the public key.
+     * @param pubKey              actual public key to associate.
+     * @param time                date of creation.
+     * @throws PGPException on key creation problem.
+     */
+    public PGPPublicKey getPGPPublicKey(int version, int algorithm, PGPAlgorithmParameters algorithmParameters, PublicKey pubKey, Date time)
+            throws PGPException
+    {
         BCPGKey bcpgKey = getPublicBCPGKey(algorithm, algorithmParameters, pubKey);
 
-        return new PGPPublicKey(new PublicKeyPacket(algorithm, time, bcpgKey), fingerPrintCalculator);
+        return new PGPPublicKey(new PublicKeyPacket(version, algorithm, time, bcpgKey), fingerPrintCalculator);
     }
 
     /**
@@ -161,11 +183,32 @@ public class JcaPGPKeyConverter
      * @param pubKey    actual public key to associate.
      * @param time      date of creation.
      * @throws PGPException on key creation problem.
+     * @deprecated use versioned {@link #getPGPPublicKey(int, int, PublicKey, Date)} instead
      */
+    @Deprecated
     public PGPPublicKey getPGPPublicKey(int algorithm, PublicKey pubKey, Date time)
         throws PGPException
     {
         return getPGPPublicKey(algorithm, null, pubKey, time);
+    }
+
+    /**
+     * Create a PGPPublicKey from the passed in JCA one.
+     * <p>
+     * Note: the time passed in affects the value of the key's keyID, so you probably only want
+     * to do this once for a JCA key, or make sure you keep track of the time you used.
+     * </p>
+     *
+     * @param version   key version
+     * @param algorithm asymmetric algorithm type representing the public key.
+     * @param pubKey    actual public key to associate.
+     * @param time      date of creation.
+     * @throws PGPException on key creation problem.
+     */
+    public PGPPublicKey getPGPPublicKey(int version, int algorithm, PublicKey pubKey, Date time)
+        throws PGPException
+    {
+        return getPGPPublicKey(version, algorithm, null, pubKey, time);
     }
 
     public PrivateKey getPrivateKey(PGPPrivateKey privKey)

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPKeyPair.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPKeyPair.java
@@ -5,6 +5,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Date;
 
+import org.bouncycastle.bcpg.PublicKeyPacket;
 import org.bouncycastle.openpgp.PGPAlgorithmParameters;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPKeyPair;
@@ -17,16 +18,30 @@ import org.bouncycastle.openpgp.PGPPublicKey;
 public class JcaPGPKeyPair
     extends PGPKeyPair
 {
+    @Deprecated
     private static PGPPublicKey getPublicKey(int algorithm, PublicKey pubKey, Date date)
         throws PGPException
     {
-        return  new JcaPGPKeyConverter().getPGPPublicKey(algorithm, pubKey, date);
+        return getPublicKey(PublicKeyPacket.VERSION_4, algorithm, pubKey, date);
     }
 
+    private static PGPPublicKey getPublicKey(int version, int algorithm, PublicKey pubKey, Date date)
+            throws PGPException
+    {
+        return new JcaPGPKeyConverter().getPGPPublicKey(version, algorithm, pubKey, date);
+    }
+
+    @Deprecated
     private static PGPPublicKey getPublicKey(int algorithm, PGPAlgorithmParameters algorithmParameters, PublicKey pubKey, Date date)
         throws PGPException
     {
-        return  new JcaPGPKeyConverter().getPGPPublicKey(algorithm, algorithmParameters, pubKey, date);
+        return getPublicKey(PublicKeyPacket.VERSION_4, algorithm, algorithmParameters, pubKey, date);
+    }
+
+    private static PGPPublicKey getPublicKey(int version, int algorithm, PGPAlgorithmParameters algorithmParameters, PublicKey pubKey, Date date)
+        throws PGPException
+    {
+        return new JcaPGPKeyConverter().getPGPPublicKey(version, algorithm, algorithmParameters, pubKey, date);
     }
 
     private static PGPPrivateKey getPrivateKey(PGPPublicKey pub, PrivateKey privKey)
@@ -43,26 +58,51 @@ public class JcaPGPKeyPair
      * @param date the creation date to associate with the key pair.
      * @throws PGPException if conversion fails.
      */
+    @Deprecated
     public JcaPGPKeyPair(int algorithm, KeyPair keyPair, Date date)
         throws PGPException
     {
-        this.pub = getPublicKey(algorithm, keyPair.getPublic(), date);
+        this(PublicKeyPacket.VERSION_4, algorithm, keyPair, date);
+    }
+
+    public JcaPGPKeyPair(int version, int algorithm, KeyPair keyPair, Date date)
+        throws PGPException
+    {
+        this.pub = getPublicKey(version, algorithm, keyPair.getPublic(), date);
         this.priv = getPrivateKey(this.pub, keyPair.getPrivate());
     }
 
     /**
-     * Construct PGP key pair from a JCA/JCE key pair.
+     * Construct version 4 PGP key pair from a JCA/JCE key pair.
      *
      * @param algorithm the PGP algorithm the key is for.
      * @param parameters additional parameters to be stored against the public key.
      * @param keyPair  the public/private key pair to convert.
      * @param date the creation date to associate with the key pair.
      * @throws PGPException if conversion fails.
+     * @deprecated use versioned {@link #JcaPGPKeyPair(int, int, PGPAlgorithmParameters, KeyPair, Date)} instead
      */
+    @Deprecated
     public JcaPGPKeyPair(int algorithm, PGPAlgorithmParameters parameters, KeyPair keyPair, Date date)
         throws PGPException
     {
-        this.pub = getPublicKey(algorithm, parameters, keyPair.getPublic(), date);
+        this(PublicKeyPacket.VERSION_4, algorithm, parameters, keyPair, date);
+    }
+
+    /**
+     * Construct PGP key pair from a JCA/JCE key pair.
+     *
+     * @param version key version
+     * @param algorithm the PGP algorithm the key is for.
+     * @param parameters additional parameters to be stored against the public key.
+     * @param keyPair  the public/private key pair to convert.
+     * @param date the creation date to associate with the key pair.
+     * @throws PGPException if conversion fails.
+     */
+    public JcaPGPKeyPair(int version, int algorithm, PGPAlgorithmParameters parameters, KeyPair keyPair, Date date)
+            throws PGPException
+    {
+        this.pub = getPublicKey(version, algorithm, parameters, keyPair.getPublic(), date);
         this.priv = getPrivateKey(this.pub, keyPair.getPrivate());
     }
 }

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePublicKeyDataDecryptorFactoryBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePublicKeyDataDecryptorFactoryBuilder.java
@@ -273,7 +273,7 @@ public class JcePublicKeyDataDecryptorFactoryBuilder
 
                 agreementName = RFC6637Utils.getAgreementAlgorithm(pubKeyData);
 
-                publicKey = converter.getPublicKey(new PGPPublicKey(new PublicKeyPacket(PublicKeyAlgorithmTags.ECDH, new Date(),
+                publicKey = converter.getPublicKey(new PGPPublicKey(new PublicKeyPacket(pubKeyData.getVersion(), PublicKeyAlgorithmTags.ECDH, new Date(),
                     new ECDHPublicBCPGKey(ecKey.getCurveOID(), publicPoint, ecKey.getHashAlgorithm(), ecKey.getSymmetricKeyAlgorithm())), fingerprintCalculator));
             }
             byte[] userKeyingMaterial = RFC6637Utils.createUserKeyingMaterial(pubKeyData, fingerprintCalculator);

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/DedicatedEd25519KeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/DedicatedEd25519KeyPairTest.java
@@ -48,7 +48,7 @@ public class DedicatedEd25519KeyPairTest
         gen.initialize(new EdDSAParameterSpec("Ed25519"));
         KeyPair kp = gen.generateKeyPair();
 
-        JcaPGPKeyPair j1 = new JcaPGPKeyPair(PublicKeyAlgorithmTags.Ed25519, kp, date);
+        JcaPGPKeyPair j1 = new JcaPGPKeyPair(PublicKeyPacket.VERSION_4, PublicKeyAlgorithmTags.Ed25519, kp, date);
         byte[] pubEnc = j1.getPublicKey().getEncoded();
         byte[] privEnc = j1.getPrivateKey().getPrivateKeyDataPacket().getEncoded();
         isTrue("Dedicated Ed25519 public key MUST be instanceof Ed25519PublicBCPGKey",
@@ -92,7 +92,7 @@ public class DedicatedEd25519KeyPairTest
         gen.init(new Ed25519KeyGenerationParameters(new SecureRandom()));
         AsymmetricCipherKeyPair kp = gen.generateKeyPair();
 
-        BcPGPKeyPair b1 = new BcPGPKeyPair(PublicKeyAlgorithmTags.Ed25519, kp, date);
+        BcPGPKeyPair b1 = new BcPGPKeyPair(PublicKeyPacket.VERSION_4, PublicKeyAlgorithmTags.Ed25519, kp, date);
         byte[] pubEnc = b1.getPublicKey().getEncoded();
         byte[] privEnc = b1.getPrivateKey().getPrivateKeyDataPacket().getEncoded();
         isTrue("Dedicated Ed25519 public key MUST be instanceof Ed25519PublicBCPGKey",
@@ -136,18 +136,18 @@ public class DedicatedEd25519KeyPairTest
         Date creationTime = new Date(Pack.bigEndianToInt(Hex.decode("63877fe3"), 0) * 1000L);
         byte[] k = Hex.decode("f94da7bb48d60a61e567706a6587d0331999bb9d891a08242ead84543df895a3");
         PGPPublicKey v4k = new PGPPublicKey(
-                new PublicKeyPacket(PublicKeyAlgorithmTags.Ed25519, creationTime, new Ed25519PublicBCPGKey(k)),
+                new PublicKeyPacket(PublicKeyPacket.VERSION_4, PublicKeyAlgorithmTags.Ed25519, creationTime, new Ed25519PublicBCPGKey(k)),
                 new BcKeyFingerprintCalculator()
         );
 
         // convert parsed key to Jca public key
         PublicKey jcpk = jc.getPublicKey(v4k);
-        PGPPublicKey jck = jc.getPGPPublicKey(PublicKeyAlgorithmTags.Ed25519, jcpk, creationTime);
+        PGPPublicKey jck = jc.getPGPPublicKey(PublicKeyPacket.VERSION_4, PublicKeyAlgorithmTags.Ed25519, jcpk, creationTime);
         isEncodingEqual(v4k.getEncoded(), jck.getEncoded());
 
         // convert parsed key to Bc public key
         AsymmetricKeyParameter bcpk = bc.getPublicKey(v4k);
-        PGPPublicKey bck = bc.getPGPPublicKey(PublicKeyAlgorithmTags.Ed25519, null, bcpk, creationTime);
+        PGPPublicKey bck = bc.getPGPPublicKey(PublicKeyPacket.VERSION_4, PublicKeyAlgorithmTags.Ed25519, null, bcpk, creationTime);
         isEncodingEqual(v4k.getEncoded(), bck.getEncoded());
     }
 


### PR DESCRIPTION
Currently, the `JcaPGPKeyConverter`, `BcPGPKeyConverter` classes assume keys to be version 4 only.
This PR adds new replacement methods which take an additional version, and deprecates the old methods.

Further, it adds versioned constructors to `JcaPGPKeyPair`, `BcPGPKeyPair` and deprecates the unversioned constructors.