### PR TITLE
Implement secret key protection using AEAD

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
@@ -213,6 +213,18 @@ public class SecretKeyPacket
         this(SECRET_KEY, pubKeyPacket, encAlgorithm, 0, s2kUsage, s2k, iv, secKeyData);
     }
 
+    public SecretKeyPacket(
+            PublicKeyPacket pubKeyPacket,
+            int encAlgorithm,
+            int aeadAlgorithm,
+            int s2kUsage,
+            S2K s2k,
+            byte[] iv,
+            byte[] secKeyData)
+    {
+        this(SECRET_KEY, pubKeyPacket, encAlgorithm, aeadAlgorithm, s2kUsage, s2k, iv, secKeyData);
+    }
+
     SecretKeyPacket(
         int keyTag,
         PublicKeyPacket pubKeyPacket,

--- a/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
@@ -3,6 +3,7 @@ package org.bouncycastle.bcpg;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.io.Streams;
 
 /**
@@ -278,7 +279,7 @@ public class SecretKeyPacket
 
     public byte[] getSecretKeyData()
     {
-        return secKeyData;
+        return Arrays.clone(secKeyData);
     }
 
     public byte[] getEncodedContents()

--- a/pg/src/main/java/org/bouncycastle/bcpg/SecretSubkeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SecretSubkeyPacket.java
@@ -82,7 +82,7 @@ public class SecretSubkeyPacket
      * @param iv            optional iv for the AEAD algorithm or encryption algorithm
      * @param secKeyData    secret key data
      */
-    SecretSubkeyPacket(
+    public SecretSubkeyPacket(
         PublicKeyPacket pubKeyPacket,
         int encAlgorithm,
         int aeadAlgorithm,

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -143,6 +143,11 @@ public class PGPSecretKey
                 S2K s2k = keyEncryptor.getS2K();
 
                 int s2kUsage;
+                if (keyEncryptor.getAeadAlgorithm() != 0)
+                {
+                    s2kUsage = SecretKeyPacket.USAGE_AEAD;
+                    return generateSecretKeyPacket(isMasterKey, pubKey.publicPk, encAlgorithm, keyEncryptor.getAeadAlgorithm(), s2kUsage, s2k, iv, encData);
+                }
 
                 if (checksumCalculator != null)
                 {
@@ -196,6 +201,18 @@ public class PGPSecretKey
         else
         {
             return new SecretSubkeyPacket(pubKey, encAlgorithm, s2kusage, s2k, iv, secKeyData);
+        }
+    }
+
+    private static SecretKeyPacket generateSecretKeyPacket(boolean isMasterKey, PublicKeyPacket pubKey, int encAlgorithm, int aeadAlgorithm, int s2kUsage, S2K s2K, byte[] iv, byte[] secKeyData)
+    {
+        if (isMasterKey)
+        {
+            return new SecretKeyPacket(pubKey, encAlgorithm, aeadAlgorithm, s2kUsage, s2K, iv, secKeyData);
+        }
+        else
+        {
+            return new SecretSubkeyPacket(pubKey, encAlgorithm, aeadAlgorithm, s2kUsage, s2K, iv, secKeyData);
         }
     }
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -457,6 +457,16 @@ public class PGPSecretKey
     }
 
     /**
+     * Return the AEAD algorithm the key is encrypted with.
+     * Returns <pre>0</pre> if no AEAD is used.
+     * @return aead key encryption algorithm
+     */
+    public int getAEADKeyEncryptionAlgorithm()
+    {
+        return secret.getAeadAlgorithm();
+    }
+
+    /**
      * Return the keyID of the public key associated with this key.
      *
      * @return the keyID associated with this key.

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PBESecretKeyDecryptor.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PBESecretKeyDecryptor.java
@@ -28,4 +28,15 @@ public abstract class PBESecretKeyDecryptor
 
     public abstract byte[] recoverKeyData(int encAlgorithm, byte[] key, byte[] iv, byte[] keyData, int keyOff, int keyLen)
         throws PGPException;
+
+    public abstract byte[] recoverKeyData(
+            int encAlgorithm,
+            int aeadAlgorithm,
+            byte[] s2kKey,
+            byte[] iv,
+            int packetTag,
+            int keyVersion,
+            byte[] keyData,
+            byte[] pubkeyData)
+            throws PGPException;
 }

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PBESecretKeyEncryptor.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PBESecretKeyEncryptor.java
@@ -8,12 +8,22 @@ import org.bouncycastle.openpgp.PGPException;
 public abstract class PBESecretKeyEncryptor
 {
     protected int encAlgorithm;
+    protected int aeadAlgorithm;
     protected char[] passPhrase;
     protected PGPDigestCalculator s2kDigestCalculator;
     protected int s2kCount;
     protected S2K s2k;
 
     protected SecureRandom random;
+
+    protected PBESecretKeyEncryptor(int encAlgorithm, int aeadAlgorithm, S2K.Argon2Params argon2Params, SecureRandom random, char[] passPhrase)
+    {
+        this.encAlgorithm = encAlgorithm;
+        this.aeadAlgorithm = aeadAlgorithm;
+        this.passPhrase = passPhrase;
+        this.s2k = S2K.argon2S2K(argon2Params);
+        this.random = random;
+    }
 
     protected PBESecretKeyEncryptor(int encAlgorithm, PGPDigestCalculator s2kDigestCalculator, SecureRandom random, char[] passPhrase)
     {
@@ -38,6 +48,11 @@ public abstract class PBESecretKeyEncryptor
     public int getAlgorithm()
     {
         return encAlgorithm;
+    }
+
+    public int getAeadAlgorithm()
+    {
+        return aeadAlgorithm;
     }
 
     public int getHashAlgorithm()

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcAEADSecretKeyEncryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcAEADSecretKeyEncryptorBuilder.java
@@ -1,0 +1,99 @@
+package org.bouncycastle.openpgp.operator.bc;
+
+import org.bouncycastle.bcpg.AEADUtils;
+import org.bouncycastle.bcpg.PacketTags;
+import org.bouncycastle.bcpg.PublicKeyPacket;
+import org.bouncycastle.bcpg.S2K;
+import org.bouncycastle.bcpg.SymmetricKeyUtils;
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.modes.AEADBlockCipher;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.HKDFParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.operator.PBESecretKeyEncryptor;
+import org.bouncycastle.util.Arrays;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+
+public class BcAEADSecretKeyEncryptorBuilder
+{
+
+    private int aeadAlgorithm;
+    private int symmetricAlgorithm;
+    private S2K.Argon2Params argon2Params;
+
+    public BcAEADSecretKeyEncryptorBuilder(int aeadAlgorithm, int symmetricAlgorithm, S2K.Argon2Params argon2Params)
+    {
+        this.aeadAlgorithm = aeadAlgorithm;
+        this.symmetricAlgorithm = symmetricAlgorithm;
+        this.argon2Params = argon2Params;
+    }
+
+    public PBESecretKeyEncryptor build(char[] passphrase, PublicKeyPacket pubKey)
+    {
+        return new PBESecretKeyEncryptor(symmetricAlgorithm, aeadAlgorithm, argon2Params, new SecureRandom(), passphrase)
+        {
+            private byte[] iv;
+
+            {
+                iv = new byte[AEADUtils.getIVLength(aeadAlgorithm)];
+                random.nextBytes(iv);
+            }
+
+            @Override
+            public byte[] encryptKeyData(byte[] key, byte[] keyData, int keyOff, int keyLen)
+                    throws PGPException
+            {
+                int packetTag = pubKey.getPacketTag() == PacketTags.PUBLIC_KEY ? PacketTags.SECRET_KEY : PacketTags.SECRET_SUBKEY;
+                byte[] hkdfInfo = new byte[] {
+                        (byte) (0xC0 | packetTag),
+                        (byte) pubKey.getVersion(),
+                        (byte) symmetricAlgorithm,
+                        (byte) aeadAlgorithm
+                };
+
+                HKDFParameters hkdfParameters = new HKDFParameters(
+                        getKey(),
+                        null,
+                        hkdfInfo);
+
+                HKDFBytesGenerator hkdfGen = new HKDFBytesGenerator(new SHA256Digest());
+                hkdfGen.init(hkdfParameters);
+                key = new byte[SymmetricKeyUtils.getKeyLengthInOctets(encAlgorithm)];
+                hkdfGen.generateBytes(key, 0, key.length);
+
+                try
+                {
+                    byte[] aad = Arrays.prepend(pubKey.getEncodedContents(), (byte) (0xC0 | packetTag));
+                    AEADBlockCipher cipher = BcAEADUtil.createAEADCipher(encAlgorithm, aeadAlgorithm);
+                    cipher.init(true, new AEADParameters(
+                            new KeyParameter(key),
+                            128,
+                            getCipherIV(),
+                            aad
+                    ));
+                    int dataLen = cipher.getOutputSize(keyData.length);
+                    byte[] encKey = new byte[dataLen];
+                    dataLen = cipher.processBytes(keyData, 0, keyData.length, encKey, 0);
+
+                    cipher.doFinal(encKey, dataLen);
+                    return encKey;
+                }
+                catch (IOException | InvalidCipherTextException e)
+                {
+                    throw new PGPException("Exception AEAD protecting private key material", e);
+                }
+            }
+
+            @Override
+            public byte[] getCipherIV()
+            {
+                return iv;
+            }
+        };
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPBESecretKeyDecryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPBESecretKeyDecryptorBuilder.java
@@ -1,10 +1,18 @@
 package org.bouncycastle.openpgp.operator.bc;
 
+import org.bouncycastle.bcpg.SymmetricKeyUtils;
 import org.bouncycastle.crypto.BufferedBlockCipher;
 import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.modes.AEADBlockCipher;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.HKDFParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptor;
 import org.bouncycastle.openpgp.operator.PGPDigestCalculatorProvider;
+import org.bouncycastle.util.Arrays;
 
 public class BcPBESecretKeyDecryptorBuilder
 {
@@ -36,6 +44,45 @@ public class BcPBESecretKeyDecryptorBuilder
                 catch (InvalidCipherTextException e)
                 {
                     throw new PGPException("decryption failed: " + e.getMessage(), e);
+                }
+            }
+
+            @Override
+            public byte[] recoverKeyData(int encAlgorithm, int aeadAlgorithm, byte[] s2kKey, byte[] iv, int packetTag,
+                                         int keyVersion, byte[] keyData, byte[] pubkeyData)
+                    throws PGPException
+            {
+
+                byte[] hkdfInfo = new byte[] {
+                        (byte) (0xC0 | packetTag), (byte) keyVersion, (byte) encAlgorithm, (byte) aeadAlgorithm
+                };
+
+                HKDFParameters hkdfParameters = new HKDFParameters(s2kKey, null, hkdfInfo);
+                HKDFBytesGenerator hkdfGen = new HKDFBytesGenerator(new SHA256Digest());
+                hkdfGen.init(hkdfParameters);
+                byte[] key = new byte[SymmetricKeyUtils.getKeyLengthInOctets(encAlgorithm)];
+                hkdfGen.generateBytes(key, 0, key.length);
+
+                byte[] aad = Arrays.prepend(pubkeyData, (byte) (0xC0 | packetTag));
+                AEADBlockCipher cipher = BcAEADUtil.createAEADCipher(encAlgorithm, aeadAlgorithm);
+                cipher.init(false, new AEADParameters(
+                        new KeyParameter(key),
+                        128,
+                        iv,
+                        aad
+                ));
+                int dataLen = cipher.getOutputSize(keyData.length);
+                byte[] data = new byte[dataLen];
+                dataLen = cipher.processBytes(keyData, 0, keyData.length, data, 0);
+
+                try
+                {
+                    cipher.doFinal(data, dataLen);
+                    return data;
+                }
+                catch (InvalidCipherTextException e)
+                {
+                    throw new PGPException("Exception recovering AEAD protected private key material", e);
                 }
             }
         };

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaAEADSecretKeyEncryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaAEADSecretKeyEncryptorBuilder.java
@@ -1,0 +1,119 @@
+package org.bouncycastle.openpgp.operator.jcajce;
+
+import org.bouncycastle.bcpg.AEADUtils;
+import org.bouncycastle.bcpg.PacketTags;
+import org.bouncycastle.bcpg.PublicKeyPacket;
+import org.bouncycastle.bcpg.S2K;
+import org.bouncycastle.bcpg.SymmetricKeyUtils;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.params.HKDFParameters;
+import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
+import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
+import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPUtil;
+import org.bouncycastle.openpgp.operator.PBESecretKeyEncryptor;
+import org.bouncycastle.util.Arrays;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Provider;
+import java.security.SecureRandom;
+
+public class JcaAEADSecretKeyEncryptorBuilder
+{
+    private int aeadAlgorithm;
+    private int symmetricAlgorithm;
+    private S2K.Argon2Params argon2Params;
+
+    private OperatorHelper helper = new OperatorHelper(new DefaultJcaJceHelper());
+    private JceAEADUtil aeadUtil = new JceAEADUtil(helper);
+
+    public JcaAEADSecretKeyEncryptorBuilder(int aeadAlgorithm, int symmetricAlgorithm, S2K.Argon2Params argon2Params)
+    {
+        this.aeadAlgorithm = aeadAlgorithm;
+        this.symmetricAlgorithm = symmetricAlgorithm;
+        this.argon2Params = argon2Params;
+    }
+
+    public JcaAEADSecretKeyEncryptorBuilder setProvider(Provider provider)
+    {
+        this.helper = new OperatorHelper(new ProviderJcaJceHelper(provider));
+        this.aeadUtil = new JceAEADUtil(helper);
+
+        return this;
+    }
+
+    public JcaAEADSecretKeyEncryptorBuilder setProvider(String providerName)
+    {
+        this.helper = new OperatorHelper(new NamedJcaJceHelper(providerName));
+        this.aeadUtil = new JceAEADUtil(helper);
+
+        return this;
+    }
+
+    public PBESecretKeyEncryptor build(char[] passphrase, PublicKeyPacket pubKey)
+    {
+        return new PBESecretKeyEncryptor(symmetricAlgorithm, aeadAlgorithm, argon2Params, new SecureRandom(), passphrase)
+        {
+            private byte[] iv;
+
+            {
+                iv = new byte[AEADUtils.getIVLength(aeadAlgorithm)];
+                random.nextBytes(iv);
+            }
+
+            @Override
+            public byte[] encryptKeyData(byte[] key, byte[] keyData, int keyOff, int keyLen)
+                    throws PGPException
+            {
+                int packetTag = pubKey.getPacketTag() == PacketTags.PUBLIC_KEY ? PacketTags.SECRET_KEY : PacketTags.SECRET_SUBKEY;
+                byte[] hkdfInfo = new byte[] {
+                        (byte) (0xC0 | packetTag),
+                        (byte) pubKey.getVersion(),
+                        (byte) symmetricAlgorithm,
+                        (byte) aeadAlgorithm
+                };
+
+                HKDFParameters hkdfParameters = new HKDFParameters(
+                        getKey(),
+                        null,
+                        hkdfInfo);
+
+                HKDFBytesGenerator hkdfGen = new HKDFBytesGenerator(new SHA256Digest());
+                hkdfGen.init(hkdfParameters);
+                key = new byte[SymmetricKeyUtils.getKeyLengthInOctets(encAlgorithm)];
+                hkdfGen.generateBytes(key, 0, key.length);
+
+                try
+                {
+                    byte[] aad = Arrays.prepend(pubKey.getEncodedContents(), (byte) (0xC0 | packetTag));
+                    SecretKey secretKey = new SecretKeySpec(key, PGPUtil.getSymmetricCipherName(encAlgorithm));
+                    final Cipher c = aeadUtil.createAEADCipher(encAlgorithm, aeadAlgorithm);
+
+                    JceAEADCipherUtil.setUpAeadCipher(c, secretKey, Cipher.ENCRYPT_MODE, iv, 128, aad);
+                    byte[] data = c.doFinal(keyData);
+                    return data;
+                }
+                catch (IOException | InvalidAlgorithmParameterException | InvalidKeyException |
+                       IllegalBlockSizeException | BadPaddingException e)
+                {
+                    throw new PGPException("Exception AEAD protecting private key material", e);
+                }
+            }
+
+            @Override
+            public byte[] getCipherIV()
+            {
+                return iv;
+            }
+        };
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEProtectionRemoverFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEProtectionRemoverFactory.java
@@ -78,7 +78,15 @@ public class JcePBEProtectionRemoverFactory
         {
             return new PGPSecretKeyDecryptorWithAAD(passPhrase, calculatorProvider)
             {
-                public byte[] recoverKeyData(int encAlgorithm, byte[] key, byte[] iv, byte[] aad, byte[] keyData,  int keyOff, int keyLen)
+                @Override
+                public byte[] recoverKeyData(int encAlgorithm, int aeadAlgorithm, byte[] s2kKey, byte[] iv,
+                                             int packetTag, int keyVersion, byte[] keyData, byte[] pubkeyData)
+                        throws PGPException
+                {
+                    throw new PGPException("Not implemented.");
+                }
+
+                public byte[] recoverKeyData(int encAlgorithm, byte[] key, byte[] iv, byte[] aad, byte[] keyData, int keyOff, int keyLen)
                     throws PGPException
                 {
                     try
@@ -137,6 +145,14 @@ public class JcePBEProtectionRemoverFactory
                     {
                         throw new PGPException("invalid key: " + e.getMessage(), e);
                     }
+                }
+
+                @Override
+                public byte[] recoverKeyData(int encAlgorithm, int aeadAlgorithm, byte[] s2kKey, byte[] iv,
+                                             int packetTag, int keyVersion, byte[] keyData, byte[] pubkeyData)
+                        throws PGPException
+                {
+                    throw new PGPException("Not implemented.");
                 }
             };
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyDecryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyDecryptorBuilder.java
@@ -7,8 +7,14 @@ import java.security.Provider;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
+import org.bouncycastle.bcpg.SymmetricKeyUtils;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.params.HKDFParameters;
 import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
 import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
 import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
@@ -16,11 +22,13 @@ import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPUtil;
 import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptor;
 import org.bouncycastle.openpgp.operator.PGPDigestCalculatorProvider;
+import org.bouncycastle.util.Arrays;
 
 public class JcePBESecretKeyDecryptorBuilder
 {
     private OperatorHelper helper = new OperatorHelper(new DefaultJcaJceHelper());
     private PGPDigestCalculatorProvider calculatorProvider;
+    private JceAEADUtil aeadUtil = new JceAEADUtil(helper);
 
     private JcaPGPDigestCalculatorProviderBuilder calculatorProviderBuilder;
 
@@ -37,6 +45,7 @@ public class JcePBESecretKeyDecryptorBuilder
     public JcePBESecretKeyDecryptorBuilder setProvider(Provider provider)
     {
         this.helper = new OperatorHelper(new ProviderJcaJceHelper(provider));
+        this.aeadUtil = new JceAEADUtil(helper);
 
         if (calculatorProviderBuilder != null)
         {
@@ -49,6 +58,7 @@ public class JcePBESecretKeyDecryptorBuilder
     public JcePBESecretKeyDecryptorBuilder setProvider(String providerName)
     {
         this.helper = new OperatorHelper(new NamedJcaJceHelper(providerName));
+        this.aeadUtil = new JceAEADUtil(helper);
 
         if (calculatorProviderBuilder != null)
         {
@@ -94,6 +104,37 @@ public class JcePBESecretKeyDecryptorBuilder
                 catch (InvalidKeyException e)
                 {
                     throw new PGPException("invalid key: " + e.getMessage(), e);
+                }
+            }
+
+            @Override
+            public byte[] recoverKeyData(int encAlgorithm, int aeadAlgorithm, byte[] s2kKey, byte[] iv, int packetTag, int keyVersion, byte[] keyData, byte[] pubkeyData)
+                    throws PGPException
+            {
+                byte[] hkdfInfo = new byte[] {
+                        (byte) (0xC0 | packetTag), (byte) keyVersion, (byte) encAlgorithm, (byte) aeadAlgorithm
+                };
+                // TODO: Replace HDKF code with JCE based implementation
+                HKDFParameters hkdfParameters = new HKDFParameters(s2kKey, null, hkdfInfo);
+                HKDFBytesGenerator hkdfGen = new HKDFBytesGenerator(new SHA256Digest());
+                hkdfGen.init(hkdfParameters);
+                byte[] key = new byte[SymmetricKeyUtils.getKeyLengthInOctets(encAlgorithm)];
+                hkdfGen.generateBytes(key, 0, key.length);
+
+                byte[] aad = Arrays.prepend(pubkeyData, (byte) (0xC0 | packetTag));
+
+                SecretKey secretKey = new SecretKeySpec(key, PGPUtil.getSymmetricCipherName(encAlgorithm));
+                final Cipher c = aeadUtil.createAEADCipher(encAlgorithm, aeadAlgorithm);
+                try
+                {
+                    JceAEADCipherUtil.setUpAeadCipher(c, secretKey, Cipher.DECRYPT_MODE, iv, 128, aad);
+                    byte[] data = c.doFinal(keyData);
+                    return data;
+                }
+                catch (InvalidAlgorithmParameterException | InvalidKeyException |
+                        IllegalBlockSizeException | BadPaddingException e)
+                {
+                    throw new PGPException("Cannot extract AEAD protected secret key material", e);
                 }
             }
         };

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/AEADProtectedPGPSecretKeyTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/AEADProtectedPGPSecretKeyTest.java
@@ -1,0 +1,87 @@
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.*;
+import org.bouncycastle.openpgp.bc.BcPGPObjectFactory;
+import org.bouncycastle.openpgp.operator.bc.BcPBESecretKeyDecryptorBuilder;
+import org.bouncycastle.openpgp.operator.bc.BcPGPDigestCalculatorProvider;
+import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyDecryptorBuilder;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+
+public class AEADProtectedPGPSecretKeyTest
+        extends AbstractPgpKeyPairTest
+{
+
+    @Override
+    public String getName()
+    {
+        return "Argon2ProtectedPGPSecretKeyTest";
+    }
+
+    @Override
+    public void performTest()
+            throws Exception
+    {
+        unlockTestVector();
+    }
+
+    private void unlockTestVector()
+            throws IOException, PGPException
+    {
+        // AEAD encrypted test vector extracted from here:
+        // https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-13.html#name-sample-locked-v6-secret-key
+        String armoredVector = "-----BEGIN PGP PRIVATE KEY BLOCK-----\n" +
+                "\n" +
+                "xYIGY4d/4xsAAAAg+U2nu0jWCmHlZ3BqZYfQMxmZu52JGggkLq2EVD34laP9JgkC\n" +
+                "FARdb9ccngltHraRe25uHuyuAQQVtKipJ0+r5jL4dacGWSAheCWPpITYiyfyIOPS\n" +
+                "3gIDyg8f7strd1OB4+LZsUhcIjOMpVHgmiY/IutJkulneoBYwrEGHxsKAAAAQgWC\n" +
+                "Y4d/4wMLCQcFFQoOCAwCFgACmwMCHgkiIQbLGGxPBgmml+TVLfpscisMHx4nwYpW\n" +
+                "cI9lJewnutmsyQUnCQIHAgAAAACtKCAQPi19In7A5tfORHHbNr/JcIMlNpAnFJin\n" +
+                "7wV2wH+q4UWFs7kDsBJ+xP2i8CMEWi7Ha8tPlXGpZR4UruETeh1mhELIj5UeM8T/\n" +
+                "0z+5oX1RHu11j8bZzFDLX9eTsgOdWATHggZjh3/jGQAAACCGkySDZ/nlAV25Ivj0\n" +
+                "gJXdp4SYfy1ZhbEvutFsr15ENf0mCQIUBA5hhGgp2oaavg6mFUXcFMwBBBUuE8qf\n" +
+                "9Ock+xwusd+GAglBr5LVyr/lup3xxQvHXFSjjA2haXfoN6xUGRdDEHI6+uevKjVR\n" +
+                "v5oAxgu7eJpaXNjCmwYYGwoAAAAsBYJjh3/jApsMIiEGyxhsTwYJppfk1S36bHIr\n" +
+                "DB8eJ8GKVnCPZSXsJ7rZrMkAAAAABAEgpukYbZ1ZNfyP5WMUzbUnSGpaUSD5t2Ki\n" +
+                "Nacp8DkBClZRa2c3AMQzSDXa9jGhYzxjzVb5scHDzTkjyRZWRdTq8U6L4da+/+Kt\n" +
+                "ruh8m7Xo2ehSSFyWRSuTSZe5tm/KXgYG\n" +
+                "-----END PGP PRIVATE KEY BLOCK-----";
+        char[] passphrase = "correct horse battery staple".toCharArray();
+        // Plaintext vectors extracted from here:
+        // https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-13.html#name-sample-v6-secret-key-transf
+        byte[] plainPrimaryKey = Hex.decode("1972817b12be707e8d5f586ce61361201d344eb266a2c82fde6835762b65b0b7");
+        byte[] plainSubkey = Hex.decode("4d600a4f794d44775c57a26e0feefed558e9afffd6ad0d582d57fb2ba2dcedb8");
+
+        ByteArrayInputStream bIn = new ByteArrayInputStream(armoredVector.getBytes(StandardCharsets.UTF_8));
+        ArmoredInputStream aIn = new ArmoredInputStream(bIn);
+        BCPGInputStream pIn = new BCPGInputStream(aIn);
+        PGPObjectFactory objFact = new BcPGPObjectFactory(pIn);
+        PGPSecretKeyRing keys = (PGPSecretKeyRing) objFact.nextObject();
+
+        Iterator<PGPSecretKey> it = keys.getSecretKeys();
+        PGPSecretKey primaryKey = it.next();
+        PGPSecretKey subkey = it.next();
+
+        // Test Bouncy Castle implementation
+        BcPBESecretKeyDecryptorBuilder bcDecryptor = new BcPBESecretKeyDecryptorBuilder(new BcPGPDigestCalculatorProvider());
+        PGPPrivateKey privPrimaryKey = primaryKey.extractPrivateKey(bcDecryptor.build(passphrase));
+        isEncodingEqual(plainPrimaryKey, privPrimaryKey.getPrivateKeyDataPacket().getEncoded());
+
+        // Test Jca/Jce implementation
+        JcePBESecretKeyDecryptorBuilder jceDecryptor = new JcePBESecretKeyDecryptorBuilder().setProvider(new BouncyCastleProvider());
+        PGPPrivateKey privSubKey = subkey.extractPrivateKey(jceDecryptor.build(passphrase));
+        isEncodingEqual(plainSubkey, privSubKey.getPrivateKeyDataPacket().getEncoded());
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new AEADProtectedPGPSecretKeyTest());
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/AEADProtectedPGPSecretKeyTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/AEADProtectedPGPSecretKeyTest.java
@@ -127,12 +127,41 @@ public class AEADProtectedPGPSecretKeyTest
         lockUnlockKeyJca(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.AES_128, passphrase, passphrase);
         lockUnlockKeyJca(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.AES_128, passphrase, passphrase);
 
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.EAX, SymmetricKeyAlgorithmTags.AES_192, passphrase, passphrase);
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.AES_192, passphrase, passphrase);
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.AES_192, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.EAX, SymmetricKeyAlgorithmTags.AES_192, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.AES_192, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.AES_192, passphrase, passphrase);
+
         lockUnlockKeyBc(keyPair, AEADAlgorithmTags.EAX, SymmetricKeyAlgorithmTags.AES_256, passphrase, passphrase);
         lockUnlockKeyBc(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.AES_256, passphrase, passphrase);
         lockUnlockKeyBc(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.AES_256, passphrase, passphrase);
         lockUnlockKeyJca(keyPair, AEADAlgorithmTags.EAX, SymmetricKeyAlgorithmTags.AES_256, passphrase, passphrase);
         lockUnlockKeyJca(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.AES_256, passphrase, passphrase);
         lockUnlockKeyJca(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.AES_256, passphrase, passphrase);
+
+
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.EAX, SymmetricKeyAlgorithmTags.CAMELLIA_128, passphrase, passphrase);
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.CAMELLIA_128, passphrase, passphrase);
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.CAMELLIA_128, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.EAX, SymmetricKeyAlgorithmTags.CAMELLIA_128, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.CAMELLIA_128, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.CAMELLIA_128, passphrase, passphrase);
+
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.EAX, SymmetricKeyAlgorithmTags.CAMELLIA_192, passphrase, passphrase);
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.CAMELLIA_192, passphrase, passphrase);
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.CAMELLIA_192, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.EAX, SymmetricKeyAlgorithmTags.CAMELLIA_192, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.CAMELLIA_192, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.CAMELLIA_192, passphrase, passphrase);
+
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.EAX, SymmetricKeyAlgorithmTags.CAMELLIA_256, passphrase, passphrase);
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.CAMELLIA_256, passphrase, passphrase);
+        lockUnlockKeyBc(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.CAMELLIA_256, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.EAX, SymmetricKeyAlgorithmTags.CAMELLIA_256, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.CAMELLIA_256, passphrase, passphrase);
+        lockUnlockKeyJca(keyPair, AEADAlgorithmTags.GCM, SymmetricKeyAlgorithmTags.CAMELLIA_256, passphrase, passphrase);
     }
 
     private void generateAndLockUnlockEd25519v6Key()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/AEADProtectedPGPSecretKeyTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/AEADProtectedPGPSecretKeyTest.java
@@ -52,6 +52,7 @@ public class AEADProtectedPGPSecretKeyTest
     {
         unlockTestVector();
         lockGeneratedV4Key();
+        lockGeneratedV6Key();
     }
 
     private void unlockTestVector()
@@ -111,12 +112,22 @@ public class AEADProtectedPGPSecretKeyTest
         Date creationTime = currentTimeRounded();
         PGPKeyPair keyPair = new BcPGPKeyPair(PublicKeyAlgorithmTags.Ed25519, kp, creationTime);
 
-        lockGeneratedV4KeyBc(keyPair);
-
-        lockGeneratedV4KeyJca(keyPair);
+        lockGeneratedKeyBc(keyPair);
+        lockGeneratedKeyJca(keyPair);
     }
 
-    private void lockGeneratedV4KeyBc(PGPKeyPair keyPair)
+    private void lockGeneratedV6Key()
+        throws PGPException
+    {
+        Ed25519KeyPairGenerator gen = new Ed25519KeyPairGenerator();
+        gen.init(new Ed25519KeyGenerationParameters(new SecureRandom()));
+        AsymmetricCipherKeyPair kp = gen.generateKeyPair();
+        Date creationTime = currentTimeRounded();
+        // TODO: Uncomment once https://github.com/bcgit/bc-java/pull/1695 is merged
+        // PGPKeyPair keyPair = new BcPGPKeyPair(PublicKeyPacket.VERSION_6, PublicKeyAlgorithmTags.Ed25519, kp, creationTime);
+    }
+
+    private void lockGeneratedKeyBc(PGPKeyPair keyPair)
             throws PGPException
     {
         BcAEADSecretKeyEncryptorBuilder bcEncBuilder = new BcAEADSecretKeyEncryptorBuilder(
@@ -145,7 +156,7 @@ public class AEADProtectedPGPSecretKeyTest
         isEncodingEqual(keyPair.getPrivateKey().getPrivateKeyDataPacket().getEncoded(), dec.getPrivateKeyDataPacket().getEncoded());
     }
 
-    private void lockGeneratedV4KeyJca(PGPKeyPair keyPair)
+    private void lockGeneratedKeyJca(PGPKeyPair keyPair)
             throws PGPException
     {
         BouncyCastleProvider prov = new BouncyCastleProvider();

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/AEADProtectedPGPSecretKeyTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/AEADProtectedPGPSecretKeyTest.java
@@ -1,18 +1,36 @@
 package org.bouncycastle.openpgp.test;
 
+import org.bouncycastle.bcpg.AEADAlgorithmTags;
 import org.bouncycastle.bcpg.ArmoredInputStream;
 import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.bcpg.HashAlgorithmTags;
+import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
+import org.bouncycastle.bcpg.S2K;
+import org.bouncycastle.bcpg.SecretKeyPacket;
+import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator;
+import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openpgp.*;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPKeyPair;
+import org.bouncycastle.openpgp.PGPObjectFactory;
+import org.bouncycastle.openpgp.PGPPrivateKey;
+import org.bouncycastle.openpgp.PGPSecretKey;
+import org.bouncycastle.openpgp.PGPSecretKeyRing;
 import org.bouncycastle.openpgp.bc.BcPGPObjectFactory;
+import org.bouncycastle.openpgp.operator.bc.BcAEADSecretKeyEncryptorBuilder;
 import org.bouncycastle.openpgp.operator.bc.BcPBESecretKeyDecryptorBuilder;
 import org.bouncycastle.openpgp.operator.bc.BcPGPDigestCalculatorProvider;
+import org.bouncycastle.openpgp.operator.bc.BcPGPKeyPair;
 import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyDecryptorBuilder;
 import org.bouncycastle.util.encoders.Hex;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Date;
 import java.util.Iterator;
 
 public class AEADProtectedPGPSecretKeyTest
@@ -30,6 +48,7 @@ public class AEADProtectedPGPSecretKeyTest
             throws Exception
     {
         unlockTestVector();
+        lockGeneratedV4Key();
     }
 
     private void unlockTestVector()
@@ -78,6 +97,37 @@ public class AEADProtectedPGPSecretKeyTest
         JcePBESecretKeyDecryptorBuilder jceDecryptor = new JcePBESecretKeyDecryptorBuilder().setProvider(new BouncyCastleProvider());
         PGPPrivateKey privSubKey = subkey.extractPrivateKey(jceDecryptor.build(passphrase));
         isEncodingEqual(plainSubkey, privSubKey.getPrivateKeyDataPacket().getEncoded());
+    }
+
+    private void lockGeneratedV4Key() throws PGPException {
+        Ed25519KeyPairGenerator gen = new Ed25519KeyPairGenerator();
+        gen.init(new Ed25519KeyGenerationParameters(new SecureRandom()));
+        AsymmetricCipherKeyPair kp = gen.generateKeyPair();
+        Date creationTime = currentTimeRounded();
+        PGPKeyPair keyPair = new BcPGPKeyPair(PublicKeyAlgorithmTags.Ed25519, kp, creationTime);
+
+        BcAEADSecretKeyEncryptorBuilder encBuilder = new BcAEADSecretKeyEncryptorBuilder(
+                AEADAlgorithmTags.OCB, SymmetricKeyAlgorithmTags.AES_256,
+                S2K.Argon2Params.memoryConstrainedParameters()
+        );
+
+        PGPSecretKey sk = new PGPSecretKey(
+                keyPair.getPrivateKey(),
+                keyPair.getPublicKey(),
+                new BcPGPDigestCalculatorProvider().get(HashAlgorithmTags.SHA1),
+                true,
+                encBuilder.build("Hello".toCharArray(), keyPair.getPublicKey().getPublicKeyPacket()));
+
+        isEquals(SecretKeyPacket.USAGE_AEAD, sk.getS2KUsage());
+        isEquals(S2K.ARGON_2, sk.getS2K().getType());
+        isEquals(3, sk.getS2K().getPasses());
+        isEquals(4, sk.getS2K().getParallelism());
+        isEquals(16, sk.getS2K().getMemorySizeExponent());
+
+        BcPBESecretKeyDecryptorBuilder decBuilder = new BcPBESecretKeyDecryptorBuilder(new BcPGPDigestCalculatorProvider());
+
+        PGPPrivateKey dec = sk.extractPrivateKey(decBuilder.build("Hello".toCharArray()));
+        isEncodingEqual(keyPair.getPrivateKey().getPrivateKeyDataPacket().getEncoded(), dec.getPrivateKeyDataPacket().getEncoded());
     }
 
     public static void main(String[] args)

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
@@ -51,6 +51,7 @@ public class RegressionTest
         new IgnoreUnknownEncryptedSessionKeys(),
         new PGPEncryptedDataTest(),
         new PGPAeadTest(),
+        new AEADProtectedPGPSecretKeyTest(),
         new CRC24Test(),
         new WildcardKeyIDTest(),
         new ArmorCRCTest(),


### PR DESCRIPTION
This PR is based on - and blocked by - #1699

Here, I added two new classes, BcAEADSecretKeyEncryptorBuilder and JcaAEADSecretKeyEncryptorBuilder, which can both be used to AEAD-encrypt PGP secret keys.

First I tried to implement AEAD protection into the existing PBESecretKeyEncryptorBuilder classes, but that turned out to result in ugly code.
Let me know what you think of my approach.