### PR TITLE
Test PGPSignatures with LegacyEd25519 keys with short MPIs

### DIFF
--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPSignatureTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPSignatureTest.java
@@ -11,13 +11,22 @@ import java.security.SignatureException;
 import java.util.Date;
 import java.util.Iterator;
 
-import org.bouncycastle.bcpg.*;
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.bcpg.CompressionAlgorithmTags;
+import org.bouncycastle.bcpg.HashAlgorithmTags;
+import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
+import org.bouncycastle.bcpg.SignatureSubpacket;
+import org.bouncycastle.bcpg.SignatureSubpacketInputStream;
+import org.bouncycastle.bcpg.SignatureSubpacketTags;
+import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
 import org.bouncycastle.bcpg.sig.IntendedRecipientFingerprint;
 import org.bouncycastle.bcpg.sig.IssuerFingerprint;
 import org.bouncycastle.bcpg.sig.KeyFlags;
 import org.bouncycastle.bcpg.sig.NotationData;
 import org.bouncycastle.bcpg.sig.SignatureTarget;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.math.ec.rfc8032.Ed25519;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPLiteralData;
 import org.bouncycastle.openpgp.PGPLiteralDataGenerator;
@@ -759,6 +768,7 @@ public class PGPSignatureTest
         testUserAttributeEncoding();
         testExportNonExportableSignature();
         testRejectionOfIllegalSignatureType0xFF();
+        testGetSignatureOfLegacyEd25519KeyWithShortMPIs();
     }
 
     private void testUserAttributeEncoding()
@@ -1411,6 +1421,17 @@ public class PGPSignatureTest
         {
             // expected
         }
+    }
+
+    private void testGetSignatureOfLegacyEd25519KeyWithShortMPIs()
+            throws PGPException, IOException
+    {
+        String ed25519KeyWithShortSignatureMPIs = "88740401160a00270502666a2d4009105ac5b83f1a5ad687162104229cfc85fe0ca2e3718b022c5ac5b83f1a5ad6870000a16b00f7754c1d14b068ae5e6816c376367569b1ae984587e8e5ec3cc54b811549a4920100ca2159e5965bf7d8655385449994aead14ccf05c3f33335b98d305c0f20ef50e";
+        ByteArrayInputStream bIn = new ByteArrayInputStream(Hex.decode(ed25519KeyWithShortSignatureMPIs));
+        BCPGInputStream pIn = new BCPGInputStream(bIn);
+        PGPSignature signature = new PGPSignature(pIn);
+        isEquals("Short MPIs in LegacyEd25519 signature MUST be properly parsed",
+                Ed25519.SIGNATURE_SIZE, signature.getSignature().length);
     }
 
     private PGPSignatureList readSignatures(String armored)


### PR DESCRIPTION
With legacy ed25519 we need to detect the curve (curve25519 / curve448) based on the length of the encoding (see https://github.com/bcgit/bc-java/pull/1675, most notably https://github.com/bcgit/bc-java/pull/1675/commits/105dbef01d688a963f98ba2815f1343774c42fae).

However, I noticed, that some ed25519 signatures MPIs are shorter than the expected 2*32 octets (leading 0s), resulting in the code misinterpreting the signature as an ed448 signature. This in turn causes signature verification failures for good signatures.

This patch catches this edge case by allowing short MPIs.