### PR TITLE
Improve test coverage of PGP (v6) keys

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.cryptlib.CryptlibObjectIdentifiers;
+import org.bouncycastle.asn1.edec.EdECObjectIdentifiers;
 import org.bouncycastle.asn1.gnu.GNUObjectIdentifiers;
 import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParametersHolder;
@@ -17,7 +18,9 @@ import org.bouncycastle.bcpg.BCPGKey;
 import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.bcpg.DSAPublicBCPGKey;
 import org.bouncycastle.bcpg.ECPublicBCPGKey;
+import org.bouncycastle.bcpg.Ed448PublicBCPGKey;
 import org.bouncycastle.bcpg.ElGamalPublicBCPGKey;
+import org.bouncycastle.bcpg.OctetArrayBCPGKey;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.bouncycastle.bcpg.PublicKeyPacket;
 import org.bouncycastle.bcpg.PublicSubkeyPacket;
@@ -27,6 +30,7 @@ import org.bouncycastle.bcpg.TrustPacket;
 import org.bouncycastle.bcpg.UserAttributePacket;
 import org.bouncycastle.bcpg.UserDataPacket;
 import org.bouncycastle.bcpg.UserIDPacket;
+import org.bouncycastle.bcpg.X448PublicBCPGKey;
 import org.bouncycastle.openpgp.operator.KeyFingerPrintCalculator;
 import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.Pack;
@@ -98,6 +102,14 @@ public class PGPPublicKey
                 {
                     this.keyStrength = 256;
                 }
+                else if (curveOID.equals(EdECObjectIdentifiers.id_X448))
+                {
+                    this.keyStrength = X448PublicBCPGKey.LENGTH * 8;
+                }
+                else if (curveOID.equals(EdECObjectIdentifiers.id_Ed448))
+                {
+                    this.keyStrength = Ed448PublicBCPGKey.LENGTH * 8;
+                }
                 else
                 {
                     X9ECParametersHolder ecParameters = ECNamedCurveTable.getByOIDLazy(curveOID);
@@ -111,6 +123,10 @@ public class PGPPublicKey
                         this.keyStrength = -1; // unknown
                     }
                 }
