### PR TITLE
Introduce KeyIdentifier class

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/KeyIdentifier.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/KeyIdentifier.java
@@ -1,0 +1,323 @@
+package org.bouncycastle.openpgp;
+
+import org.bouncycastle.bcpg.FingerprintUtil;
+import org.bouncycastle.openpgp.operator.KeyFingerPrintCalculator;
+import org.bouncycastle.util.Arrays;
+
+import java.util.List;
+
+/**
+ * Utility class for matching key-ids / fingerprints.
+ * A {@link KeyIdentifier} can be created from either a 64-bit key-id, a fingerprint, or both.
+ * This class was created to enable a seamless transition from use of key-ids in the API
+ * towards identifying keys via fingerprints.
+ */
+public class KeyIdentifier
+{
+    private final byte[] fingerprint;
+    private final long keyId;
+
+    /**
+     * Create a new {@link KeyIdentifier} based on a keys fingerprint.
+     * For fingerprints matching the format of a v4, v5 or v6 key, the constructor will
+     * try to derive the corresponding key-id from the fingerprint.
+     *
+     * @param fingerprint fingerprint
+     */
+    public KeyIdentifier(byte[] fingerprint)
+    {
+        this.fingerprint = Arrays.clone(fingerprint);
+
+        // v4
+        if (fingerprint.length == 20)
+        {
+            keyId = FingerprintUtil.keyIdFromV4Fingerprint(fingerprint);
+        }
+        // v5, v6
+        else if (fingerprint.length == 32)
+        {
+            keyId = FingerprintUtil.keyIdFromV6Fingerprint(fingerprint);
+        }
+        else
+        {
+            keyId = 0L;
+        }
+    }
+
+    /**
+     * Create a {@link KeyIdentifier} based on the given fingerprint and key-id.
+     *
+     * @param fingerprint fingerprint
+     * @param keyId key-id
+     */
+    public KeyIdentifier(byte[] fingerprint, long keyId)
+    {
+        this.fingerprint = Arrays.clone(fingerprint);
+        this.keyId = keyId;
+    }
+
+    /**
+     * Create a {@link KeyIdentifier} based on the given key-id.
+     * {@code fingerprint} will be set to {@code null}.
+     *
+     * @param keyId key-id
+     */
+    public KeyIdentifier(long keyId)
+    {
+        this(null, keyId);
+    }
+
+    /**
+     * Create a {@link KeyIdentifier} for the given {@link PGPPublicKey}.
+     *
+     * @param key key
+     */
+    public KeyIdentifier(PGPPublicKey key)
+    {
+        this(key.getFingerprint(), key.getKeyID());
+    }
+
+    /**
+     * Create a {@link KeyIdentifier} for the given {@link PGPSecretKey}.
+     *
+     * @param key key
+     */
+    public KeyIdentifier(PGPSecretKey key)
+    {
+        this(key.getPublicKey());
+    }
+
+    /**
+     * Create a {@link KeyIdentifier} for the given {@link PGPPrivateKey}.
+     *
+     * @param key key
+     * @param fingerprintCalculator calculate the fingerprint
+     * @throws PGPException if an exception happens while calculating the fingerprint
+     */
+    public KeyIdentifier(PGPPrivateKey key, KeyFingerPrintCalculator fingerprintCalculator)
+            throws PGPException
+    {
+        this(new PGPPublicKey(key.getPublicKeyPacket(), fingerprintCalculator));
+    }
+
+    /**
+     * Create a wildcard {@link KeyIdentifier}.
+     */
+    private KeyIdentifier()
+    {
+        this(new byte[0], 0L);
+    }
+
+    /**
+     * Create a wildcard {@link KeyIdentifier}.
+     *
+     * @return wildcard key identifier
+     */
+    public static KeyIdentifier wildcard()
+    {
+        return new KeyIdentifier();
+    }
+
+
+
+    /**
+     * Return the fingerprint of the {@link KeyIdentifier}.
+     * {@code fingerprint} might be null, if the {@link KeyIdentifier} was created from just a key-id.
+     * If {@link #isWildcard()} returns true, this method returns an empty, but non-null array.
+     *
+     * @return fingerprint
+     */
+    public byte[] getFingerprint()
+    {
+        return fingerprint;
+    }
+
+    /**
+     * Return the key-id of the {@link KeyIdentifier}.
+     * This might be {@code 0L} if {@link #isWildcard()} returns true, or if an unknown
+     * fingerprint was passed in.
+     *
+     * @return key-id
+     */
+    public long getKeyId()
+    {
+        return keyId;
+    }
+
+    /**
+     * Return true, if this {@link KeyIdentifier} matches the given {@link PGPPublicKey}.
+     * This will return true if the fingerprint matches, or if the key-id matches,
+     * or if {@link #isWildcard()} returns true.
+     *
+     * @param key key
+     * @return if the identifier matches the key
+     */
+    public boolean matches(PGPPublicKey key)
+    {
+        return matches(key, true);
+    }
+
+    /**
+     * Return true, if this {@link KeyIdentifier} matches the given {@link PGPPublicKey}.
+     * This will return true if the fingerprint matches, or if the key-id matches,
+     * or - in case that {@code matchWildcard} is true - if {@link #isWildcard()} returns true.
+     *
+     * @param key key
+     * @param matchWildcard whether to match wildcards
+     * @return whether the identifier matches the key
+     */
+    public boolean matches(PGPPublicKey key, boolean matchWildcard)
+    {
+        if (matchWildcard && isWildcard())
+        {
+            return true;
+        }
+
+        if (fingerprint != null)
+        {
+            return Arrays.constantTimeAreEqual(fingerprint, key.getFingerprint());
+        }
+        else
+        {
+            return keyId == key.getKeyID();
+        }
+    }
+
+    /**
+     * Return true if this {@link KeyIdentifier} matches the given {@link PGPSecretKey}.
+     * This will return true if the fingerprint matches, or if the key-id matches,
+     * or if {@link #isWildcard()} returns true.
+     *
+     * @param key key
+     * @return whether the identifier matches the key
+     */
+    public boolean matches(PGPSecretKey key)
+    {
+        return matches(key.getPublicKey());
+    }
+
+    /**
+     * Return true, if this {@link KeyIdentifier} matches the given {@link PGPSecretKey}.
+     * This will return true if the fingerprint matches, or if the key-id matches,
+     * or - in case that {@code matchWildcard} is true - if {@link #isWildcard()} returns true.
+     *
+     * @param key key
+     * @param matchWildcard whether to match wildcards
+     * @return whether the identifier matches the key
+     */
+    public boolean matches(PGPSecretKey key, boolean matchWildcard)
+    {
+        return matches(key.getPublicKey(), matchWildcard);
+    }
+
+    /**
+     * Return true if this {@link KeyIdentifier} matches the given {@link PGPPrivateKey}.
+     * This will return true if the fingerprint matches, or if the key-id matches,
+     * or in case that {@link #isWildcard()} is true.
+     *
+     * @param key key
+     * @param fingerprintCalculator to calculate the fingerprint
+     * @return whether the identifier matches the key
+     * @throws PGPException if an exception happens while calculating the fingerprint
+     */
+    public boolean matches(PGPPrivateKey key,
+                           KeyFingerPrintCalculator fingerprintCalculator)
+            throws PGPException
+    {
+        return matches(new PGPPublicKey(key.getPublicKeyPacket(), fingerprintCalculator));
+    }
+
+    /**
+     * Return true if this {@link KeyIdentifier} matches the given {@link PGPPrivateKey}.
+     * This will return true if the fingerprint matches, or if the key-id matches,
+     * or - in case that {@code matchWildcard} is true - if {@link #isWildcard()} is true.
+     *
+     * @param key key
+     * @param fingerprintCalculator to calculate the fingerprint
+     * @return whether the identifier matches the key
+     * @throws PGPException if an exception happens while calculating the fingerprint
+     */
+    public boolean matches(PGPPrivateKey key,
+                           KeyFingerPrintCalculator fingerprintCalculator,
+                           boolean matchWildcard)
+            throws PGPException
+    {
+        return matches(new PGPPublicKey(key.getPublicKeyPacket(), fingerprintCalculator), matchWildcard);
+    }
+
+    /**
+     * Returns true, if the {@link KeyIdentifier} specifies a wildcard (matches anything).
+     * This is for example used with anonymous recipient key-ids / fingerprints, where the recipient
+     * needs to try all available keys to decrypt the message.
+     *
+     * @return is wildcard
+     */
+    public boolean isWildcard()
+    {
+        return keyId == 0L && fingerprint.length == 0;
+    }
+
+    /**
+     * Return true, if any of the {@link KeyIdentifier KeyIdentifiers} in the {@code identifiers} list
+     * matches the given {@link PGPPublicKey}.
+     *
+     * @param identifiers list of identifiers
+     * @param key key
+     * @return true if any matches, false if none matches
+     */
+    public static boolean matches(List<KeyIdentifier> identifiers, PGPPublicKey key)
+    {
+        for (KeyIdentifier identifier : identifiers)
+        {
+            if (identifier.matches(key))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return true, if any of the {@link KeyIdentifier KeyIdentifiers} in the {@code identifiers} list
+     * matches the given {@link PGPSecretKey}.
+     *
+     * @param identifiers list of identifiers
+     * @param key key
+     * @return true if any matches, false if none matches
+     */
+    public static boolean matches(List<KeyIdentifier> identifiers, PGPSecretKey key)
+    {
+        for (KeyIdentifier identifier : identifiers)
+        {
+            if (identifier.matches(key))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return true, if any of the {@link KeyIdentifier KeyIdentifiers} in the {@code identifiers} list
+     * matches the given {@link PGPPrivateKey}.
+     *
+     * @param identifiers list of identifiers
+     * @param key key
+     * @param fingerprintCalculator to calculate the fingerprint
+     * @return true if any matches, false if none matches
+     */
+    public static boolean matches(List<KeyIdentifier> identifiers,
+                                  PGPPrivateKey key,
+                                  KeyFingerPrintCalculator fingerprintCalculator)
+            throws PGPException
+    {
+        for (KeyIdentifier identifier : identifiers)
+        {
+            if (identifier.matches(key, fingerprintCalculator))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyPair.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyPair.java
@@ -41,6 +41,16 @@ public class PGPKeyPair
     {
         return pub.getKeyID();
     }
+
+    /**
+     * Return the {@link KeyIdentifier} associated with the public key.
+     *
+     * @return key identifier
+     */
+    public KeyIdentifier getKeyIdentifier()
+    {
+        return new KeyIdentifier(getPublicKey());
+    }
     
     public PGPPublicKey getPublicKey()
     {

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPOnePassSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPOnePassSignature.java
@@ -120,6 +120,16 @@ public class PGPOnePassSignature
     }
 
     /**
+     * Return a {@link KeyIdentifier} identifying this {@link PGPOnePassSignature}.
+     *
+     * @return key identifier
+     */
+    public KeyIdentifier getKeyIdentifier()
+    {
+        return new KeyIdentifier(getFingerprint(), getKeyID());
+    }
+
+    /**
      * Return the salt used in the corresponding signature.
      * Only for {@link OnePassSignaturePacket#VERSION_6} packets.
      * @return salt

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -396,6 +396,16 @@ public class PGPPublicKey
     }
 
     /**
+     * Return a {@link KeyIdentifier} identifying this key.
+     *
+     * @return key identifier
+     */
+    public KeyIdentifier getKeyIdentifier()
+    {
+        return new KeyIdentifier(this);
+    }
+
+    /**
      * Return the fingerprint of the public key.
      *
      * @return key fingerprint.

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKeyEncryptedData.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKeyEncryptedData.java
@@ -52,10 +52,22 @@ public class PGPPublicKeyEncryptedData
      * Return the keyID for the key used to encrypt the data.
      *
      * @return long
+     * @deprecated use {@link #getKeyIdentifier()} instead
      */
+    @Deprecated
     public long getKeyID()
     {
         return keyData.getKeyID();
+    }
+
+    /**
+     * Return a {@link KeyIdentifier} for the key used to encrypt the data.
+     *
+     * @return key identifier
+     */
+    public KeyIdentifier getKeyIdentifier()
+    {
+        return new KeyIdentifier(keyData.getKeyFingerprint(), keyData.getKeyID());
     }
 
     /**

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -450,6 +450,16 @@ public class PGPSecretKey
     }
 
     /**
+     * Return a {@link KeyIdentifier} for this key.
+     *
+     * @return identifier
+     */
+    public KeyIdentifier getKeyIdentifier()
+    {
+        return new KeyIdentifier(this);
+    }
+
+    /**
      * Return the fingerprint of the public key associated with this key.
      *
      * @return key fingerprint.

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -18,6 +18,8 @@ import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.bouncycastle.bcpg.SignaturePacket;
 import org.bouncycastle.bcpg.SignatureSubpacket;
 import org.bouncycastle.bcpg.TrustPacket;
+import org.bouncycastle.bcpg.sig.IssuerFingerprint;
+import org.bouncycastle.bcpg.sig.IssuerKeyID;
 import org.bouncycastle.math.ec.rfc8032.Ed25519;
 import org.bouncycastle.math.ec.rfc8032.Ed448;
 import org.bouncycastle.openpgp.operator.PGPContentVerifier;
@@ -386,12 +388,75 @@ public class PGPSignature
 
     /**
      * Return the id of the key that created the signature.
+     * Note: Since signatures of version 4 or later encode the issuer information inside a
+     * signature subpacket ({@link IssuerKeyID} or {@link IssuerFingerprint}), there is not
+     * a single source of truth for the key-id.
+     * To match any suitable issuer keys, use {@link #getKeyIdentifiers()} instead.
      *
      * @return keyID of the signatures corresponding key.
      */
     public long getKeyID()
     {
         return sigPck.getKeyID();
+    }
+
+    /**
+     * Create a list of {@link KeyIdentifier} objects, for all {@link IssuerFingerprint}
+     * and {@link IssuerKeyID} signature subpackets found in either the hashed or unhashed areas
+     * of the signature.
+     *
+     * @return all detectable {@link KeyIdentifier KeyIdentifiers}
+     */
+    public List<KeyIdentifier> getKeyIdentifiers()
+    {
+        List<KeyIdentifier> identifiers = new ArrayList<>();
+        identifiers.addAll(getHashedKeyIdentifiers());
+        identifiers.addAll(getUnhashedKeyIdentifiers());
+        return identifiers;
+    }
+
+    /**
+     * Return a list of all {@link KeyIdentifier KeyIdentifiers} that could be derived from
+     * any {@link IssuerFingerprint} or {@link IssuerKeyID} subpackets of the hashed signature
+     * subpacket area.
+     *
+     * @return hashed key identifiers
+     */
+    public List<KeyIdentifier> getHashedKeyIdentifiers()
+    {
+        return extractKeyIdentifiers(sigPck.getHashedSubPackets());
+    }
+
+    /**
+     * Return a list of all {@link KeyIdentifier KeyIdentifiers} that could be derived from
+     * any {@link IssuerFingerprint} or {@link IssuerKeyID} subpackets of the unhashed signature
+     * subpacket area.
+     *
+     * @return unhashed key identifiers
+     */
+    public List<KeyIdentifier> getUnhashedKeyIdentifiers()
+    {
+        return extractKeyIdentifiers(sigPck.getUnhashedSubPackets());
+    }
+
+    private List<KeyIdentifier> extractKeyIdentifiers(SignatureSubpacket[] subpackets)
+    {
+        List<KeyIdentifier> identifiers = new ArrayList<>();
+        for (SignatureSubpacket s : subpackets)
+        {
+            if (s instanceof IssuerFingerprint)
+            {
+                IssuerFingerprint issuer = (IssuerFingerprint) s;
+                identifiers.add(new KeyIdentifier(issuer.getFingerprint()));
+            }
+
+            if (s instanceof IssuerKeyID)
+            {
+                IssuerKeyID issuer = (IssuerKeyID) s;
+                identifiers.add(new KeyIdentifier(issuer.getKeyID()));
+            }
+        }
+        return identifiers;
     }
 
     /**


### PR DESCRIPTION
For historic reasons, many places in the OpenPGP API and specification rely on 64-bit key-ids.
However, later versions of the standard migrate to use fingerprints (20 or 32 bytes) to reduce the risk of attacks based on the birthday paradox (key-id collisions).

In this PR I introduce the `KeyIdentifier` class, which can be created from both a key-id or a fingerprint, and which shall be used as a common stand-in for either key-id or fingerprints.
This enables a smooth transition from using key-ids to using fingerprints.

TODO:
* [ ] Implement tests
* [ ] integrate `KeyIdentifier` into existing API to transition away from pure key-ID uses