### PR TITLE
open GMSignatureSpi constructor to subclass

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/GMSignatureSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/ec/GMSignatureSpi.java
@@ -29,7 +29,7 @@ public class GMSignatureSpi
 
     private final SM2Signer signer;
 
-    GMSignatureSpi(SM2Signer signer)
+    protected GMSignatureSpi(SM2Signer signer)
     {
         this.signer = signer;
     }

--- a/prov/src/main/jdk1.1/org/bouncycastle/jcajce/provider/asymmetric/ec/GMSignatureSpi.java
+++ b/prov/src/main/jdk1.1/org/bouncycastle/jcajce/provider/asymmetric/ec/GMSignatureSpi.java
@@ -31,7 +31,7 @@ public class GMSignatureSpi
 
     private SM2Signer signer;
 
-    GMSignatureSpi(SM2Signer signer)
+    protected GMSignatureSpi(SM2Signer signer)
     {
         super("SM3withSM2");
         this.signer = signer;


### PR DESCRIPTION
I want to create a `GMSignatureSpi` subclass with customized `SM2Signer`. But `GMSignatureSpi`'s constrcutor is not opened to subclass. Please accept this to open it.