+            }
+            else if (key instanceof OctetArrayBCPGKey)
+            {
+                this.keyStrength = key.getEncoded().length * 8;
             }
         }
     }

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/AbstractPgpKeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/AbstractPgpKeyPairTest.java
@@ -10,11 +10,29 @@ import org.bouncycastle.openpgp.operator.jcajce.JcaPGPKeyConverter;
 import org.bouncycastle.openpgp.operator.jcajce.JcaPGPKeyPair;
 
 import java.security.KeyPair;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 public abstract class AbstractPgpKeyPairTest
         extends AbstractPacketTest
 {
+
+    public static Date parseUTCTimestamp(String timestamp)
+    {
+        // Not thread safe, so we use a local variable
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        try
+        {
+            return dateFormat.parse(timestamp);
+        }
+        catch (ParseException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
 
     public Date currentTimeRounded()
     {

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/DedicatedEd25519KeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/DedicatedEd25519KeyPairTest.java
@@ -42,6 +42,18 @@ public class DedicatedEd25519KeyPairTest
         testV4SigningVerificationWithBcKey();
 
         testConversionOfTestVectorKey();
+        testBitStrength();
+    }
+
+    private void testBitStrength()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, PGPException
+    {
+        Date date = currentTimeRounded();
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("EDDSA", new BouncyCastleProvider());
+        gen.initialize(new EdDSAParameterSpec("Ed25519"));
+        KeyPair kp = gen.generateKeyPair();
+        JcaPGPKeyPair k = new JcaPGPKeyPair(PublicKeyPacket.VERSION_6, PublicKeyAlgorithmTags.Ed25519, kp, date);
+        isEquals("Ed25519 key size mismatch", 256, k.getPublicKey().getBitStrength());
     }
 
     private void testConversionOfJcaKeyPair()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/DedicatedEd448KeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/DedicatedEd448KeyPairTest.java
@@ -45,6 +45,19 @@ public class DedicatedEd448KeyPairTest
         testConversionOfBcKeyPair();
         testV4SigningVerificationWithJcaKey();
         testV4SigningVerificationWithBcKey();
+
+        testBitStrength();
+    }
+
+    private void testBitStrength()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, PGPException
+    {
+        Date date = currentTimeRounded();
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("EDDSA", new BouncyCastleProvider());
+        gen.initialize(new EdDSAParameterSpec("Ed448"));
+        KeyPair kp = gen.generateKeyPair();
+        JcaPGPKeyPair k = new JcaPGPKeyPair(PublicKeyPacket.VERSION_6, PublicKeyAlgorithmTags.Ed448, kp, date);
+        isEquals("Ed448 key size mismatch", 456, k.getPublicKey().getBitStrength());
     }
 
     private void testConversionOfJcaKeyPair()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/DedicatedX25519KeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/DedicatedX25519KeyPairTest.java
@@ -49,6 +49,19 @@ public class DedicatedX25519KeyPairTest
         testConversionOfBcKeyPair();
         testV4MessageEncryptionDecryptionWithJcaKey();
         testV4MessageEncryptionDecryptionWithBcKey();
+
+        testBitStrength();
+    }
+
+    private void testBitStrength()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, PGPException
+    {
+        Date date = currentTimeRounded();
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("XDH", new BouncyCastleProvider());
+        gen.initialize(new XDHParameterSpec("X25519"));
+        KeyPair kp = gen.generateKeyPair();
+        JcaPGPKeyPair k = new JcaPGPKeyPair(PublicKeyPacket.VERSION_6, PublicKeyAlgorithmTags.X25519, kp, date);
+        isEquals("X25519 key size mismatch", 256, k.getPublicKey().getBitStrength());
     }
 
     private void testConversionOfJcaKeyPair()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/DedicatedX448KeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/DedicatedX448KeyPairTest.java
@@ -8,6 +8,7 @@ import org.bouncycastle.bcpg.PublicKeyPacket;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.generators.X448KeyPairGenerator;
 import org.bouncycastle.crypto.params.X448KeyGenerationParameters;
+import org.bouncycastle.jcajce.spec.EdDSAParameterSpec;
 import org.bouncycastle.jcajce.spec.XDHParameterSpec;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openpgp.*;
@@ -49,6 +50,19 @@ public class DedicatedX448KeyPairTest
         testConversionOfBcKeyPair();
         testV4MessageEncryptionDecryptionWithJcaKey();
         testV4MessageEncryptionDecryptionWithBcKey();
+
+        testBitStrength();
+    }
+
+    private void testBitStrength()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, PGPException
+    {
+        Date date = currentTimeRounded();
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("XDH", new BouncyCastleProvider());
+        gen.initialize(new XDHParameterSpec("X448"));
+        KeyPair kp = gen.generateKeyPair();
+        JcaPGPKeyPair k = new JcaPGPKeyPair(PublicKeyPacket.VERSION_6, PublicKeyAlgorithmTags.X448, kp, date);
+        isEquals("X448 key size mismatch", 448, k.getPublicKey().getBitStrength());
     }
 
     private void testConversionOfJcaKeyPair()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/LegacyEd25519KeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/LegacyEd25519KeyPairTest.java
@@ -4,6 +4,7 @@ import org.bouncycastle.bcpg.EdDSAPublicBCPGKey;
 import org.bouncycastle.bcpg.EdSecretBCPGKey;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
+import org.bouncycastle.bcpg.PublicKeyPacket;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator;
 import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters;
@@ -44,6 +45,19 @@ public class LegacyEd25519KeyPairTest
         testConversionOfBcKeyPair();
         testV4SigningVerificationWithJcaKey();
         testV4SigningVerificationWithBcKey();
