### PR TITLE
Fix PGPEncryptedData.isAEAD() and abort verify() for AEAD encrypted data

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedData.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedData.java
@@ -183,7 +183,18 @@ public abstract class PGPEncryptedData
      */
     public boolean isAEAD()
     {
-        return (encData instanceof AEADEncDataPacket);
+        if (encData instanceof AEADEncDataPacket)
+        {
+            return true;
+        }
+        if (encData instanceof SymmetricEncIntegrityPacket)
+        {
+            return ((SymmetricEncIntegrityPacket) encData).getVersion() == SymmetricEncIntegrityPacket.VERSION_2;
+        }
+        else
+        {
+            return false;
+        }
     }
 
     /**
@@ -211,6 +222,12 @@ public abstract class PGPEncryptedData
         while (encStream.read() >= 0)
         {
             // do nothing
+        }
+
+        if (isAEAD())
+        {
+            // AEAD data needs no manual verification, as decryption detects errors automatically
+            return true;
         }
 
         //


### PR DESCRIPTION
Calling `pgpEncData.verify()` on AEAD encrypted data was throwing an NPE, as the `PGPEncryptedData` class was trying to read the MDC value from `truncStream` which is null at this point.

I changed the code to return `true` for AEAD encrypted data, as the integrity verification is done while reading when finalizing the data stream.