### PR TITLE
LibrePGP V5 fingerprint calculation

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcKeyFingerprintCalculator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcKeyFingerprintCalculator.java
@@ -60,14 +60,14 @@ public class BcKeyFingerprintCalculator
                 throw new PGPException("can't encode key components: " + e.getMessage(), e);
             }
         }
-        else if (publicPk.getVersion() == PublicKeyPacket.VERSION_6)
+        else if (publicPk.getVersion() == 5 || publicPk.getVersion() == PublicKeyPacket.VERSION_6)
         {
             try
             {
                 byte[] kBytes = publicPk.getEncodedContents();
                 digest = new SHA256Digest();
 
-                digest.update((byte)0x9b);
+                digest.update((byte) (publicPk.getVersion() == PublicKeyPacket.VERSION_6 ? 0x9b : 0x9a));
 
                 digest.update((byte)(kBytes.length >> 24));
                 digest.update((byte)(kBytes.length >> 16));

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcKeyFingerprintCalculator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcKeyFingerprintCalculator.java
@@ -23,7 +23,7 @@ public class BcKeyFingerprintCalculator
         BCPGKey key = publicPk.getKey();
         Digest digest;
 
-        if (publicPk.getVersion() <= 3)
+        if (publicPk.getVersion() <= PublicKeyPacket.VERSION_3)
         {
             RSAPublicBCPGKey rK = (RSAPublicBCPGKey)key;
 
@@ -42,7 +42,7 @@ public class BcKeyFingerprintCalculator
                 throw new PGPException("can't encode key components: " + e.getMessage(), e);
             }
         }
-        else if (publicPk.getVersion() == 4)
+        else if (publicPk.getVersion() == PublicKeyPacket.VERSION_4)
         {
             try
             {
@@ -60,7 +60,7 @@ public class BcKeyFingerprintCalculator
                 throw new PGPException("can't encode key components: " + e.getMessage(), e);
             }
         }
-        else if (publicPk.getVersion() == 6)
+        else if (publicPk.getVersion() == PublicKeyPacket.VERSION_6)
         {
             try
             {

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaKeyFingerprintCalculator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaKeyFingerprintCalculator.java
@@ -63,7 +63,7 @@ public class JcaKeyFingerprintCalculator
     {
         BCPGKey key = publicPk.getKey();
 
-        if (publicPk.getVersion() <= 3)
+        if (publicPk.getVersion() <= PublicKeyPacket.VERSION_3)
         {
             RSAPublicBCPGKey rK = (RSAPublicBCPGKey)key;
 
@@ -92,7 +92,7 @@ public class JcaKeyFingerprintCalculator
                 throw new PGPException("can't encode key components: " + e.getMessage(), e);
             }
         }
-        else if (publicPk.getVersion() == 4)
+        else if (publicPk.getVersion() == PublicKeyPacket.VERSION_4)
         {
             try
             {
@@ -120,7 +120,7 @@ public class JcaKeyFingerprintCalculator
                 throw new PGPException("can't encode key components: " + e.getMessage(), e);
             }
         }
-        else if (publicPk.getVersion() == 6)
+        else if (publicPk.getVersion() == PublicKeyPacket.VERSION_6)
         {
             try
             {

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaKeyFingerprintCalculator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaKeyFingerprintCalculator.java
@@ -120,15 +120,14 @@ public class JcaKeyFingerprintCalculator
                 throw new PGPException("can't encode key components: " + e.getMessage(), e);
             }
         }
-        else if (publicPk.getVersion() == PublicKeyPacket.VERSION_6)
+        else if (publicPk.getVersion() == 5 || publicPk.getVersion() == PublicKeyPacket.VERSION_6)
         {
             try
             {
                 byte[] kBytes = publicPk.getEncodedContents();
 
                 MessageDigest digest = helper.createMessageDigest("SHA-256");
-
-                digest.update((byte)0x9b);
+                digest.update((byte) (publicPk.getVersion() == PublicKeyPacket.VERSION_6 ? 0x9b : 0x9a));
 
                 digest.update((byte)(kBytes.length >> 24));
                 digest.update((byte)(kBytes.length >> 16));


### PR DESCRIPTION
This PR adds support for calculating the fingerprint of v5 LibrePGP keys.

The v5 calculation is untested, as I cannot find an official test vector, though I'm pretty certain it is correct, as it only trivially diverges from v6 fingerprint calculation.