+
+        testBitStrength();
+    }
+
+    private void testBitStrength()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, PGPException
+    {
+        Date date = currentTimeRounded();
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("EDDSA", new BouncyCastleProvider());
+        gen.initialize(new EdDSAParameterSpec("Ed25519"));
+        KeyPair kp = gen.generateKeyPair();
+        JcaPGPKeyPair k = new JcaPGPKeyPair(PublicKeyPacket.VERSION_6, PublicKeyAlgorithmTags.EDDSA_LEGACY, kp, date);
+        isEquals("Ed25519 key size mismatch", 256, k.getPublicKey().getBitStrength());
     }
 
     private void testV4SigningVerificationWithJcaKey()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/LegacyEd448KeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/LegacyEd448KeyPairTest.java
@@ -12,6 +12,7 @@ import org.bouncycastle.bcpg.EdDSAPublicBCPGKey;
 import org.bouncycastle.bcpg.EdSecretBCPGKey;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
+import org.bouncycastle.bcpg.PublicKeyPacket;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.generators.Ed448KeyPairGenerator;
 import org.bouncycastle.crypto.params.Ed448KeyGenerationParameters;
@@ -48,6 +49,19 @@ public class LegacyEd448KeyPairTest
         testConversionOfBcKeyPair();
         testV4SigningVerificationWithJcaKey();
         testV4SigningVerificationWithBcKey();
+
+        testBitStrength();
+    }
+
+    private void testBitStrength()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, PGPException
+    {
+        Date date = currentTimeRounded();
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("EDDSA", new BouncyCastleProvider());
+        gen.initialize(new EdDSAParameterSpec("Ed448"));
+        KeyPair kp = gen.generateKeyPair();
+        JcaPGPKeyPair k = new JcaPGPKeyPair(PublicKeyPacket.VERSION_6, PublicKeyAlgorithmTags.EDDSA_LEGACY, kp, date);
+        isEquals("Ed448 key size mismatch", 456, k.getPublicKey().getBitStrength());
     }
 
     private void testV4SigningVerificationWithJcaKey()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/LegacyX25519KeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/LegacyX25519KeyPairTest.java
@@ -3,6 +3,7 @@ package org.bouncycastle.openpgp.test;
 import org.bouncycastle.bcpg.ECDHPublicBCPGKey;
 import org.bouncycastle.bcpg.ECSecretBCPGKey;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
+import org.bouncycastle.bcpg.PublicKeyPacket;
 import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.generators.X25519KeyPairGenerator;
@@ -48,6 +49,19 @@ public class LegacyX25519KeyPairTest
         testConversionOfBcKeyPair();
         testV4MessageEncryptionDecryptionWithJcaKey();
         testV4MessageEncryptionDecryptionWithBcKey();
+
+        testBitStrength();
+    }
+
+    private void testBitStrength()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, PGPException
+    {
+        Date date = currentTimeRounded();
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("XDH", new BouncyCastleProvider());
+        gen.initialize(new XDHParameterSpec("X25519"));
+        KeyPair kp = gen.generateKeyPair();
+        JcaPGPKeyPair k = new JcaPGPKeyPair(PublicKeyPacket.VERSION_6, PublicKeyAlgorithmTags.ECDH, kp, date);
+        isEquals("X25519 key size mismatch", 256, k.getPublicKey().getBitStrength());
     }
 
     private void testConversionOfJcaKeyPair()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/LegacyX448KeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/LegacyX448KeyPairTest.java
@@ -29,6 +29,19 @@ public class LegacyX448KeyPairTest
     {
         testConversionOfJcaKeyPair();
         testConversionOfBcKeyPair();
+
+        testBitStrength();
+    }
+
+    private void testBitStrength()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, PGPException
+    {
+        Date date = currentTimeRounded();
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("XDH", new BouncyCastleProvider());
+        gen.initialize(new XDHParameterSpec("X448"));
+        KeyPair kp = gen.generateKeyPair();
+        JcaPGPKeyPair k = new JcaPGPKeyPair(PublicKeyPacket.VERSION_6, PublicKeyAlgorithmTags.ECDH, kp, date);
+        isEquals("X448 key size mismatch", 448, k.getPublicKey().getBitStrength());
     }
 
     private void testConversionOfJcaKeyPair()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/PGPv6KeyTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/PGPv6KeyTest.java
@@ -1,22 +1,31 @@
 package org.bouncycastle.openpgp.test;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import java.util.Iterator;
 
