### PR TITLE
Fix parsing of LibrePGP key-id

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -70,6 +70,10 @@ public class PGPPublicKey
         {
             this.keyID = Pack.bigEndianToLong(fingerprint, fingerprint.length - 8);
         }
+        else if (publicPk.getVersion() == PublicKeyPacket.LIBREPGP_5)
+        {
+            this.keyID = Pack.bigEndianToLong(fingerprint, 0);
+        }
         else if (publicPk.getVersion() == PublicKeyPacket.VERSION_6)
         {
             this.keyID = Pack.bigEndianToLong(fingerprint, 0);

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -18,6 +18,7 @@ import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.bcpg.DSAPublicBCPGKey;
 import org.bouncycastle.bcpg.ECPublicBCPGKey;
 import org.bouncycastle.bcpg.ElGamalPublicBCPGKey;
+import org.bouncycastle.bcpg.FingerprintUtil;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.bouncycastle.bcpg.PublicKeyPacket;
 import org.bouncycastle.bcpg.PublicSubkeyPacket;
@@ -29,7 +30,6 @@ import org.bouncycastle.bcpg.UserDataPacket;
 import org.bouncycastle.bcpg.UserIDPacket;
 import org.bouncycastle.openpgp.operator.KeyFingerPrintCalculator;
 import org.bouncycastle.util.Arrays;
-import org.bouncycastle.util.Pack;
 
 /**
  * general class to handle a PGP public key object.
@@ -68,15 +68,15 @@ public class PGPPublicKey
         }
         else if (publicPk.getVersion() == PublicKeyPacket.VERSION_4)
         {
-            this.keyID = Pack.bigEndianToLong(fingerprint, fingerprint.length - 8);
+            this.keyID = FingerprintUtil.keyIdFromV4Fingerprint(fingerprint);
         }
         else if (publicPk.getVersion() == PublicKeyPacket.LIBREPGP_5)
         {
-            this.keyID = Pack.bigEndianToLong(fingerprint, 0);
+            this.keyID = FingerprintUtil.keyIdFromLibrePgpFingerprint(fingerprint);
         }
         else if (publicPk.getVersion() == PublicKeyPacket.VERSION_6)
         {
-            this.keyID = Pack.bigEndianToLong(fingerprint, 0);
+            this.keyID = FingerprintUtil.keyIdFromV6Fingerprint(fingerprint);
         }
 
         // key strength

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPv5KeyTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPv5KeyTest.java
@@ -90,6 +90,10 @@ public class PGPv5KeyTest
         isEncodingEqual("Fingerprint mismatch for the subkey.",
             Hex.decode("E4557C2B02FFBF4B04F87401EC336AF7133D0F85BE7FD09BAEFD9CAEB8C93965"), it.next().getFingerprint());
 
+        it = secretKeys.getPublicKeys();
+        isEquals( "Primary key ID mismatch", 1816212655223104514L, it.next().getKeyID());
+        isEquals("Subkey ID mismatch", -1993550735865823413L, it.next().getKeyID());
+
         bOut = new ByteArrayOutputStream();
         BCPGOutputStream pOut = new BCPGOutputStream(bOut, PacketFormat.LEGACY);
         secretKeys.encode(pOut);


### PR DESCRIPTION
Hey!
When rewriting the public key parser logic, I accidentally missed parsing out the key-id of LibrePGP (v5) keys.
This patch fixes this slip-up and adds a test.