### PR TITLE
AEADEncDataPacket: Throw UnsupportedPacketVersionException

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/AEADEncDataPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/AEADEncDataPacket.java
@@ -40,7 +40,7 @@ public class AEADEncDataPacket
         version = (byte)in.read();
         if (version != VERSION_1)
         {
-            throw new IllegalArgumentException("wrong AEAD packet version: " + version);
+            throw new UnsupportedPacketVersionException("wrong AEAD packet version: " + version);
         }
 
         algorithm = (byte)in.read();

--- a/pg/src/main/java/org/bouncycastle/bcpg/AEADEncDataPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/AEADEncDataPacket.java
@@ -5,10 +5,13 @@ import java.io.IOException;
 import org.bouncycastle.util.Arrays;
 
 /**
- * Packet representing AEAD encrypted data. At the moment this appears to exist in the following
+ * Packet representing non-standard, LibrePGP OCB (AEAD) encrypted data. At the moment this appears to exist in the following
  * expired draft only, but it's appearing despite this.
+ * For standardized, interoperable OpenPGP AEAD encrypted data, see {@link SymmetricEncIntegrityPacket} of version
+ * {@link SymmetricEncIntegrityPacket#VERSION_2}.
  *
- * @ref https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-rfc4880bis-04#section-5.16
+ * @see  <a href="https://www.ietf.org/archive/id/draft-koch-librepgp-00.html#name-ocb-encrypted-data-packet-t">
+ *     LibrePGP - OCB Encrypted Data Packet</a>
  */
 public class AEADEncDataPacket
     extends InputStreamPacket

--- a/pg/src/test/java/org/bouncycastle/bcpg/test/OCBEncryptedDataPacketTest.java
+++ b/pg/src/test/java/org/bouncycastle/bcpg/test/OCBEncryptedDataPacketTest.java
@@ -1,0 +1,70 @@
+package org.bouncycastle.bcpg.test;
+
+import org.bouncycastle.bcpg.*;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class OCBEncryptedDataPacketTest extends AbstractPacketTest {
+    @Override
+    public String getName() {
+        return "OCBEncryptedDataPacketTest";
+    }
+
+    @Override
+    public void performTest() throws Exception {
+        parseTestVector();
+        parseUnsupportedPacketVersion();
+    }
+
+    private void parseTestVector() throws IOException {
+        String testVector = "" +
+                "d45301090210c265ff63a61ed8af00fa" +
+                "43866be8eb9eef77241518a3d60e387b" +
+                "1e283bdd90e2233d17a937a595686024" +
+                "1d13ddfaccd2b724a491167631d1cd3e" +
+                "a74fe5d9e617f1f267d891fd338fddb2" +
+                "c66c025cde";
+
+        ByteArrayInputStream bIn = new ByteArrayInputStream(Hex.decode(testVector));
+        BCPGInputStream pIn = new BCPGInputStream(bIn);
+
+        AEADEncDataPacket p = (AEADEncDataPacket) pIn.readPacket();
+        isTrue("Packet length encoding format mismatch", p.hasNewPacketFormat());
+        isEquals("Packet version mismatch", 1, p.getVersion());
+        isEquals("Symmetric algorithm mitmatch", SymmetricKeyAlgorithmTags.AES_256, p.getAlgorithm());
+        isEquals("AEAD encryption algorithm mismatch", AEADAlgorithmTags.OCB, p.getAEADAlgorithm());
+        isEquals("Chunk size mismatch", 16, p.getChunkSize());
+        isEncodingEqual("IV mismatch", Hex.decode("C265FF63A61ED8AF00FA43866BE8EB"), p.getIV());
+    }
+
+    private void parseUnsupportedPacketVersion() throws IOException {
+        // Test vector with modified packet version 99
+        String testVector = "" +
+                "d45399090210c265ff63a61ed8af00fa" +
+                "43866be8eb9eef77241518a3d60e387b" +
+                "1e283bdd90e2233d17a937a595686024" +
+                "1d13ddfaccd2b724a491167631d1cd3e" +
+                "a74fe5d9e617f1f267d891fd338fddb2" +
+                "c66c025cde";
+
+        ByteArrayInputStream bIn = new ByteArrayInputStream(Hex.decode(testVector));
+        BCPGInputStream pIn = new BCPGInputStream(bIn);
+
+        try
+        {
+            pIn.readPacket();
+            fail("Expected UnsupportedPacketVersionException for unsupported version 99");
+        }
+        catch (UnsupportedPacketVersionException e)
+        {
+            // expected
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new OCBEncryptedDataPacketTest());
+    }
+}


### PR DESCRIPTION
If an unsupported version of the LibrePGP `AEADEncDataPacket` is encountered, the code currently throws an `IllegalArgumentException`.

This PR changes this behavior to throw an `UnsupportedPacketVersionException` instead.