+import org.bouncycastle.bcpg.AEADAlgorithmTags;
 import org.bouncycastle.bcpg.ArmoredInputStream;
 import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
+import org.bouncycastle.bcpg.PublicKeyPacket;
+import org.bouncycastle.bcpg.SecretKeyPacket;
+import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.bouncycastle.openpgp.PGPSecretKey;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
 import org.bouncycastle.openpgp.operator.KeyFingerPrintCalculator;
 import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
-import org.bouncycastle.util.Arrays;
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator;
 import org.bouncycastle.util.encoders.Hex;
-import org.bouncycastle.util.test.SimpleTest;
 
 public class PGPv6KeyTest
-    extends SimpleTest
+    extends AbstractPgpKeyPairTest
 {
 
     private static final String ARMORED_CERT = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
@@ -45,9 +54,31 @@ public class PGPv6KeyTest
         "M0g12vYxoWM8Y81W+bHBw805I8kWVkXU6vFOi+HWvv/ira7ofJu16NnoUkhclkUr\n" +
         "k0mXubZvyl4GBg==\n" +
         "-----END PGP PRIVATE KEY BLOCK-----";
+    // https://www.rfc-editor.org/rfc/rfc9580.html#name-sample-locked-version-6-sec
+    private static final String ARMORED_PROTECTED_KEY = "-----BEGIN PGP PRIVATE KEY BLOCK-----\n" +
+            "\n" +
+            "xYIGY4d/4xsAAAAg+U2nu0jWCmHlZ3BqZYfQMxmZu52JGggkLq2EVD34laP9JgkC\n" +
+            "FARdb9ccngltHraRe25uHuyuAQQVtKipJ0+r5jL4dacGWSAheCWPpITYiyfyIOPS\n" +
+            "3gIDyg8f7strd1OB4+LZsUhcIjOMpVHgmiY/IutJkulneoBYwrEGHxsKAAAAQgWC\n" +
+            "Y4d/4wMLCQcFFQoOCAwCFgACmwMCHgkiIQbLGGxPBgmml+TVLfpscisMHx4nwYpW\n" +
+            "cI9lJewnutmsyQUnCQIHAgAAAACtKCAQPi19In7A5tfORHHbNr/JcIMlNpAnFJin\n" +
+            "7wV2wH+q4UWFs7kDsBJ+xP2i8CMEWi7Ha8tPlXGpZR4UruETeh1mhELIj5UeM8T/\n" +
+            "0z+5oX1RHu11j8bZzFDLX9eTsgOdWATHggZjh3/jGQAAACCGkySDZ/nlAV25Ivj0\n" +
+            "gJXdp4SYfy1ZhbEvutFsr15ENf0mCQIUBA5hhGgp2oaavg6mFUXcFMwBBBUuE8qf\n" +
+            "9Ock+xwusd+GAglBr5LVyr/lup3xxQvHXFSjjA2haXfoN6xUGRdDEHI6+uevKjVR\n" +
+            "v5oAxgu7eJpaXNjCmwYYGwoAAAAsBYJjh3/jApsMIiEGyxhsTwYJppfk1S36bHIr\n" +
+            "DB8eJ8GKVnCPZSXsJ7rZrMkAAAAABAEgpukYbZ1ZNfyP5WMUzbUnSGpaUSD5t2Ki\n" +
+            "Nacp8DkBClZRa2c3AMQzSDXa9jGhYzxjzVb5scHDzTkjyRZWRdTq8U6L4da+/+Kt\n" +
+            "ruh8m7Xo2ehSSFyWRSuTSZe5tm/KXgYG\n" +
+            "-----END PGP PRIVATE KEY BLOCK-----";
+    private static final Date CREATION_TIME = parseUTCTimestamp("2022-11-30 16:08:03 UTC");
+
     private static final byte[] PRIMARY_FINGERPRINT = Hex.decode("CB186C4F0609A697E4D52DFA6C722B0C1F1E27C18A56708F6525EC27BAD9ACC9");
     private static final byte[] SUBKEY_FINGERPRINT = Hex.decode("12C83F1E706F6308FE151A417743A1F033790E93E9978488D1DB378DA9930885");
+    private static final long PRIMARY_KEYID = -3812177997909612905L;
+    private static final long SUBKEY_KEYID = 1353401087992750856L;
 
+    private static final KeyFingerPrintCalculator fingerPrintCalculator = new BcKeyFingerprintCalculator();
 
     @Override
     public String getName()
@@ -59,7 +90,15 @@ public class PGPv6KeyTest
     public void performTest()
         throws Exception
     {
-        KeyFingerPrintCalculator fingerPrintCalculator = new BcKeyFingerprintCalculator();
+        parseUnprotectedCertTest();
+        parseUnprotectedKeyTest();
+        testJcaFingerprintCalculation();
+        parseProtectedKeyTest();
+    }
+
+    private void parseUnprotectedCertTest()
+            throws IOException
+    {
         ByteArrayInputStream bIn = new ByteArrayInputStream(ARMORED_CERT.getBytes());
         ArmoredInputStream armorIn = new ArmoredInputStream(bIn);
         BCPGInputStream bcIn = new BCPGInputStream(armorIn);
@@ -68,22 +107,112 @@ public class PGPv6KeyTest
 
         Iterator<PGPPublicKey> pIt = publicKeys.getPublicKeys();
         PGPPublicKey key = (PGPPublicKey)pIt.next();
-        isTrue(key.hasFingerprint(PRIMARY_FINGERPRINT));
-        key = (PGPPublicKey)pIt.next();
-        isTrue(key.hasFingerprint(SUBKEY_FINGERPRINT));
+        isTrue("Primary key fingerprint mismatch", key.hasFingerprint(PRIMARY_FINGERPRINT));
+        isEquals("Primary key-ID mismatch", PRIMARY_KEYID, key.getKeyID());
+        isEquals("Primary key version mismatch", PublicKeyPacket.VERSION_6, key.getVersion());
+        isEquals("Primary key creation time mismatch", CREATION_TIME, key.getCreationTime());
+        isEquals("Primary key bit-strength mismatch", 256, key.getBitStrength());
 
-        bIn = new ByteArrayInputStream(ARMORED_KEY.getBytes());
-        armorIn = new ArmoredInputStream(bIn);
-        bcIn = new BCPGInputStream(armorIn);
+        key = (PGPPublicKey)pIt.next();
+        isTrue("Subkey fingerprint mismatch", key.hasFingerprint(SUBKEY_FINGERPRINT));
+        isEquals("Subkey key-ID mismatch", SUBKEY_KEYID, key.getKeyID());
+        isEquals("Subkey version mismatch", PublicKeyPacket.VERSION_6, key.getVersion());
+        isEquals("Subkey creation time mismatch", CREATION_TIME, key.getCreationTime());
+        isEquals("Subkey bit-strength mismatch", 256, key.getBitStrength());
+
+        isFalse("Unexpected key object in key ring", pIt.hasNext());
+    }
+
+    private void parseUnprotectedKeyTest()
+            throws IOException, PGPException
+    {
+        ByteArrayInputStream bIn = new ByteArrayInputStream(ARMORED_KEY.getBytes());
+        ArmoredInputStream armorIn = new ArmoredInputStream(bIn);
+        BCPGInputStream bcIn = new BCPGInputStream(armorIn);
 
         PGPSecretKeyRing secretKeys = new PGPSecretKeyRing(bcIn, fingerPrintCalculator);
 
         Iterator<PGPSecretKey> sIt = secretKeys.getSecretKeys();
-        PGPSecretKey sKey = (PGPSecretKey)sIt.next();
-        isTrue(Arrays.areEqual(PRIMARY_FINGERPRINT, sKey.getFingerprint()));
+        PGPSecretKey key = (PGPSecretKey)sIt.next();
+        isEncodingEqual("Primary key fingerprint mismatch", PRIMARY_FINGERPRINT, key.getFingerprint());
+        isEquals("Primary key-ID mismatch", PRIMARY_KEYID, key.getKeyID());
+        isEquals("Primary key version mismatch", PublicKeyPacket.VERSION_6, key.getPublicKey().getVersion());
+        isEquals("Primary key creation time mismatch", CREATION_TIME, key.getPublicKey().getCreationTime());
+        isEquals("Primary key S2K-usage mismatch", SecretKeyPacket.USAGE_NONE, key.getS2KUsage());
+        isNull("Primary key S2K MUST be null", key.getS2K());
 
-        sKey = (PGPSecretKey)sIt.next();
-        isTrue(Arrays.areEqual(SUBKEY_FINGERPRINT, sKey.getFingerprint()));
+        key = (PGPSecretKey)sIt.next();
+        isEncodingEqual("Subkey fingerprint mismatch", SUBKEY_FINGERPRINT, key.getFingerprint());
+        isEquals("Subkey key-ID mismatch", SUBKEY_KEYID, key.getKeyID());
+        isEquals("Subkey version mismatch", PublicKeyPacket.VERSION_6, key.getPublicKey().getVersion());
+        isEquals("Subkey creation time mismatch", CREATION_TIME, key.getPublicKey().getCreationTime());
+        isEquals("Subkey S2K-usage mismatch", SecretKeyPacket.USAGE_NONE, key.getS2KUsage());
+        isNull("Subkey S2K MUST be null", key.getS2K());
+
+        isFalse("Unexpected key object in key ring", sIt.hasNext());
+    }
+
+    private void testJcaFingerprintCalculation()
+            throws IOException
+    {
+        ByteArrayInputStream bIn = new ByteArrayInputStream(ARMORED_CERT.getBytes());
+        ArmoredInputStream armorIn = new ArmoredInputStream(bIn);
+        BCPGInputStream bcIn = new BCPGInputStream(armorIn);
+
+        JcaKeyFingerprintCalculator fpCalc =  new JcaKeyFingerprintCalculator();
+        fpCalc.setProvider(new BouncyCastleProvider());
+        PGPPublicKeyRing publicKeys = new PGPPublicKeyRing(bcIn, fpCalc);
+
+        Iterator<PGPPublicKey> pIt = publicKeys.getPublicKeys();
+        PGPPublicKey key = (PGPPublicKey)pIt.next();
+        isTrue("Primary key fingerprint mismatch", key.hasFingerprint(PRIMARY_FINGERPRINT));
+        isEquals("Primary key-ID mismatch", PRIMARY_KEYID, key.getKeyID());
+        key = (PGPPublicKey)pIt.next();
+        isTrue("Subkey fingerprint mismatch", key.hasFingerprint(SUBKEY_FINGERPRINT));
+        isEquals("Subkey key-ID mismatch", SUBKEY_KEYID, key.getKeyID());
+    }
+
+    private void parseProtectedKeyTest()
+            throws IOException, PGPException
+    {
+        ByteArrayInputStream bIn = new ByteArrayInputStream(ARMORED_PROTECTED_KEY.getBytes(StandardCharsets.UTF_8));
+        ArmoredInputStream aIn = new ArmoredInputStream(bIn);
+        BCPGInputStream pIn = new BCPGInputStream(aIn);
+
+        PGPSecretKeyRing secretKeys = new PGPSecretKeyRing(pIn, fingerPrintCalculator);
+        Iterator<PGPSecretKey> sIt = secretKeys.getSecretKeys();
+
+        PGPSecretKey key = sIt.next();
+        isEncodingEqual("Primary key fingerprint mismatch", PRIMARY_FINGERPRINT, key.getFingerprint());
+        isEquals("Primary key ID mismatch", PRIMARY_KEYID, key.getKeyID());
+        isEquals("Primary key algorithm mismatch",
+                PublicKeyAlgorithmTags.Ed25519, key.getPublicKey().getAlgorithm());
+        isEquals("Primary key version mismatch", PublicKeyPacket.VERSION_6, key.getPublicKey().getVersion());
+        isEquals("Primary key creation time mismatch", CREATION_TIME, key.getPublicKey().getCreationTime());
+        isEquals("Primary key S2K-Usage mismatch", SecretKeyPacket.USAGE_AEAD, key.getS2KUsage());
+        isEquals("Primary key AEAD algorithm mismatch",
+                AEADAlgorithmTags.OCB, key.getAEADKeyEncryptionAlgorithm());
+        isEquals("Primary key protection algorithm mismatch",
+                SymmetricKeyAlgorithmTags.AES_256, key.getKeyEncryptionAlgorithm());
+        isEncodingEqual("Primary key S2K salt mismatch",
+                Hex.decode("5d6fd71c9e096d1eb6917b6e6e1eecae"), key.getS2K().getIV());
+
+        key = sIt.next();
+        isEncodingEqual("Subkey fingerprint mismatch", SUBKEY_FINGERPRINT, key.getFingerprint());
+        isEquals("Subkey ID mismatch", SUBKEY_KEYID, key.getKeyID());
+        isEquals("Subkey algorithm mismatch",
+                PublicKeyAlgorithmTags.X25519, key.getPublicKey().getAlgorithm());
+        isEquals("Subkey version mismatch", PublicKeyPacket.VERSION_6, key.getPublicKey().getVersion());
+        isEquals("Subkey creation time mismatch", CREATION_TIME, key.getPublicKey().getCreationTime());
+        isEquals("Subkey S2K-Usage mismatch", SecretKeyPacket.USAGE_AEAD, key.getS2KUsage());
+        isEquals("Subkey AEAD algorithm mismatch",
+                AEADAlgorithmTags.OCB, key.getAEADKeyEncryptionAlgorithm());
+        isEquals("Subkey protection algorithm mismatch",
+                SymmetricKeyAlgorithmTags.AES_256, key.getKeyEncryptionAlgorithm());
+        isEncodingEqual("Subkey S2K salt mismatch",
+                Hex.decode("0e61846829da869abe0ea61545dc14cc"), key.getS2K().getIV());
+
+        isFalse("Unexpected key in key ring", sIt.hasNext());
     }
 
     public static void main(String[] args)

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
@@ -81,6 +81,7 @@ public class RegressionTest
         new Curve25519PrivateKeyEncodingTest(),
         new EdDSAKeyConversionWithLeadingZeroTest(),
         new ECDSAKeyPairTest(),
+        new UnknownBCPGKeyPairTest(),
 
         new PGPv5KeyTest(),
         new PGPv5MessageDecryptionTest(),

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/UnknownBCPGKeyPairTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/UnknownBCPGKeyPairTest.java
@@ -1,0 +1,45 @@
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.PublicKeyPacket;
+import org.bouncycastle.bcpg.PublicSubkeyPacket;
+import org.bouncycastle.bcpg.UnknownBCPGKey;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
+import org.bouncycastle.util.encoders.Hex;
+
+public class UnknownBCPGKeyPairTest
+        extends AbstractPgpKeyPairTest
+{
+    @Override
+    public String getName()
+    {
+        return "UnknownBCPGKeyPairTest";
+    }
+
+    @Override
+    public void performTest()
+            throws Exception
+    {
+        testGetBitStrength();
+    }
+
+    private void testGetBitStrength()
+            throws PGPException
+    {
+        byte[] raw = Hex.decode("decaffc0ffeebabe"); // 8 octets = 64-bit key size
+        UnknownBCPGKey key = new UnknownBCPGKey(raw.length, raw);
+        PublicKeyPacket packet = new PublicSubkeyPacket(
+                PublicKeyPacket.VERSION_6,
+                99, // unknown algorithm ID
+                currentTimeRounded(),
+                key);
+        PGPPublicKey pgpKey = new PGPPublicKey(packet, new BcKeyFingerprintCalculator());
+        isEquals("Unknown key getBitStrength() mismatch", 64, pgpKey.getBitStrength());
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new UnknownBCPGKeyPairTest());
+    }
+}


### PR DESCRIPTION
This PR changes the `PGPv6KeyTest` to more extensively cover parsing of different fields, like key-id, creation time, s2k etc.

Testing also showed, that `getBitStrength()` returned `0` for (dedicated X25519), X448, Ed25519, Ed448 keys.
It also returned `0` for unknown keys.

This PR fixes these issues by properly parsing the bit strength (as in key-size, not security-level).