### PR TITLE
Add support for unknown PGP key types

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
@@ -60,10 +60,10 @@ public class PublicKeyPacket
         }
 
         algorithm = (byte)in.read();
+        long keyOctets = 0;
         if (version == VERSION_6)
         {
-            // TODO: Use keyOctets to be able to parse unknown keys
-            long keyOctets = ((long)in.read() << 24) | ((long)in.read() << 16) | ((long)in.read() << 8) | in.read();
+            keyOctets = ((long)in.read() << 24) | ((long)in.read() << 16) | ((long)in.read() << 8) | in.read();
         }
 
         switch (algorithm)
@@ -102,6 +102,12 @@ public class PublicKeyPacket
             key = new Ed448PublicBCPGKey(in);
             break;
         default:
+            if (version == VERSION_6)
+            {
+                // with version 6, we can gracefully handle unknown key types, as the length is known.
+                key = new UnknownBCPGKey((int) keyOctets, in);
+                break;
+            }
             throw new IOException("unknown PGP public key algorithm encountered: " + algorithm);
         }
     }

--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
@@ -61,7 +61,7 @@ public class PublicKeyPacket
 
         algorithm = (byte)in.read();
         long keyOctets = 0;
-        if (version == VERSION_6)
+        if (version == VERSION_6 || version == 5)
         {
             keyOctets = ((long)in.read() << 24) | ((long)in.read() << 16) | ((long)in.read() << 8) | in.read();
         }
@@ -102,9 +102,9 @@ public class PublicKeyPacket
             key = new Ed448PublicBCPGKey(in);
             break;
         default:
-            if (version == VERSION_6)
+            if (version == VERSION_6 || version == 5)
             {
-                // with version 6, we can gracefully handle unknown key types, as the length is known.
+                // with version 5 & 6, we can gracefully handle unknown key types, as the length is known.
                 key = new UnknownBCPGKey((int) keyOctets, in);
                 break;
             }

