### PR TITLE
Deprecate RevocationKey signature subpacket.

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/RevocationKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/RevocationKey.java
@@ -5,6 +5,9 @@ import org.bouncycastle.bcpg.SignatureSubpacketTags;
 
 /**
  * Represents revocation key OpenPGP signature sub packet.
+ * Note: This packet is deprecated. Applications MUST NOT generate such a packet.
+ *
+ * @deprecated since RFC9580
  */
 public class RevocationKey extends SignatureSubpacket
 {

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketGenerator.java
@@ -368,8 +368,8 @@ public class PGPSignatureSubpacketGenerator
      *
      * @param isCritical   true if should be treated as critical, false otherwise.
      * @param keyAlgorithm algorithm of the revocation key
-     * @param fingerprint  fingerprint of the revocation key
-     * @deprecated use {@link #addRevocationKey(boolean, int, byte[])} instead.
+     * @param fingerprint  fingerprint of the revocation key (v4 only)
+     * @deprecated the revocation key mechanism is deprecated. Applications MUST NOT generate such a packet.
      */
     public void setRevocationKey(boolean isCritical, int keyAlgorithm, byte[] fingerprint)
     {
@@ -381,7 +381,8 @@ public class PGPSignatureSubpacketGenerator
      *
      * @param isCritical   true if should be treated as critical, false otherwise.
      * @param keyAlgorithm algorithm of the revocation key
-     * @param fingerprint  fingerprint of the revocation key
+     * @param fingerprint  fingerprint of the revocation key (v4 only)
+     * @deprecated the revocation key mechanism is deprecated. Applications MUST NOT generate such a packet.
      */
     public void addRevocationKey(boolean isCritical, int keyAlgorithm, byte[] fingerprint)
     {


### PR DESCRIPTION
RFC9580 §5.2.3.23 states that applications MUST NOT generate such a packet.