### PR TITLE
Ordered attribute table

### DIFF
--- a/util/src/main/java/org/bouncycastle/asn1/cms/AttributeTable.java
+++ b/util/src/main/java/org/bouncycastle/asn1/cms/AttributeTable.java
@@ -1,6 +1,5 @@
 package org.bouncycastle.asn1.cms;
 
-import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
 
@@ -124,11 +123,9 @@ public class AttributeTable
         
         if (value instanceof Vector)
         {
-            Enumeration<Attribute> e = ((Vector<Attribute>)value).elements();
-            
-            while (e.hasMoreElements())
+            for (Attribute attribute : (Vector<Attribute>) value)
             {
-                v.add(e.nextElement());
+                v.add(attribute);
             }
         }
         else if (value != null)
@@ -143,10 +140,8 @@ public class AttributeTable
     {
         int size = 0;
 
-        for (Enumeration en = attributes.elements(); en.hasMoreElements();)
+        for (Object o : attributes.values())
         {
-            Object o = en.nextElement();
-
             if (o instanceof Vector)
             {
                 size += ((Vector)o).size();
@@ -168,19 +163,14 @@ public class AttributeTable
     public ASN1EncodableVector toASN1EncodableVector()
     {
         ASN1EncodableVector  v = new ASN1EncodableVector();
-        Enumeration          e = attributes.elements();
         
-        while (e.hasMoreElements())
+        for (Object value : attributes.values())
         {
-            Object value = e.nextElement();
-            
             if (value instanceof Vector)
             {
-                Enumeration en = ((Vector)value).elements();
-                
-                while (en.hasMoreElements())
+                for (Object element : (Vector)value)
                 {
-                    v.add(Attribute.getInstance(en.nextElement()));
+                    v.add(Attribute.getInstance(element));
                 }
             }
             else
@@ -200,12 +190,9 @@ public class AttributeTable
     private Hashtable<ASN1ObjectIdentifier, Object> copyTable(Hashtable<ASN1ObjectIdentifier, Object> in)
     {
         Hashtable<ASN1ObjectIdentifier, Object>   out = new Hashtable<>();
-        Enumeration<ASN1ObjectIdentifier> e = in.keys();
         
-        while (e.hasMoreElements())
+        for (ASN1ObjectIdentifier key : in.keySet())
         {
-            ASN1ObjectIdentifier key = e.nextElement();
-            
             out.put(key, in.get(key));
         }
         

--- a/util/src/main/java/org/bouncycastle/asn1/cms/AttributeTable.java
+++ b/util/src/main/java/org/bouncycastle/asn1/cms/AttributeTable.java
@@ -1,6 +1,8 @@
 package org.bouncycastle.asn1.cms;
 
 import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Vector;
 
 import org.bouncycastle.asn1.ASN1Encodable;
@@ -14,12 +16,18 @@ import org.bouncycastle.asn1.DERSet;
  */
 public class AttributeTable
 {
-    private Hashtable<ASN1ObjectIdentifier, Object> attributes = new Hashtable<>();
+    private Map<ASN1ObjectIdentifier, Object> attributes = new LinkedHashMap<>();
+
+    public AttributeTable(
+        Map<ASN1ObjectIdentifier, Object>  attrs)
+    {
+        attributes = new LinkedHashMap<>(attrs);
+    }
 
     public AttributeTable(
         Hashtable<ASN1ObjectIdentifier, Object>  attrs)
     {
-        attributes = new Hashtable<>(attrs);
+        this((Map<ASN1ObjectIdentifier, Object>) attrs);
     }
 
     public AttributeTable(

--- a/util/src/main/java/org/bouncycastle/asn1/cms/AttributeTable.java
+++ b/util/src/main/java/org/bouncycastle/asn1/cms/AttributeTable.java
@@ -19,7 +19,7 @@ public class AttributeTable
     public AttributeTable(
         Hashtable<ASN1ObjectIdentifier, Object>  attrs)
     {
-        attributes = copyTable(attrs);
+        attributes = new Hashtable<>(attrs);
     }
 
     public AttributeTable(
@@ -157,7 +157,7 @@ public class AttributeTable
 
     public Hashtable<ASN1ObjectIdentifier, Object> toHashtable()
     {
-        return copyTable(attributes);
+        return new Hashtable<>(attributes);
     }
     
     public ASN1EncodableVector toASN1EncodableVector()
@@ -185,18 +185,6 @@ public class AttributeTable
     public Attributes toASN1Structure()
     {
         return new Attributes(this.toASN1EncodableVector());
-    }
-
-    private Hashtable<ASN1ObjectIdentifier, Object> copyTable(Hashtable<ASN1ObjectIdentifier, Object> in)
-    {
-        Hashtable<ASN1ObjectIdentifier, Object>   out = new Hashtable<>();
-        
-        for (ASN1ObjectIdentifier key : in.keySet())
-        {
-            out.put(key, in.get(key));
-        }
-        
-        return out;
     }
 
     /**

--- a/util/src/main/java/org/bouncycastle/asn1/cms/AttributeTable.java
+++ b/util/src/main/java/org/bouncycastle/asn1/cms/AttributeTable.java
@@ -15,10 +15,10 @@ import org.bouncycastle.asn1.DERSet;
  */
 public class AttributeTable
 {
-    private Hashtable attributes = new Hashtable();
+    private Hashtable<ASN1ObjectIdentifier, Object> attributes = new Hashtable<>();
 
     public AttributeTable(
-        Hashtable  attrs)
+        Hashtable<ASN1ObjectIdentifier, Object>  attrs)
     {
         attributes = copyTable(attrs);
     }
@@ -69,13 +69,13 @@ public class AttributeTable
         }
         else
         {
-            Vector v;
+            Vector<Attribute> v;
             
             if (value instanceof Attribute)
             {
-                v = new Vector();
+                v = new Vector<>();
                 
-                v.addElement(value);
+                v.addElement((Attribute) value);
                 v.addElement(a);
             }
             else
@@ -102,7 +102,7 @@ public class AttributeTable
         
         if (value instanceof Vector)
         {
-            return (Attribute)((Vector)value).elementAt(0);
+            return ((Vector<Attribute>)value).elementAt(0);
         }
         
         return (Attribute)value;
@@ -124,11 +124,11 @@ public class AttributeTable
         
         if (value instanceof Vector)
         {
-            Enumeration e = ((Vector)value).elements();
+            Enumeration<Attribute> e = ((Vector<Attribute>)value).elements();
             
             while (e.hasMoreElements())
             {
-                v.add((Attribute)e.nextElement());
+                v.add(e.nextElement());
             }
         }
         else if (value != null)
@@ -160,7 +160,7 @@ public class AttributeTable
         return size;
     }
 
-    public Hashtable toHashtable()
+    public Hashtable<ASN1ObjectIdentifier, Object> toHashtable()
     {
         return copyTable(attributes);
     }
@@ -197,15 +197,14 @@ public class AttributeTable
         return new Attributes(this.toASN1EncodableVector());
     }
 
-    private Hashtable copyTable(
-        Hashtable in)
+    private Hashtable<ASN1ObjectIdentifier, Object> copyTable(Hashtable<ASN1ObjectIdentifier, Object> in)
     {
-        Hashtable   out = new Hashtable();
-        Enumeration e = in.keys();
+        Hashtable<ASN1ObjectIdentifier, Object>   out = new Hashtable<>();
+        Enumeration<ASN1ObjectIdentifier> e = in.keys();
         
         while (e.hasMoreElements())
         {
-            Object key = e.nextElement();
+            ASN1ObjectIdentifier key = e.nextElement();
             
             out.put(key, in.get(key));
         }


### PR DESCRIPTION
I'd like to suggest a modification to the AttributeTable class such that the insertion order of the attributes is preserved. The current implementation uses a Hashtable and doesn't guarantee any order. This PR replaces the Hashtable with a LinkedHashMap.