### PR TITLE
Implement decryption for AEAD protected keys

### DIFF
--- a/pg/build.gradle
+++ b/pg/build.gradle
@@ -93,5 +93,7 @@ artifacts {
 test {
     forkEvery = 1;
     maxParallelForks = 8;
+    minHeapSize = "512m"
+    maxHeapSize = "3072m"
 }
 

--- a/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
@@ -3,6 +3,7 @@ package org.bouncycastle.bcpg;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.io.Streams;
 
 /**
@@ -278,7 +279,7 @@ public class SecretKeyPacket
 
     public byte[] getSecretKeyData()
     {
-        return secKeyData;
+        return Arrays.clone(secKeyData);
     }
 
     public byte[] getEncodedContents()

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PBESecretKeyDecryptor.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PBESecretKeyDecryptor.java
@@ -28,4 +28,15 @@ public abstract class PBESecretKeyDecryptor
 
     public abstract byte[] recoverKeyData(int encAlgorithm, byte[] key, byte[] iv, byte[] keyData, int keyOff, int keyLen)
         throws PGPException;
+
+    public abstract byte[] recoverKeyData(
+            int encAlgorithm,
+            int aeadAlgorithm,
+            byte[] s2kKey,
+            byte[] iv,
+            int packetTag,
+            int keyVersion,
+            byte[] keyData,
+            byte[] pubkeyData)
+            throws PGPException;
 }

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPBESecretKeyDecryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPBESecretKeyDecryptorBuilder.java
@@ -1,10 +1,18 @@
 package org.bouncycastle.openpgp.operator.bc;
 
+import org.bouncycastle.bcpg.SymmetricKeyUtils;
 import org.bouncycastle.crypto.BufferedBlockCipher;
 import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.modes.AEADBlockCipher;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.HKDFParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptor;
 import org.bouncycastle.openpgp.operator.PGPDigestCalculatorProvider;
+import org.bouncycastle.util.Arrays;
 
 public class BcPBESecretKeyDecryptorBuilder
 {
@@ -36,6 +44,45 @@ public class BcPBESecretKeyDecryptorBuilder
                 catch (InvalidCipherTextException e)
                 {
                     throw new PGPException("decryption failed: " + e.getMessage(), e);
+                }
+            }
+
+            @Override
+            public byte[] recoverKeyData(int encAlgorithm, int aeadAlgorithm, byte[] s2kKey, byte[] iv, int packetTag,
+                                         int keyVersion, byte[] keyData, byte[] pubkeyData)
+                    throws PGPException
+            {
+
+                byte[] hkdfInfo = new byte[] {
+                        (byte) (0xC0 | packetTag), (byte) keyVersion, (byte) encAlgorithm, (byte) aeadAlgorithm
+                };
+
+                HKDFParameters hkdfParameters = new HKDFParameters(s2kKey, null, hkdfInfo);
+                HKDFBytesGenerator hkdfGen = new HKDFBytesGenerator(new SHA256Digest());
+                hkdfGen.init(hkdfParameters);
+                byte[] key = new byte[SymmetricKeyUtils.getKeyLengthInOctets(encAlgorithm)];
+                hkdfGen.generateBytes(key, 0, key.length);
+
+                byte[] aad = Arrays.prepend(pubkeyData, (byte) (0xC0 | packetTag));
+                AEADBlockCipher cipher = BcAEADUtil.createAEADCipher(encAlgorithm, aeadAlgorithm);
+                cipher.init(false, new AEADParameters(
+                        new KeyParameter(key),
+                        128,
+                        iv,
+                        aad
+                ));
+                int dataLen = cipher.getOutputSize(keyData.length);
+                byte[] data = new byte[dataLen];
+                dataLen = cipher.processBytes(keyData, 0, keyData.length, data, 0);
+
+                try
+                {
+                    cipher.doFinal(data, dataLen);
+                    return data;
+                }
+                catch (InvalidCipherTextException e)
+                {
+                    throw new PGPException("Exception recovering AEAD protected private key material", e);
                 }
             }
         };

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEProtectionRemoverFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEProtectionRemoverFactory.java
@@ -78,7 +78,15 @@ public class JcePBEProtectionRemoverFactory
         {
             return new PGPSecretKeyDecryptorWithAAD(passPhrase, calculatorProvider)
             {
-                public byte[] recoverKeyData(int encAlgorithm, byte[] key, byte[] iv, byte[] aad, byte[] keyData,  int keyOff, int keyLen)
+                @Override
+                public byte[] recoverKeyData(int encAlgorithm, int aeadAlgorithm, byte[] s2kKey, byte[] iv,
+                                             int packetTag, int keyVersion, byte[] keyData, byte[] pubkeyData)
+                        throws PGPException
+                {
+                    throw new PGPException("Not implemented.");
+                }
+
+                public byte[] recoverKeyData(int encAlgorithm, byte[] key, byte[] iv, byte[] aad, byte[] keyData, int keyOff, int keyLen)
                     throws PGPException
                 {
                     try
@@ -137,6 +145,14 @@ public class JcePBEProtectionRemoverFactory
                     {
                         throw new PGPException("invalid key: " + e.getMessage(), e);
                     }
+                }
+
+                @Override
+                public byte[] recoverKeyData(int encAlgorithm, int aeadAlgorithm, byte[] s2kKey, byte[] iv,
+                                             int packetTag, int keyVersion, byte[] keyData, byte[] pubkeyData)
+                        throws PGPException
+                {
+                    throw new PGPException("Not implemented.");
                 }
             };
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyDecryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyDecryptorBuilder.java
@@ -7,8 +7,14 @@ import java.security.Provider;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
+import org.bouncycastle.bcpg.SymmetricKeyUtils;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.params.HKDFParameters;
 import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
 import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
 import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
@@ -16,11 +22,13 @@ import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPUtil;
 import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptor;
 import org.bouncycastle.openpgp.operator.PGPDigestCalculatorProvider;
+import org.bouncycastle.util.Arrays;
 
 public class JcePBESecretKeyDecryptorBuilder
 {
     private OperatorHelper helper = new OperatorHelper(new DefaultJcaJceHelper());
     private PGPDigestCalculatorProvider calculatorProvider;
+    private JceAEADUtil aeadUtil = new JceAEADUtil(helper);
 
     private JcaPGPDigestCalculatorProviderBuilder calculatorProviderBuilder;
 
@@ -37,6 +45,7 @@ public class JcePBESecretKeyDecryptorBuilder
     public JcePBESecretKeyDecryptorBuilder setProvider(Provider provider)
     {
         this.helper = new OperatorHelper(new ProviderJcaJceHelper(provider));
+        this.aeadUtil = new JceAEADUtil(helper);
 
         if (calculatorProviderBuilder != null)
         {
@@ -49,6 +58,7 @@ public class JcePBESecretKeyDecryptorBuilder
     public JcePBESecretKeyDecryptorBuilder setProvider(String providerName)
     {
         this.helper = new OperatorHelper(new NamedJcaJceHelper(providerName));
+        this.aeadUtil = new JceAEADUtil(helper);
 
         if (calculatorProviderBuilder != null)
         {
@@ -94,6 +104,37 @@ public class JcePBESecretKeyDecryptorBuilder
                 catch (InvalidKeyException e)
                 {
                     throw new PGPException("invalid key: " + e.getMessage(), e);
+                }
+            }
+
+            @Override
+            public byte[] recoverKeyData(int encAlgorithm, int aeadAlgorithm, byte[] s2kKey, byte[] iv, int packetTag, int keyVersion, byte[] keyData, byte[] pubkeyData)
+                    throws PGPException
+            {
+                byte[] hkdfInfo = new byte[] {
+                        (byte) (0xC0 | packetTag), (byte) keyVersion, (byte) encAlgorithm, (byte) aeadAlgorithm
+                };
+                // TODO: Replace HDKF code with JCE based implementation
+                HKDFParameters hkdfParameters = new HKDFParameters(s2kKey, null, hkdfInfo);
+                HKDFBytesGenerator hkdfGen = new HKDFBytesGenerator(new SHA256Digest());
+                hkdfGen.init(hkdfParameters);
+                byte[] key = new byte[SymmetricKeyUtils.getKeyLengthInOctets(encAlgorithm)];
+                hkdfGen.generateBytes(key, 0, key.length);
+
+                byte[] aad = Arrays.prepend(pubkeyData, (byte) (0xC0 | packetTag));
+
+                SecretKey secretKey = new SecretKeySpec(key, PGPUtil.getSymmetricCipherName(encAlgorithm));
+                final Cipher c = aeadUtil.createAEADCipher(encAlgorithm, aeadAlgorithm);
+                try
+                {
+                    JceAEADCipherUtil.setUpAeadCipher(c, secretKey, Cipher.DECRYPT_MODE, iv, 128, aad);
+                    byte[] data = c.doFinal(keyData);
+                    return data;
+                }
+                catch (InvalidAlgorithmParameterException | InvalidKeyException |
+                        IllegalBlockSizeException | BadPaddingException e)
+                {
+                    throw new PGPException("Cannot extract AEAD protected secret key material", e);
                 }
             }
         };

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/AEADProtectedPGPSecretKeyTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/AEADProtectedPGPSecretKeyTest.java
@@ -1,0 +1,87 @@
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.*;
+import org.bouncycastle.openpgp.bc.BcPGPObjectFactory;
+import org.bouncycastle.openpgp.operator.bc.BcPBESecretKeyDecryptorBuilder;
+import org.bouncycastle.openpgp.operator.bc.BcPGPDigestCalculatorProvider;
+import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyDecryptorBuilder;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+
+public class AEADProtectedPGPSecretKeyTest
+        extends AbstractPgpKeyPairTest
+{
+
+    @Override
+    public String getName()
+    {
+        return "Argon2ProtectedPGPSecretKeyTest";
+    }
+
+    @Override
+    public void performTest()
+            throws Exception
+    {
+        unlockTestVector();
+    }
+
+    private void unlockTestVector()
+            throws IOException, PGPException
+    {
+        // AEAD encrypted test vector extracted from here:
+        // https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-13.html#name-sample-locked-v6-secret-key
+        String armoredVector = "-----BEGIN PGP PRIVATE KEY BLOCK-----\n" +
+                "\n" +
+                "xYIGY4d/4xsAAAAg+U2nu0jWCmHlZ3BqZYfQMxmZu52JGggkLq2EVD34laP9JgkC\n" +
+                "FARdb9ccngltHraRe25uHuyuAQQVtKipJ0+r5jL4dacGWSAheCWPpITYiyfyIOPS\n" +
+                "3gIDyg8f7strd1OB4+LZsUhcIjOMpVHgmiY/IutJkulneoBYwrEGHxsKAAAAQgWC\n" +
+                "Y4d/4wMLCQcFFQoOCAwCFgACmwMCHgkiIQbLGGxPBgmml+TVLfpscisMHx4nwYpW\n" +
+                "cI9lJewnutmsyQUnCQIHAgAAAACtKCAQPi19In7A5tfORHHbNr/JcIMlNpAnFJin\n" +
+                "7wV2wH+q4UWFs7kDsBJ+xP2i8CMEWi7Ha8tPlXGpZR4UruETeh1mhELIj5UeM8T/\n" +
+                "0z+5oX1RHu11j8bZzFDLX9eTsgOdWATHggZjh3/jGQAAACCGkySDZ/nlAV25Ivj0\n" +
+                "gJXdp4SYfy1ZhbEvutFsr15ENf0mCQIUBA5hhGgp2oaavg6mFUXcFMwBBBUuE8qf\n" +
+                "9Ock+xwusd+GAglBr5LVyr/lup3xxQvHXFSjjA2haXfoN6xUGRdDEHI6+uevKjVR\n" +
+                "v5oAxgu7eJpaXNjCmwYYGwoAAAAsBYJjh3/jApsMIiEGyxhsTwYJppfk1S36bHIr\n" +
+                "DB8eJ8GKVnCPZSXsJ7rZrMkAAAAABAEgpukYbZ1ZNfyP5WMUzbUnSGpaUSD5t2Ki\n" +
+                "Nacp8DkBClZRa2c3AMQzSDXa9jGhYzxjzVb5scHDzTkjyRZWRdTq8U6L4da+/+Kt\n" +
+                "ruh8m7Xo2ehSSFyWRSuTSZe5tm/KXgYG\n" +
+                "-----END PGP PRIVATE KEY BLOCK-----";
+        char[] passphrase = "correct horse battery staple".toCharArray();
+        // Plaintext vectors extracted from here:
+        // https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-13.html#name-sample-v6-secret-key-transf
+        byte[] plainPrimaryKey = Hex.decode("1972817b12be707e8d5f586ce61361201d344eb266a2c82fde6835762b65b0b7");
+        byte[] plainSubkey = Hex.decode("4d600a4f794d44775c57a26e0feefed558e9afffd6ad0d582d57fb2ba2dcedb8");
+
+        ByteArrayInputStream bIn = new ByteArrayInputStream(armoredVector.getBytes(StandardCharsets.UTF_8));
+        ArmoredInputStream aIn = new ArmoredInputStream(bIn);
+        BCPGInputStream pIn = new BCPGInputStream(aIn);
+        PGPObjectFactory objFact = new BcPGPObjectFactory(pIn);
+        PGPSecretKeyRing keys = (PGPSecretKeyRing) objFact.nextObject();
+
+        Iterator<PGPSecretKey> it = keys.getSecretKeys();
+        PGPSecretKey primaryKey = it.next();
+        PGPSecretKey subkey = it.next();
+
+        // Test Bouncy Castle implementation
+        BcPBESecretKeyDecryptorBuilder bcDecryptor = new BcPBESecretKeyDecryptorBuilder(new BcPGPDigestCalculatorProvider());
+        PGPPrivateKey privPrimaryKey = primaryKey.extractPrivateKey(bcDecryptor.build(passphrase));
+        isEncodingEqual(plainPrimaryKey, privPrimaryKey.getPrivateKeyDataPacket().getEncoded());
+
+        // Test Jca/Jce implementation
+        JcePBESecretKeyDecryptorBuilder jceDecryptor = new JcePBESecretKeyDecryptorBuilder().setProvider(new BouncyCastleProvider());
+        PGPPrivateKey privSubKey = subkey.extractPrivateKey(jceDecryptor.build(passphrase));
+        isEncodingEqual(plainSubkey, privSubKey.getPrivateKeyDataPacket().getEncoded());
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new AEADProtectedPGPSecretKeyTest());
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
@@ -51,6 +51,7 @@ public class RegressionTest
         new IgnoreUnknownEncryptedSessionKeys(),
         new PGPEncryptedDataTest(),
         new PGPAeadTest(),
+        new AEADProtectedPGPSecretKeyTest(),
         new CRC24Test(),
         new WildcardKeyIDTest(),
         new ArmorCRCTest(),


### PR DESCRIPTION
This PR adds support for decrypting AEAD protected OpenPGP secret keys.

TODO:
* JcePBEProtectionRemoverFactory does not implement the new key recovery method, as it would require some ugly code duplication. I'm still thinking of a cleaner way to implement this.
* Executing the test together with the other PGP related tests results in OutOfMemoryErrors. Running the test isolated however succeeds just fine. 