### PR TITLE
Trivial: Added two properties from mail, missing in jmail

### DIFF
--- a/jmail/src/main/resources/org/bouncycastle/mail/smime/validator/SignedMailValidatorMessages.properties
+++ b/jmail/src/main/resources/org/bouncycastle/mail/smime/validator/SignedMailValidatorMessages.properties
@@ -1,0 +1,172 @@
+## constructor exception messages
+
+# Signature valid
+SignedMailValidator.sigValid.title = Signature valid
+SignedMailValidator.sigValid.text = Signature valid
+SignedMailValidator.sigValid.summary = Signature valid
+SignedMailValidator.sigValid.details = Signature valid
+
+# Signature invalid
+SignedMailValidator.sigInvalid.title = Signature invalid
+SignedMailValidator.sigInvalid.text = Signature invalid
+SignedMailValidator.sigInvalid.summary = Signature invalid
+SignedMailValidator.sigInvalid.details = Signature invalid
+
+# message is not signed
+SignedMailValidator.noSignedMessage.title = Message is not signed
+SignedMailValidator.noSignedMessage.text = SignedMailValidator: MimeMessage message is not a signed message.
+SignedMailValidator.noSignedMessage.summary = SignedMailValidator: MimeMessage message is not a signed message.
+SignedMailValidator.noSignedMessage.details = SignedMailValidator: MimeMessage message is not a signed message.
+
+# exception reading the Mime message
+# {0} message of the underlying exception
+# {1} the underlying exception
+# {2} the name of the exception
+SignedMailValidator.exceptionReadingMessage.title = Exception reading the MimeMessage
+SignedMailValidator.exceptionReadingMessage.text = SignedMailValidator: there was a {2} reading the MimeMessage: {0}.
+SignedMailValidator.exceptionReadingMessage.summary = SignedMailValidator: there was a {2} reading the MimeMessage: {0}.
+SignedMailValidator.exceptionReadingMessage.details = SignedMailValidator: there was a {2} reading the MimeMessage: {0}.
+
+## exception messages
+
+# signer has not signed the mail message
+SignedMailValidator.wrongSigner.title = Signer has not signed the message
+SignedMailValidator.wrongSigner.text = The given signer did not sign the mail message.
+SignedMailValidator.wrongSigner.summary = The given signer did not sign the mail message.
+SignedMailValidator.wrongSigner.details = The given signer did not sign the mail message.
+
+## notifications messages
+
+# short signing key
+# {0} the key length as Integer
+SignedMailValidator.shortSigningKey.title = Careless short signing key
+SignedMailValidator.shortSigningKey.text = Warning: The signing key is only {0} bits long.
+SignedMailValidator.shortSigningKey.summary = Warning: The signing key is only {0} bits long.
+SignedMailValidator.shortSigningKey.details = Warning: The signing key is only {0} bits long.
+
+# signing certificate has very long validity period
+# {0} notBefore date
+# {1} notAfter date
+SignedMailValidator.longValidity.title = Very long validity period
+SignedMailValidator.longValidity.text = Warning: The signing certificate has a very long validity period: from {0,date} {0,time,full} until {1,date} {1,time,full}.
+SignedMailValidator.longValidity.summary = Warning: The signing certificate has a very long validity period: from {0,date} {0,time,full} until {1,date} {1,time,full}.
+SignedMailValidator.longValidity.details = Warning: The signing certificate has a very long validity period: from {0,date} {0,time,full} until {1,date} {1,time,full}.
+
+# signed receipt requested
+SignedMailValidator.signedReceiptRequest.title = Signed Receipt Request
+SignedMailValidator.signedReceiptRequest.text = The signature contains a signed receipt request.
+SignedMailValidator.signedReceiptRequest.summary = The signature contains a signed receipt request.
+SignedMailValidator.signedReceiptRequest.details = The signature contains a signed receipt request as per RFC 2634.
+
+## error messages
+
+# no signer certificate found
+SignedMailValidator.noSignerCert.title = No signer certificate found
+SignedMailValidator.noSignerCert.text = Signature Validation failed: No signer certificate found.
+SignedMailValidator.noSignerCert.summary = Signature Validation failed: No signer certificate found.
+SignedMailValidator.noSignerCert.details = Signature Validation failed: No signer certificate found.
+
+# certificate contains no email address
+SignedMailValidator.noEmailInCert.title = Certificate not usable for email signatures
+SignedMailValidator.noEmailInCert.text = The signer certificate is not usable for email signatures: it contains no email address.
+SignedMailValidator.noEmailInCert.summary = The signer certificate is not usable for email signatures: it contains no email address.
+SignedMailValidator.noEmailInCert.details = The signer certificate is not usable for email signatures: it contains no email address.
+
+# certificate email address does not match from email address
+# {0} from email addresses in the message 
+# {1} email addresses in the certificate
+SignedMailValidator.emailFromCertMismatch.title = Email address mismatch
+SignedMailValidator.emailFromCertMismatch.text = Email address in signer certificate does not match the sender address. Signer email: {1}. Sender email: {0}.
+SignedMailValidator.emailFromCertMismatch.summary = Email address in signer certificate does not match the sender address. Signer email: {1}. Sender email: {0}.
+SignedMailValidator.emailFromCertMismatch.details = Email address in signer certificate does not match the sender address. Signer email: {1}. Sender email: {0}.
+
+# exception extracting email addresses from certificate
+# {0} message of the underlying exception
+# {1} the underlying exception
+# {2} the name of the exception
+SignedMailValidator.certGetEmailError.title = Exception extracting email addresses from certificate
+SignedMailValidator.certGetEmailError.text = There was a {2} extracting the email addresses from the certificate. Cause: {0}.
+SignedMailValidator.certGetEmailError.summary = There was a {2} extracting the email addresses from the certificate.
+SignedMailValidator.certGetEmailError.details = There was a {2} extracting the email addresses from the certificate. Cause: {0}.
+
+# no signing time found
+SignedMailValidator.noSigningTime.title = No signing time
+SignedMailValidator.noSigningTime.text = The signature contains no signing time. Using the current time for validating the certificate path.
+SignedMailValidator.noSigningTime.summary = The signature contains no signing time.
+SignedMailValidator.noSigningTime.details = The signature contains no signing time. Using the current time for validating the certificate path.
+
+# expired at signing time
+# {0} signing time
+# {1} not after date
+SignedMailValidator.certExpired.title = Certificate expired at signing time
+SignedMailValidator.certExpired.text = The message was signed at {0,date} {0,time,full}. But the certificate expired at {1,date} {1,time,full}.
+SignedMailValidator.certExpired.summary = The message was signed at {0,date} {0,time,full}. But the certificate expired at {1,date} {1,time,full}.
+SignedMailValidator.certExpired.details = The message was signed at {0,date} {0,time,full}. But the certificate expired at {1,date} {1,time,full}.
+
+# not yet valid at signing time
+# {0} signing time
+# {1} notBefore date
+SignedMailValidator.certNotYetValid.title = Certificate not yet valid at signing time
+SignedMailValidator.certNotYetValid.text = The message was signed at {0,date} {0,time,full}. But the certificate is not valid before {1,date} {1,time,full}.
+SignedMailValidator.certNotYetValid.summary = The message was signed at {0,date} {0,time,full}. But the certificate is not valid before {1,date} {1,time,full}.
+SignedMailValidator.certNotYetValid.details = The message was signed at {0,date} {0,time,full}. But the certificate is not valid before {1,date} {1,time,full}.
+
+# exception retrieving the signer certificate
+# {0} message of the underlying exception
+# {1} the underlying exception
+# {2} the name of the exception
+SignedMailValidator.exceptionRetrievingSignerCert.title = Exception retrieving the signer certificate
+SignedMailValidator.exceptionRetrievingSignerCert.text = Signature Validation failed. There was a {2} retrieving the signer certificate: {0}. 
+SignedMailValidator.exceptionRetrievingSignerCert.summary = Signature Validation failed. There was a {2} retrieving the signer certificate.
+SignedMailValidator.exceptionRetrievingSignerCert.details = Signature Validation failed  There was a {2} retrieving the signer certificate: {0}.
+
+# exception verifying the signature
+# {0} message of the underlying exception
+# {1} the underlying exception 
+# {2} the name of the exception
+SignedMailValidator.exceptionVerifyingSignature.title = Signature not verified
+SignedMailValidator.exceptionVerifyingSignature.text = Signature not verified. There was a {2}. Cause: {0}.
+SignedMailValidator.exceptionVerifyingSignature.summary = Signature not verified. There was a {2}.
+SignedMailValidator.exceptionVerifyingSignature.details = Signature not verified. There was a {2}. Cause: {0}.
+
+# signature not verified
+SignedMailValidator.signatureNotVerified.title = Signature not verified
+SignedMailValidator.signatureNotVerified.text = Signature not verified. The public key of the signer does not correspond to the signature.
+SignedMailValidator.signatureNotVerified.summary = Signature not verified. The public key of the signer does not correspond to the signature.
+SignedMailValidator.signatureNotVerified.details = Signature not verified. The public key of the signer does not correspond to the signature.
+
+# certificate key usage does not permit digitalSignature or nonRepudiation
+SignedMailValidator.signingNotPermitted.title = Key not usable for email signatures
+SignedMailValidator.signingNotPermitted.text = The key usage extension of signer certificate does not permit using the key for email signatures.
+SignedMailValidator.signingNotPermitted.summary = The signer key is not usable for email signatures.
+SignedMailValidator.signingNotPermitted.details = The key usage extension of signer certificate does not permit using the key for email signatures.
+
+# certificate extended key usage does not permit emailProtection or anyExtendedKeyUsage
+SignedMailValidator.extKeyUsageNotPermitted.title = Key not usable for email signatures
+SignedMailValidator.extKeyUsageNotPermitted.text = The extended key usage extension of the signer certificate does not permit using the key for email signatures.
+SignedMailValidator.extKeyUsageNotPermitted.summary = The signer key is not usable for email signatures.
+SignedMailValidator.extKeyUsageNotPermitted.details = The extended key usage extension of the signer certificate does not permit using the key for email signatures.
+
+# exception processing the extended key usage extension
+# {0} message of the underlying exception
+# {1} the underlying exception
+# {2} the name of the exception
+SignedMailValidator.extKeyUsageError.title = Exception processing the extended key usage extension 
+SignedMailValidator.extKeyUsageError.text = There was a {2} processing the extended key usage extension. Cause: {0}.
+SignedMailValidator.extKeyUsageError.summary = There was a {2} processing the extended key usage extension.
+SignedMailValidator.extKeyUsageError.details = There was a {2} processing the extended key usage extension. Cause: {0}.
+
+# cannot create certificate path (exception)
+# {0} message of the underlying exception
+# {1} the underlying exception
+# {2} the name of the exception
+SignedMailValidator.exceptionCreateCertPath.title = Certificate path validation failed
+SignedMailValidator.exceptionCreateCertPath.text = Certificate path validation failed. There was a {2} creating the CertPath: {0}.
+SignedMailValidator.exceptionCreateCertPath.summary = Certificate path validation failed. There was a {2} creating the CertPath: {0}.
+SignedMailValidator.exceptionCreateCertPath.details = Certificate path validation failed. There was a {2} creating the CertPath: {0}.
+
+# certificate path is invalid
+SignedMailValidator.certPathInvalid.title = Certificate path invalid
+SignedMailValidator.certPathInvalid.text = The certificate path is invalid.
+SignedMailValidator.certPathInvalid.summary = The certificate path is invalid.
+SignedMailValidator.certPathInvalid.details = The certificate path is invalid.

