### PR TITLE
Use the proper method to update a signature with salt

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -195,10 +195,18 @@ public class PGPSignature
     }
 
     private void updateWithSalt()
+            throws PGPException
     {
         if (getVersion() == SignaturePacket.VERSION_6)
         {
-            update(sigPck.getSalt());
+            try
+            {
+                sigOut.write(sigPck.getSalt());
+            }
+            catch (IOException e)
+            {
+                throw new PGPException("Could not update with salt.", e);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1780

Using `update(salt)` instead of `sigOut.write(salt)` caused some preprocessing on the salt value in some cases (Cleartext Signature Framework line endings), which resulted in broken signature verification.