### PR TITLE
PGPSignatureSubpacketVector: Add factory method to create instance from collection of SignatureSubpackets

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketVector.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketVector.java
@@ -2,6 +2,7 @@ package org.bouncycastle.openpgp;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -34,6 +35,34 @@ import org.bouncycastle.bcpg.sig.TrustSignature;
  */
 public class PGPSignatureSubpacketVector
 {
+
+    /**
+     * Create a new {@link PGPSignatureSubpacketVector} from the given {@link Collection} of
+     * {@link SignatureSubpacket} items.
+     * If the collection is <pre>null</pre>, return an empty {@link PGPSignatureSubpacketVector}.
+     *
+     * @param packets collection of items or null
+     * @return PGPSignatureSubpacketVector
+     */
+    public static PGPSignatureSubpacketVector fromSubpackets(Collection<SignatureSubpacket> packets)
+    {
+        if (packets == null)
+        {
+            return fromSubpackets((SignatureSubpacket[]) null);
+        }
+        else
+        {
+            return fromSubpackets(packets.toArray(new SignatureSubpacket[0]));
+        }
+    }
+
+    /**
+     * Create a new {@link PGPSignatureSubpacketVector} from the given {@link SignatureSubpacket[]}.
+     * If the array is <pre>null</pre>, return an empty {@link PGPSignatureSubpacketVector}.
+     *
+     * @param packets array of items or null
+     * @return PGPSignatureSubpacketVector
+     */
     public static PGPSignatureSubpacketVector fromSubpackets(SignatureSubpacket[] packets)
     {
         if (packets == null)

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPGeneralTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPGeneralTest.java
@@ -25,6 +25,7 @@ import org.bouncycastle.bcpg.HashAlgorithmTags;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.bouncycastle.bcpg.RSAPublicBCPGKey;
 import org.bouncycastle.bcpg.RSASecretBCPGKey;
+import org.bouncycastle.bcpg.SignatureSubpacket;
 import org.bouncycastle.bcpg.SignatureSubpacketTags;
 import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
 import org.bouncycastle.bcpg.attr.ImageAttribute;
@@ -2102,7 +2103,7 @@ public class PGPGeneralTest
         isTrue("isPrimaryUserID should be true", hashedPcks.isPrimaryUserID());
 
 
-        PGPSignatureSubpacketVector hashedPcks2 = PGPSignatureSubpacketVector.fromSubpackets(null);
+        PGPSignatureSubpacketVector hashedPcks2 = PGPSignatureSubpacketVector.fromSubpackets((SignatureSubpacket[]) null);
         isTrue("Empty PGPSignatureSubpacketVector", hashedPcks2.size() == 0);
 
         hashedGen = new PGPSignatureSubpacketGenerator();


### PR DESCRIPTION
When constructing a `PGPSignatureSubpacketVector`, e.g. during signature generation, it is inconvenient to work with `SignatureSubpacket[]`s. Instead, it is easier to work with `Collection`s, which can dynamically grow.

This PR adds a new factory method which takes in a `Collection` and forwards to the existing factory method, passing the collection as an array.