### PR TITLE
Fix unpacking time (unsigned int) from octets for large values

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
@@ -134,7 +134,7 @@ public class PublicKeyPacket
             throw new UnsupportedPacketVersionException("Unsupported Public Key Packet version encountered: " + version);
         }
 
-        time = StreamUtil.read4OctetLength(in);
+        time = StreamUtil.readSeconds(in);
 
         if (version == 2 || version == VERSION_3)
         {
@@ -324,7 +324,7 @@ public class PublicKeyPacket
 
         pOut.write(version);
 
-        StreamUtil.writeTime(pOut, time);
+        StreamUtil.writeSeconds(pOut, time);
 
         if (version <= VERSION_3)
         {

--- a/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
@@ -26,7 +26,7 @@ public class SignaturePacket
 
     private int                    version;
     private int                    signatureType;
-    private long                   creationTime;
+    private long                   creationTime; // millis
     private long                   keyID;
     private int                    keyAlgorithm;
     private int                    hashAlgorithm;
@@ -647,10 +647,8 @@ public class SignaturePacket
         {
             pOut.write(5); // the length of the next block
 
-            long    time = creationTime / 1000;
-
             pOut.write(signatureType);
-            StreamUtil.writeTime(pOut, time);
+            StreamUtil.writeTime(pOut, creationTime);
 
             StreamUtil.writeKeyID(pOut, keyID);
 

--- a/pg/src/main/java/org/bouncycastle/bcpg/StreamUtil.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/StreamUtil.java
@@ -111,13 +111,26 @@ class StreamUtil
     static void writeTime(BCPGOutputStream pOut, long time)
         throws IOException
     {
-        StreamUtil.write4OctetLength(pOut, (int)time);
+        StreamUtil.writeSeconds(pOut, time / 1000);
     }
 
     static long readTime(BCPGInputStream in)
         throws IOException
     {
-        return (long)read4OctetLength(in) * 1000L;
+        long s = readSeconds(in);
+        return s * 1000L;
+    }
+
+    static void writeSeconds(BCPGOutputStream pOut, long time)
+        throws IOException
+    {
+        StreamUtil.write4OctetLength(pOut, (int)time);
+    }
+
+    static long readSeconds(BCPGInputStream in)
+        throws IOException
+    {
+        return ((long)read4OctetLength(in)) & 0xFFFFFFFFL;
     }
 
     static void write2OctetLength(OutputStream pOut, int len)

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/Utils.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/Utils.java
@@ -57,7 +57,7 @@ class Utils
             throw new IllegalStateException("Byte array has unexpected length. Expected length 4, got " + bytes.length);
         }
 
-        return Pack.bigEndianToInt(bytes, 0);
+        return Pack.bigEndianToInt(bytes, 0) & 0xFFFFFFFFL; // time is unsigned
     }
 
     static byte[] timeToBytes(long t)

--- a/pg/src/test/java/org/bouncycastle/bcpg/test/AllTests.java
+++ b/pg/src/test/java/org/bouncycastle/bcpg/test/AllTests.java
@@ -24,7 +24,8 @@ public class AllTests
                         new OnePassSignaturePacketTest(),
                         new OpenPgpMessageTest(),
                         new FingerprintUtilTest(),
-                        new EncryptedMessagePacketTest()
+                        new EncryptedMessagePacketTest(),
+                        new TimeEncodingTest()
                 };
 
         for (int i = 0; i != tests.length; i++)

--- a/pg/src/test/java/org/bouncycastle/bcpg/test/TimeEncodingTest.java
+++ b/pg/src/test/java/org/bouncycastle/bcpg/test/TimeEncodingTest.java
@@ -1,0 +1,70 @@
+package org.bouncycastle.bcpg.test;
+
+import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.bcpg.BCPGOutputStream;
+import org.bouncycastle.bcpg.PacketFormat;
+import org.bouncycastle.bcpg.PublicKeyPacket;
+import org.bouncycastle.bcpg.UnknownBCPGKey;
+import org.bouncycastle.bcpg.sig.KeyExpirationTime;
+import org.bouncycastle.util.test.SimpleTest;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Date;
+
+public class TimeEncodingTest
+        extends SimpleTest
+{
+    @Override
+    public String getName()
+    {
+        return "UtilsTest";
+    }
+
+    @Override
+    public void performTest()
+            throws Exception
+    {
+        testRoundtrippingLargeUnsignedInt();
+        testKeyWithLargeCreationTime();
+    }
+
+    private void testRoundtrippingLargeUnsignedInt()
+    {
+        // Integer.MAX_VALUE < large < 0xffffffff
+        long large = 2523592696L; // fits a 32-bit *unsigned* int, but overflows signed int
+        // KeyExpirationTime packs the time into 4 octets
+        KeyExpirationTime kexp = new KeyExpirationTime(false, large);
+        // getTime() parses the time from 4 octets
+        isEquals("Roundtripped unsigned int mismatches before packet parser pass", large, kexp.getTime());
+
+        // To be safe, do an additional packet encode/decode roundtrip
+        KeyExpirationTime pKexp = new KeyExpirationTime(kexp.isCritical(), kexp.isLongLength(), kexp.getData());
+        isEquals("Roundtripped unsigned int mismatches after packet parser pass", large, pKexp.getTime());
+    }
+
+    private void testKeyWithLargeCreationTime()
+            throws IOException
+    {
+        long maxSeconds = 0xFFFFFFFEL; // Fits 32 unsigned int, but not signed int
+        Date maxPGPDate = new Date(maxSeconds * 1000);
+        UnknownBCPGKey k = new UnknownBCPGKey(1, new byte[]{1}); // dummy
+        PublicKeyPacket p = new PublicKeyPacket(PublicKeyPacket.VERSION_6, 99, maxPGPDate, k);
+        isEquals("Key creation time mismatches before encoding", maxPGPDate, p.getTime());
+
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        BCPGOutputStream pOut = new BCPGOutputStream(bOut, PacketFormat.CURRENT);
+        p.encode(pOut);
+        pOut.close();
+        ByteArrayInputStream bIn = new ByteArrayInputStream(bOut.toByteArray());
+        BCPGInputStream pIn = new BCPGInputStream(bIn);
+        PublicKeyPacket parsed = (PublicKeyPacket) pIn.readPacket();
+        isEquals("Key creation time mismatches after encoding", maxPGPDate, parsed.getTime());
+    }
+
+    public static void main(String[] args)
+    {
+        runTest(new TimeEncodingTest());
+    }
+}


### PR DESCRIPTION
Time, as well as offsets (e.g. expiration) in OpenPGP are stored as seconds in unsigned Integers.

I noticed, that https://github.com/bcgit/bc-java/commit/8385a2ca13573435a64d6bd96769c97e2e9edee8 broke some tests in PGPainless that dealt with large expiration time intervals.

Turns out, the changed code accidentally converted the values to signed ints, which break for large (but legal) intervals.

The patch converts back to an unsigned value.