### PR TITLE
Fix LibrePGP SKESK5 + OCBED1 decryption

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/SymmetricKeyEncSessionPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SymmetricKeyEncSessionPacket.java
@@ -19,6 +19,7 @@ public class SymmetricKeyEncSessionPacket
 
     /**
      * Version 5 SKESK packet.
+     * LibrePGP only.
      * Used only with {@link AEADEncDataPacket AED} packets.
      */
     public static final int VERSION_5 = 5;
@@ -61,7 +62,32 @@ public class SymmetricKeyEncSessionPacket
 
             this.secKeyData = in.readAll();
         }
-        else if (version == VERSION_5 || version == VERSION_6)
+        else if (version == VERSION_5)
+        {
+            encAlgorithm = in.read();
+            aeadAlgorithm = in.read();
+
+            s2k = new S2K(in);
+
+            int ivLen = AEADUtils.getIVLength(aeadAlgorithm);
+            iv = new byte[ivLen]; // also called nonce
+            if (in.read(iv) != iv.length)
+            {
+                throw new EOFException("Premature end of stream.");
+            }
+
+            int authTagLen = AEADUtils.getAuthTagLength(aeadAlgorithm);
+            authTag = new byte[authTagLen];
+
+            // Read all trailing bytes
+            byte[] sessKeyAndAuthTag = in.readAll();
+            // determine session key length by subtracting auth tag
+            this.secKeyData = new byte[sessKeyAndAuthTag.length - authTagLen];
+
+            System.arraycopy(sessKeyAndAuthTag, 0, secKeyData, 0, secKeyData.length);
+            System.arraycopy(sessKeyAndAuthTag, secKeyData.length, authTag, 0, authTagLen);
+        }
+        else if (version == VERSION_6)
         {
             // https://www.ietf.org/archive/id/draft-ietf-openpgp-crypto-refresh-07.html#section-5.3.2-3.2
             // SymAlg + AEADAlg + S2KCount + S2K + IV
@@ -108,7 +134,6 @@ public class SymmetricKeyEncSessionPacket
         {
             throw new UnsupportedPacketVersionException("Unsupported PGP symmetric-key encrypted session key packet version encountered: " + version);
         }
-
     }
 
     /**

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPv5MessageDecryptionTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPv5MessageDecryptionTest.java
@@ -1,0 +1,97 @@
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.bcpg.test.AbstractPacketTest;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.PGPEncryptedDataList;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPLiteralData;
+import org.bouncycastle.openpgp.PGPObjectFactory;
+import org.bouncycastle.openpgp.PGPPBEEncryptedData;
+import org.bouncycastle.openpgp.bc.BcPGPObjectFactory;
+import org.bouncycastle.openpgp.jcajce.JcaPGPObjectFactory;
+import org.bouncycastle.openpgp.operator.bc.BcPBEDataDecryptorFactory;
+import org.bouncycastle.openpgp.operator.bc.BcPGPDigestCalculatorProvider;
+import org.bouncycastle.openpgp.operator.jcajce.JcePBEDataDecryptorFactoryBuilder;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.encoders.Hex;
+import org.bouncycastle.util.io.Streams;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class PGPv5MessageDecryptionTest
+        extends AbstractPacketTest
+{
+
+    // https://www.ietf.org/archive/id/draft-koch-librepgp-01.html#name-sample-ocb-encryption-and-d
+    private static final byte[] MSG0_SKESK5 = Hex.decode("c33d05070203089f0b7da3e5ea647790" +
+            "99e326e5400a90936cefb4e8eba08c67" +
+            "73716d1f2714540a38fcac529949dac5" +
+            "29d3de31e15b4aeb729e330033dbed");
+    private static final byte[] MSG0_OCBED = Hex.decode("d4490107020e5ed2bc1e470abe8f1d64" +
+            "4c7a6c8a567b0f7701196611a154ba9c" +
+            "2574cd056284a8ef68035c623d93cc70" +
+            "8a43211bb6eaf2b27f7c18d571bcd83b" +
+            "20add3a08b73af15b9a098");
+
+    @Override
+    public String getName()
+    {
+        return "PGPv5MessageDecryptionTest";
+    }
+
+    @Override
+    public void performTest()
+            throws Exception
+    {
+        decryptSKESK5OCBED1_bc();
+        decryptSKESK5OCBED1_jce();
+    }
+
+    private void decryptSKESK5OCBED1_bc()
+            throws IOException, PGPException
+    {
+        String passphrase = "password";
+
+        ByteArrayInputStream bIn = new ByteArrayInputStream(Arrays.concatenate(MSG0_SKESK5, MSG0_OCBED));
+        BCPGInputStream pIn = new BCPGInputStream(bIn);
+        PGPObjectFactory objFac = new BcPGPObjectFactory(pIn);
+        PGPEncryptedDataList encList = (PGPEncryptedDataList) objFac.nextObject();
+        PGPPBEEncryptedData encData = (PGPPBEEncryptedData) encList.get(0);
+        InputStream decIn = encData.getDataStream(
+                new BcPBEDataDecryptorFactory(passphrase.toCharArray(),
+                        new BcPGPDigestCalculatorProvider()));
+        objFac = new BcPGPObjectFactory(decIn);
+        PGPLiteralData lit = (PGPLiteralData) objFac.nextObject();
+        byte[] plaintext = Streams.readAll(lit.getDataStream());
+        isEncodingEqual("Plaintext mismatch", plaintext, "Hello, world!\n".getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void decryptSKESK5OCBED1_jce()
+            throws IOException, PGPException
+    {
+        // https://www.ietf.org/archive/id/draft-koch-librepgp-01.html#name-sample-ocb-encryption-and-d
+        String passphrase = "password";
+        ByteArrayInputStream bIn = new ByteArrayInputStream(Arrays.concatenate(MSG0_SKESK5, MSG0_OCBED));
+        BCPGInputStream pIn = new BCPGInputStream(bIn);
+        PGPObjectFactory objFac = new JcaPGPObjectFactory(pIn);
+        PGPEncryptedDataList encList = (PGPEncryptedDataList) objFac.nextObject();
+        PGPPBEEncryptedData encData = (PGPPBEEncryptedData) encList.get(0);
+        InputStream decIn = encData.getDataStream(
+                new JcePBEDataDecryptorFactoryBuilder()
+                        .setProvider(new BouncyCastleProvider())
+                        .build(passphrase.toCharArray()));
+        objFac = new JcaPGPObjectFactory(decIn);
+        PGPLiteralData lit = (PGPLiteralData) objFac.nextObject();
+        byte[] plaintext = Streams.readAll(lit.getDataStream());
+        isEncodingEqual("Plaintext mismatch", plaintext, "Hello, world!\n".getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new PGPv5MessageDecryptionTest());
+    }
+}


### PR DESCRIPTION
While playing with some test vectors from the LibrePGP document, I noticed that decryption of message encrypted using a v5 SKESK (`SymmetricKeyEncSessionPacket`) + OCBED (`AEADEncDataPacket`) packets would fail decrypting.

It turns out that LibrePGP omits the additional HKDF key derivation step introduced by OpenPGP v6.
This PR adds the test vectors from the LibrePGP document and fixes decryption.