--- a/jmail/src/main/resources/org/bouncycastle/mail/smime/validator/SignedMailValidatorMessages_de.properties
+++ b/jmail/src/main/resources/org/bouncycastle/mail/smime/validator/SignedMailValidatorMessages_de.properties
@@ -1,0 +1,172 @@
+## constructor exception messages
+
+# Signatur gültig
+SignedMailValidator.sigValid.title = Signatur gültig
+SignedMailValidator.sigValid.text = Signatur gültig
+SignedMailValidator.sigValid.summary = Signatur gültig
+SignedMailValidator.sigValid.details = Signatur gültig
+
+# Signatur ungültig
+SignedMailValidator.sigInvalid.title = Signatur ungültig
+SignedMailValidator.sigInvalid.text = Signatur ungültig
+SignedMailValidator.sigInvalid.summary = Signatur ungültig
+SignedMailValidator.sigInvalid.details = Signatur ungültig
+
+# message is not signed
+SignedMailValidator.noSignedMessage.title = Die Nachricht ist nicht signiert
+SignedMailValidator.noSignedMessage.text = SignedMailValidator: Die MimeMessage message ist nicht signiert.
+SignedMailValidator.noSignedMessage.summary = SignedMailValidator: Die MimeMessage message ist nicht signiert.
+SignedMailValidator.noSignedMessage.details = SignedMailValidator: Die MimeMessage message ist nicht signiert.
+
+# exception reading the Mime message
+# {0} message of the underlying exception
+# {1} the underlying exception
+# {2} the name of the exception
+SignedMailValidator.exceptionReadingMessage.title = Fehler beim lesen der MimeMessage
+SignedMailValidator.exceptionReadingMessage.text = SignedMailValidator: Es gab eine {2} beim lesen der MimeMessage: {0}.
+SignedMailValidator.exceptionReadingMessage.summary = SignedMailValidator: Es gab eine {2} beim lesen der MimeMessage.
+SignedMailValidator.exceptionReadingMessage.details = SignedMailValidator: Es gab eine {2} beim lesen der MimeMessage: {0}.
+
+## exception messages
+
+# signer has not signed the mail message
+SignedMailValidator.wrongSigner.title = Falscher Unterzeichner
+SignedMailValidator.wrongSigner.text = Die Email enhält keine Signatur vom gegebenen Unterzeichner.
+SignedMailValidator.wrongSigner.summary = Die Email enhält keine Signatur vom gegebenen Unterzeichner.
+SignedMailValidator.wrongSigner.details = Die Email enhält keine Signatur vom gegebenen Unterzeichner.
+
+## notifications messages
+
+# short signing key
+# {0} the key length as Integer
+SignedMailValidator.shortSigningKey.title = Fahrlässig kurzer Signaturschlüssel
+SignedMailValidator.shortSigningKey.text = Warnung: Der Signaturschlüssel ist nur {0} bit lang.
+SignedMailValidator.shortSigningKey.summary = Warnung: Der Signaturschlüssel ist nur {0} bit lang.
+SignedMailValidator.shortSigningKey.details = Warnung: Der Signaturschlüssel ist nur {0} bit lang.
+
+# signing certificate has very long validity period
+# {0} notBefore date
+# {1} notAfter date
+SignedMailValidator.longValidity.title = Sehr lange Gültigkeitsdauer
+SignedMailValidator.longValidity.text = Warnung: Das Signierzertifikat hat eine sehr lange Gültigkeitsdauer: von  {0,date} {0,time,full} bis {1,date} {1,time,full}.
+SignedMailValidator.longValidity.summary = Warnung: Das Signierzertifikat hat eine sehr lange Gültigkeitsdauer: von  {0,date} {0,time,full} bis {1,date} {1,time,full}.
+SignedMailValidator.longValidity.details = Warnung: Das Signierzertifikat hat eine sehr lange Gültigkeitsdauer: von  {0,date} {0,time,full} bis {1,date} {1,time,full}.
+
+# signed receipt requested
+SignedMailValidator.signedReceiptRequest.title = Signed Receipt Request
+SignedMailValidator.signedReceiptRequest.text = Die Signatur enthält einen signed receipt request.
+SignedMailValidator.signedReceiptRequest.summary = Die Signatur enthält einen signed receipt request.
+SignedMailValidator.signedReceiptRequest.details = Die Signatur enthält einen signed receipt request gemäss RFC 2634.
+
+## error messages
+
+# no signer certificate found
+SignedMailValidator.noSignerCert.title = Kein Unterzeichner Zertifikat gefunden
+SignedMailValidator.noSignerCert.text = Signatur Validierung fehlgeschlagen: Es wurde kein Unterzeichner Zertifikat gefunden.
+SignedMailValidator.noSignerCert.summary = Signatur Validierung fehlgeschlagen: Es wurde kein Unterzeichner Zertifikat gefunden.
+SignedMailValidator.noSignerCert.details = Signatur Validierung fehlgeschlagen: Es wurde kein Unterzeichner Zertifikat gefunden.
+
+# certificate contains no email address
+SignedMailValidator.noEmailInCert.title = Zertifikat nicht für Email Signaturen verwendbar
+SignedMailValidator.noEmailInCert.text = Das Unterzeichner Zertifikat kann nicht für Email Signaturen verwendet werden: Es enthält keine Email Addresse.
+SignedMailValidator.noEmailInCert.summary = Das Unterzeichner Zertifikat kann nicht für Email Signaturen verwendet werden: Es enthält keine Email Addresse.
+SignedMailValidator.noEmailInCert.details = Das Unterzeichner Zertifikat kann nicht für Email Signaturen verwendet werden: Es enthält keine Email Addresse.
+
+# certificate email address does not match from email address
+# {0} from email addresses in the message 
+# {1} email addresses in the certificate
+SignedMailValidator.emailFromCertMismatch.title = Email Addressen stimmen nicht überein
+SignedMailValidator.emailFromCertMismatch.text = Die Email Addresse im Unterzeichner Zertifikat stimmt nicht mit der Sender Addresse überein. Unterzeichner: {1}. Sender: {0}.
+SignedMailValidator.emailFromCertMismatch.summary = Die Email Addresse im Unterzeichner Zertifikat stimmt nicht mit der Sender Addresse überein. Unterzeichner: {1}. Sender: {0}.
+SignedMailValidator.emailFromCertMismatch.details = Die Email Addresse im Unterzeichner Zertifikat stimmt nicht mit der Sender Addresse überein. Unterzeichner: {1}. Sender: {0}.
+
+# exception extracting email addresses from certificate
+# {0} message of the underlying exception
+# {1} the underlying exception
+# {2} the name of the exception
+SignedMailValidator.certGetEmailError.title = Fehler bei extrahieren der Email Addresse vom Zertifikat
+SignedMailValidator.certGetEmailError.text = Es gab eine {2} beim Extrahieren der Email Addresse vom Zertifikat. Grund: {0}.
+SignedMailValidator.certGetEmailError.summary = Es gab eine {2} beim Extrahieren der Email Addresse vom Zertifikat.
+SignedMailValidator.certGetEmailError.details = Es gab eine {2} beim Extrahieren der Email Addresse vom Zertifikat. Grund: {0}.
+
+# no signing time found
+SignedMailValidator.noSigningTime.title = Keine Signierzeit
+SignedMailValidator.noSigningTime.text = Die Signatur enthält keine Signier Zeit. Benutze die aktuelle Zeit zur Zertifikationpfad Validierung.
+SignedMailValidator.noSigningTime.summary = Die Signatur enthält keine Signier Zeit.
+SignedMailValidator.noSigningTime.details = Die Signatur enthält keine Signier Zeit. Benutze die aktuelle Zeit zur Zertifikationpfad Validierung.
+
+# expired at signing time
+# {0} signing time
+# {1} not after date
+SignedMailValidator.certExpired.title = Zertifikat zur Signierzeit abgelaufen
+SignedMailValidator.certExpired.text = Die Nachricht wurde am {0,date} {0,time,full} signiert. Aber das Zertifikat ist am {1,date} {1,time,full} abgelaufen.
+SignedMailValidator.certExpired.summary = Die Nachricht wurde am {0,date} {0,time,full} signiert. Aber das Zertifikat ist am {1,date} {1,time,full} abgelaufen.
+SignedMailValidator.certExpired.details = Die Nachricht wurde am {0,date} {0,time,full} signiert. Aber das Zertifikat ist am {1,date} {1,time,full} abgelaufen.
+
+# not yet valid at signing time
+# {0} signing time
+# {1} notBefore date
+SignedMailValidator.certNotYetValid.title = Zertifikat noch nicht gültig zur Signierzeit
+SignedMailValidator.certNotYetValid.text = Die Nachricht wurde am {0,date} {0,time,full} signiert. Aber das Zertifikat ist erst gültig ab {1,date} {1,time,full}.
+SignedMailValidator.certNotYetValid.summary = Die Nachricht wurde am {0,date} {0,time,full} signiert. Aber das Zertifikat ist erst gültig ab {1,date} {1,time,full}.
+SignedMailValidator.certNotYetValid.details = Die Nachricht wurde am {0,date} {0,time,full} signiert. Aber das Zertifikat ist erst gültig ab {1,date} {1,time,full}.
+
+# exception retrieving the signer certificate
+# {0} message of the underlying exception
+# {1} the underlying exception
+# {2} the name of the exception
+SignedMailValidator.exceptionRetrievingSignerCert.title = Fehler beim Lesen des Signaturzertifikats
+SignedMailValidator.exceptionRetrievingSignerCert.text = Signatur Validierung fehlgeschlagen. Es gab eine {2} beim Lesen des Signaturzertifikats: {0}. 
+SignedMailValidator.exceptionRetrievingSignerCert.summary = Signatur Validierung fehlgeschlagen. Es gab eine {2} beim Lesen des Signaturzertifikats.
+SignedMailValidator.exceptionRetrievingSignerCert.details = Signatur Validierung fehlgeschlagen. Es gab eine {2} beim Lesen des Signaturzertifikats: {0}.
+
+# exception verifying the signature
+# {0} message of the underlying exception
+# {1} the underlying exception 
+# {2} the name of the exception
+SignedMailValidator.exceptionVerifyingSignature.title = Signatur nicht verifiziert
+SignedMailValidator.exceptionVerifyingSignature.text = Signatur nicht verifiziert. Es gab eine {2}. Grund: {0}.
+SignedMailValidator.exceptionVerifyingSignature.summary = Signatur nicht verifiziert. Es gab eine {2}.
+SignedMailValidator.exceptionVerifyingSignature.details = Signatur nicht verifiziert. Es gab eine {2}. Grund: {0}.
+
+# signature not verified
+SignedMailValidator.signatureNotVerified.title = Signatur nicht verifiziert
+SignedMailValidator.signatureNotVerified.text = Signatur nicht verifiziert. Der öffentliche Schlüssel des Unterzeichners passt nicht zur Signatur.
+SignedMailValidator.signatureNotVerified.summary = Signatur nicht verifiziert. Der öffentliche Schlüssel des Unterzeichners passt nicht zur Signatur.
+SignedMailValidator.signatureNotVerified.details = Signatur nicht verifiziert. Der öffentliche Schlüssel des Unterzeichners passt nicht zur Signatur.
+
+# certificate key usage does not permit digitalSignature or nonRepudiation
+SignedMailValidator.signingNotPermitted.title = Schlüssel nicht verwendbar für Email Signaturen
+SignedMailValidator.signingNotPermitted.text = Der Schlüssel des Unterzeichners darf nicht für Email Signaturen verwendet werden.
+SignedMailValidator.signingNotPermitted.summary = Der Schlüssel des Unterzeichners darf nicht für Email Signaturen verwendet werden.
+SignedMailValidator.signingNotPermitted.details = Die Schlüsselverwendung des Unterzeichner Zertifikats erlaubt keine Verwendung für Email Signaturen.
+
+# certificate extended key usage does not permit emailProtection or anyExtendedKeyUsage
+SignedMailValidator.extKeyUsageNotPermitted.title = Schlüssel nicht verwendbar für Email Signaturen
+SignedMailValidator.extKeyUsageNotPermitted.text = Der Schlüssel des Unterzeichners darf nicht für Email Signaturen verwendet werden.
+SignedMailValidator.extKeyUsageNotPermitted.summary = Der Schlüssel des Unterzeichners darf nicht für Email Signaturen verwendet werden.
+SignedMailValidator.extKeyUsageNotPermitted.details = Die erweiterte Schlüsselverwendung des Unterzeichner Zertifikats erlaubt keine Verwendung für Email Signaturen.
+
+# exception processing the extended key usage extension
+# {0} message of the underlying exception
+# {1} the underlying exception
+# {2} the name of the exception
+SignedMailValidator.extKeyUsageError.title = Fehler bei der Verarbeitung der Extended key usage Erweiterung 
+SignedMailValidator.extKeyUsageError.text = Es gab eine {2} bei der Verarbeitung der Extended key usage Erweiterung. Grund: {0}.
+SignedMailValidator.extKeyUsageError.summary = Es gab eine {2} bei der Verarbeitung der Extended key usage Erweiterung.
+SignedMailValidator.extKeyUsageError.details = Es gab eine {2} bei der Verarbeitung der Extended key usage Erweiterung. Grund: {0}.
+
+# cannot create certificate path (exception)
+# {0} message of the underlying exception
+# {1} the underlying exception
+# {2} the name of the exception
+SignedMailValidator.exceptionCreateCertPath.title = Zertifizierungspfad Validierung fehlgeschlagen
+SignedMailValidator.exceptionCreateCertPath.text = Die Zertifizierungspfad Validierung ist fehlgeschlagen. Es gab eine {2} beim erstellen des Zertifizierungspfad: {0}.
+SignedMailValidator.exceptionCreateCertPath.summary = Die Zertifizierungspfad Validierung ist fehlgeschlagen. Es gab eine {2} beim erstellen des Zertifizierungspfad: {0}.
+SignedMailValidator.exceptionCreateCertPath.details = Die Zertifizierungspfad Validierung ist fehlgeschlagen. Es gab eine {2} beim erstellen des Zertifizierungspfad: {0}.
+
+# certificate path is invalid
+SignedMailValidator.certPathInvalid.title = Zertifikats-Pfad ungültig
+SignedMailValidator.certPathInvalid.text = Der Zertifikats-Pfad ist ungültig.
+SignedMailValidator.certPathInvalid.summary = Der Zertifikats-Pfad ist ungültig.
+SignedMailValidator.certPathInvalid.details = Der Zertifikats-Pfad ist ungültig.


### PR DESCRIPTION
This is trivial change - `SignedMailValidatorMessages.properties` and `SignedMailValidatorMessages_de.properties` are present in mail, but missing in jmail. 