### PR TITLE
Document `OpenBSDBCrypt` password handling

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/generators/BCrypt.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/BCrypt.java
@@ -616,10 +616,10 @@ public final class BCrypt
 
     /**
      * Calculates the <b>bcrypt</b> hash of an input - note for processing general passwords you want to
-     * make sure the password is terminated in a manner similar to what is done by passwordToByteArray().
+     * make sure the password is terminated in a manner similar to what is done by {@link #passwordToByteArray(char[])}.
      * <p>
      * This implements the raw <b>bcrypt</b> function as defined in the bcrypt specification, not
-     * the crypt encoded version implemented in OpenBSD.
+     * the crypt encoded version implemented in OpenBSD, see {@link OpenBSDBCrypt} for that.
      * </p>
      * @param pwInput    the password bytes (up to 72 bytes) to use for this invocation.
      * @param salt     the 128 bit salt to use for this invocation.

--- a/core/src/main/java/org/bouncycastle/crypto/generators/OpenBSDBCrypt.java
+++ b/core/src/main/java/org/bouncycastle/crypto/generators/OpenBSDBCrypt.java
@@ -12,7 +12,10 @@ import org.bouncycastle.util.Strings;
  * Password hashing scheme BCrypt,
  * designed by Niels Provos and David Mazières, using the
  * String format and the Base64 encoding
- * of the reference implementation on OpenBSD
+ * of the reference implementation on OpenBSD.
+ * <p>
+ * Passwords are encoded using UTF-8. Encoded passwords longer than
+ * 72 bytes are truncated and all remaining bytes are ignored.
  */
 public class OpenBSDBCrypt
 {

--- a/core/src/main/jdk1.4/org/bouncycastle/crypto/generators/OpenBSDBCrypt.java
+++ b/core/src/main/jdk1.4/org/bouncycastle/crypto/generators/OpenBSDBCrypt.java
@@ -12,7 +12,10 @@ import org.bouncycastle.util.Strings;
  * Password hashing scheme BCrypt,
  * designed by Niels Provos and David Mazières, using the
  * String format and the Base64 encoding
- * of the reference implementation on OpenBSD
+ * of the reference implementation on OpenBSD.
+ * <p>
+ * Passwords are encoded using UTF-8. Encoded passwords longer than
+ * 72 bytes are truncated and all remaining bytes are ignored.
  */
 public class OpenBSDBCrypt
 {


### PR DESCRIPTION
Previously the behavior was not explicitly documented, and it might not have been obvious that passwords longer than 72 bytes will be truncated.