--- a/pg/src/main/java/org/bouncycastle/bcpg/UnknownBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/UnknownBCPGKey.java
@@ -1,0 +1,21 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+/**
+ * Key class for unknown/unsupported OpenPGP key types.
+ */
+public class UnknownBCPGKey
+        extends OctetArrayBCPGKey
+{
+    public UnknownBCPGKey(int length, BCPGInputStream in)
+            throws IOException
+    {
+        super(length, in);
+    }
+
+    public UnknownBCPGKey(int length, byte[] key)
+    {
+        super(length, key);
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/bcpg/test/AllTests.java
+++ b/pg/src/test/java/org/bouncycastle/bcpg/test/AllTests.java
@@ -23,7 +23,8 @@ public class AllTests
                         new SignaturePacketTest(),
                         new OnePassSignaturePacketTest(),
                         new OpenPgpMessageTest(),
-                        new FingerprintUtilTest()
+                        new FingerprintUtilTest(),
+                        new UnknownPublicKeyPacketTest()
                 };
 
         for (int i = 0; i != tests.length; i++)

--- a/pg/src/test/java/org/bouncycastle/bcpg/test/UnknownPublicKeyPacketTest.java
+++ b/pg/src/test/java/org/bouncycastle/bcpg/test/UnknownPublicKeyPacketTest.java
@@ -7,6 +7,8 @@ import org.bouncycastle.bcpg.UnknownBCPGKey;
 import org.bouncycastle.util.encoders.Hex;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
@@ -16,12 +18,19 @@ public class UnknownPublicKeyPacketTest
 {
 
     @Override
-    public String getName() {
+    public String getName()
+    {
         return "UnknownPublicKeyPacketTest";
     }
 
     @Override
-    public void performTest() throws Exception {
+    public void performTest()
+            throws Exception
+    {
+        parseUnknownV6PublicKey();
+    }
+
+    private void parseUnknownV6PublicKey() throws ParseException, IOException {
         SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
         parser.setTimeZone(TimeZone.getTimeZone("UTC"));
 

--- a/pg/src/test/java/org/bouncycastle/bcpg/test/UnknownPublicKeyPacketTest.java
+++ b/pg/src/test/java/org/bouncycastle/bcpg/test/UnknownPublicKeyPacketTest.java
@@ -1,0 +1,52 @@
+package org.bouncycastle.bcpg.test;
+
+import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.bcpg.PacketFormat;
+import org.bouncycastle.bcpg.PublicKeyPacket;
+import org.bouncycastle.bcpg.UnknownBCPGKey;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.io.ByteArrayInputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class UnknownPublicKeyPacketTest
+        extends AbstractPacketTest
+{
+
+    @Override
+    public String getName() {
+        return "UnknownPublicKeyPacketTest";
+    }
+
+    @Override
+    public void performTest() throws Exception {
+        SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
+        parser.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        String testVector = "c61406665ef5f3630000000a00010203040506070809";
+        byte[] rawKey = new byte[]{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
+        Date creationTime = parser.parse("2024-06-04 11:09:39 UTC");
+
+        PublicKeyPacket p = new PublicKeyPacket(
+                PublicKeyPacket.VERSION_6,
+                99,
+                creationTime,
+                new UnknownBCPGKey(10, rawKey));
+        isEncodingEqual("Encoding mismatch", Hex.decode(testVector), p.getEncoded(PacketFormat.CURRENT));
+
+        ByteArrayInputStream bIn = new ByteArrayInputStream(Hex.decode(testVector));
+        BCPGInputStream pIn = new BCPGInputStream(bIn);
+        PublicKeyPacket parsed = (PublicKeyPacket) pIn.readPacket();
+        isEquals("Packet version mismatch", PublicKeyPacket.VERSION_6, parsed.getVersion());
+        isEquals("Public key algorithm mismatch", 99, parsed.getAlgorithm());
+        isEquals("Creation time mismatch", creationTime, parsed.getTime());
+        isEncodingEqual("Raw key encoding mismatch", rawKey, parsed.getKey().getEncoded());
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new UnknownPublicKeyPacketTest());
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/bcpg/test/UnknownSecretKeyPacketTest.java
+++ b/pg/src/test/java/org/bouncycastle/bcpg/test/UnknownSecretKeyPacketTest.java
@@ -1,6 +1,14 @@
 package org.bouncycastle.bcpg.test;
 
-import org.bouncycastle.bcpg.*;
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.bcpg.ArmoredOutputStream;
+import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.bcpg.BCPGOutputStream;
+import org.bouncycastle.bcpg.PacketFormat;
+import org.bouncycastle.bcpg.PublicKeyPacket;
+import org.bouncycastle.bcpg.SecretKeyPacket;
+import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
+import org.bouncycastle.bcpg.UnknownBCPGKey;
 import org.bouncycastle.util.encoders.Hex;
 
 import java.io.ByteArrayInputStream;
@@ -51,7 +59,11 @@ public class UnknownSecretKeyPacketTest
         BCPGInputStream pIn = new BCPGInputStream(aIn);
         SecretKeyPacket p = (SecretKeyPacket) pIn.readPacket();
 
-        isEncodingEqual(sk.getEncoded(PacketFormat.CURRENT), p.getEncoded(PacketFormat.CURRENT));
+        isEquals("Packet version mismatch", PublicKeyPacket.VERSION_6, p.getPublicKeyPacket().getVersion());
+        isEquals("Algorithm mismatch", 99, p.getPublicKeyPacket().getAlgorithm());
+        isEncodingEqual("Public key encoding mismatch", Hex.decode("c0ffee"), p.getPublicKeyPacket().getKey().getEncoded());
+        isEncodingEqual("Secret key encoding mismatch", Hex.decode("0decaf"), p.getSecretKeyData());
+        isEncodingEqual("Packet encoding mismatch", sk.getEncoded(PacketFormat.CURRENT), p.getEncoded(PacketFormat.CURRENT));
     }
 
     public static void main(String[] args)

--- a/pg/src/test/java/org/bouncycastle/bcpg/test/UnknownSecretKeyPacketTest.java
+++ b/pg/src/test/java/org/bouncycastle/bcpg/test/UnknownSecretKeyPacketTest.java
@@ -1,0 +1,61 @@
+package org.bouncycastle.bcpg.test;
+
+import org.bouncycastle.bcpg.*;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Date;
+
+public class UnknownSecretKeyPacketTest
+        extends AbstractPacketTest
+{
+    @Override
+    public String getName()
+    {
+        return "UnknownSecretKeyPacketTest";
+    }
+
+    @Override
+    public void performTest()
+            throws Exception
+    {
+        parseUnknownUnencryptedV6SecretKey();
+    }
+
+    private void parseUnknownUnencryptedV6SecretKey()
+            throws IOException
+    {
+        Date creationTime = new Date((new Date().getTime() / 1000) * 1000);
+        SecretKeyPacket sk = new SecretKeyPacket(
+                new PublicKeyPacket(
+                        PublicKeyPacket.VERSION_6,
+                        99,
+                        creationTime,
+                        new UnknownBCPGKey(3, Hex.decode("c0ffee"))),
+                SymmetricKeyAlgorithmTags.NULL,
+                null,
+                null,
+                Hex.decode("0decaf"));
+
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        ArmoredOutputStream aOut = new ArmoredOutputStream(bOut);
+        BCPGOutputStream pOut = new BCPGOutputStream(aOut, PacketFormat.CURRENT);
+        sk.encode(pOut);
+        pOut.close();
+        aOut.close();
+
+        ByteArrayInputStream bIn = new ByteArrayInputStream(bOut.toByteArray());
+        ArmoredInputStream aIn = new ArmoredInputStream(bIn);
+        BCPGInputStream pIn = new BCPGInputStream(aIn);
+        SecretKeyPacket p = (SecretKeyPacket) pIn.readPacket();
+
+        isEncodingEqual(sk.getEncoded(PacketFormat.CURRENT), p.getEncoded(PacketFormat.CURRENT));
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new UnknownSecretKeyPacketTest());
+    }
+}


### PR DESCRIPTION
This PR adds support for OpenPGP (v6) keys with unknown public key algorithms.

The v6 test key
```
-----BEGIN PGP PUBLIC KEY BLOCK-----

xhQGZl7182MAAAAKAAECAwQFBgcICQ==
=anvn
-----END PGP PUBLIC KEY BLOCK-----
```
contains a key with unknown algorithm `99` and consists of the octets `0-9`:
```
Public-Key Packet, new CTB, 2 header bytes + 20 bytes
    Version: 6
    Creation time: 2024-06-04 11:09:39 UTC
    Pk algo: Unknown algo 99
    Fingerprint: ACD6CEC3A014079F78DA9A60B98F9E3D4E7321834E1EBEC68A1C3701F882D5A3
    KeyID: ACD6CEC3A014079F
  
    00000000  c6                                                 CTB
    00000001     14                                              length
    00000002        06                                           version
    00000003           66 5e f5 f3                               creation_time
    00000007                       63                            pk_algo
    00000008                           00 00 00 0a               public_len
    0000000c                                       00 01 02 03   rest
    00000010  04 05 06 07 08 09
```

Handling unknown keys gracefully is possible with v6 keys, since the key encoding length is known.

TODO: Figure out, if we can also support unknown v4/v5 keys.