### PR TITLE
Ellipitic Curve implementation of JPAKE (Password-Authenticated Key Exchange by Juggling)

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKECurve.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKECurve.java
@@ -1,0 +1,161 @@
+package org.bouncycastle.crypto.agreement.ecjpake;
+
+import java.math.BigInteger;
+import org.bouncycastle.math.ec.ECPoint;
+import org.bouncycastle.math.ec.ECCurve;
+
+/**
+ * A pre-computed elliptic curve over a prime field, in short-Weierstrass form for use during an EC J-PAKE exchange.
+ * <p>
+ * In general, J-PAKE can use any elliptic curve or prime order group 
+ * that is suitable for public key cryptography.
+ * <p>
+ * See {@link ECJPAKECurves} for convenient standard curves.
+ * <p>
+ * NIST <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-186.pdf">publishes</a>
+ * many curves with different forms and levels of security.
+ */
+public class ECJPAKECurve
+{
+    private final ECCurve.Fp curve;
+	private final BigInteger a;
+	private final BigInteger b;
+	private final BigInteger q;
+	private final BigInteger h;
+	private final BigInteger n;
+	private final ECPoint g;
+
+    /**
+     * Constructs a new {@link ECJPAKECurve}.
+     * <p>
+     * In general, you should use one of the pre-approved curves from
+     * {@link ECJPAKECurves}, rather than manually constructing one.
+     * <p>
+     * The following basic checks are performed:
+     * <ul>
+     * <li>q must be prime</li>
+     * <li>n must be prime</li>
+     * <li>The curve must not be singular i.e. the discriminant is equal to 0 mod q</li>
+     * <li>G must lie on the curve</li>
+     * <li>n*h must equal the order of the curve</li>
+     * <li>a must be in [0, q-1]</li>
+     * <li>b must be in [0, q-1]</li>
+     * </ul>
+     * <p>
+     * The prime checks are performed using {@link BigInteger#isProbablePrime(int)},
+     * and are therefore subject to the same probability guarantees.
+     * <p>
+     * These checks prevent trivial mistakes.
+     * However, due to the small uncertainties if p and q are not prime,
+     * advanced attacks are not prevented.
+     * Use it at your own risk.
+     *
+     * @throws NullPointerException if any argument is null
+     * @throws IllegalArgumentException if any of the above validations fail
+     */
+    public ECJPAKECurve(BigInteger a, BigInteger b, BigInteger q, BigInteger h, BigInteger n, ECPoint g, ECCurve.Fp curve)
+    {
+        /**
+         * Don't skip the checks on user-specified groups.
+         */
+        this(a, b, q, h, n, g, curve, false);
+    }
+
+    /**
+     * Internal package-private constructor used by the pre-approved
+     * groups in {@link ECJPAKECurves}.
+     * These pre-approved curves can avoid the expensive checks.
+     */
+    ECJPAKECurve(BigInteger a, BigInteger b, BigInteger q, BigInteger h, BigInteger n, ECPoint g, ECCurve.Fp curve, boolean skipChecks)
+    {
+        ECJPAKEUtil.validateNotNull(a, "a");
+        ECJPAKEUtil.validateNotNull(b, "b");
+        ECJPAKEUtil.validateNotNull(q, "q");
+        ECJPAKEUtil.validateNotNull(h, "h");
+        ECJPAKEUtil.validateNotNull(n, "n");
+        ECJPAKEUtil.validateNotNull(g, "g");
+        ECJPAKEUtil.validateNotNull(curve, "curve");
+
+        if (!skipChecks)
+        {
+
+            /*
+             * Note that these checks do not guarantee that n and q are prime.
+             * We just have reasonable certainty that they are prime.
+             */
+            if(!q.isProbablePrime(20)) {
+                throw new IllegalArgumentException("Field size q must be prime");
+            }
+
+            if(!n.isProbablePrime(20)) {
+                throw new IllegalArgumentException("The order n must be prime");
+            }
+
+            if((a.pow(3).multiply(BigInteger.valueOf(4)).add(b.pow(2).multiply(BigInteger.valueOf(27))).mod(q)) == BigInteger.valueOf(0)) {
+                throw new IllegalArgumentException("The curve is singular, i.e the discriminant is equal to 0 mod q.");
+            }
+
+            if (!g.isValid()) {
+                throw new IllegalArgumentException("The base point G does not lie on the curve.");
+            }
+
+            BigInteger totalPoints = n.multiply(h);
+            if(!totalPoints.equals(curve.getOrder())) {
+                throw new IllegalArgumentException("n is not equal to the order of your curve");
+            }
+
+            if(a.compareTo(BigInteger.ZERO) == -1 || a.compareTo(q.subtract(BigInteger.ONE)) == 1) {
+                throw new IllegalArgumentException("The parameter 'a' is not in the field [0, q-1]");
+            }
+
+            if(b.compareTo(BigInteger.ZERO) == -1 || b.compareTo(q.subtract(BigInteger.ONE)) == 1) {
+                throw new IllegalArgumentException("The parameter 'b' is not in the field [0, q-1]");
+            }
+        }
+
+        this.a = a;
+        this.b = b;
+        this.h = h;
+        this.n = n;
+        this.q = q;
+        this.g = g;
+        this.curve = curve;
+    }
+
+    public BigInteger getA()
+    {
+        return a;
+    }
+
+    public BigInteger getB()
+    {
+        return b;
+    }
+
+    public BigInteger getN()
+    {
+        return n;
+    }
+
+    public BigInteger getH()
+    {
+        return h;
+    }
+
+    public BigInteger getQ()
+    {
+        return q;
+    }
+
+    public ECPoint getG()
+    {
+        return g;
+    }
+
+    public ECCurve.Fp getCurve()
+    {
+        return curve;
+    }
+
+
+}

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKECurves.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKECurves.java
@@ -1,0 +1,100 @@
+package org.bouncycastle.crypto.agreement.ecjpake;
+
+import java.math.BigInteger;
+import org.bouncycastle.math.ec.ECCurve;
+import org.bouncycastle.math.ec.ECPoint;
+
+/**
+ * Standard pre-computed elliptic curves for use by EC J-PAKE.
+ * (J-PAKE can use pre-computed elliptic curves or prime order groups, same as DSA and Diffie-Hellman.)
+ * <p>
+ * This class contains some convenient constants for use as input for
+ * constructing {@link ECJPAKEParticipant}s.
+ * <p>
+ * The prime order groups below are taken from NIST SP 800-186,
+ * "Recommendations for Discrete Logarithm-based Cryptography: Elliptic Curve Domain Parameters",
+ * <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-186.pdf">published by NIST</a>.
+ */
+public class ECJPAKECurves 
+{
+
+    /**
+     * From NIST.
+     * 128-bit security.
+     */
+    public static final ECJPAKECurve NIST_P256;
+
+    static{
+        //a
+        BigInteger a_p256 = new BigInteger("ffffffff00000001000000000000000000000000fffffffffffffffffffffffc", 16);
+        //b
+        BigInteger b_p256 = new BigInteger("5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b", 16);
+        //q
+        BigInteger q_p256 = new BigInteger("ffffffff00000001000000000000000000000000ffffffffffffffffffffffff", 16);
+        //h
+        BigInteger h_p256 = BigInteger.ONE;
+        //n
+        BigInteger n_p256 = new BigInteger("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551", 16);
+        //g
+        ECCurve.Fp curve_p256 = new ECCurve.Fp(q_p256, a_p256, b_p256, n_p256, h_p256);
+        ECPoint g_p256 = curve_p256.createPoint(
+            new BigInteger("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296", 16),
+            new BigInteger("4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5", 16));
+
+        NIST_P256 = new ECJPAKECurve(a_p256, b_p256, q_p256, h_p256, n_p256, g_p256, curve_p256, true);
+    }
+
+    /**
+     * From NIST.
+     * 192-bit security.
+     */
+    public static final ECJPAKECurve NIST_P384;
+
+    static{
+        //a
+        BigInteger a_p384 = new BigInteger("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc", 16);
+        //b
+        BigInteger b_p384 = new BigInteger("b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef", 16);
+        //q
+        BigInteger q_p384 = new BigInteger("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff", 16);
+        //h
+        BigInteger h_p384 = BigInteger.ONE;
+        //n
+        BigInteger n_p384 = new BigInteger("ffffffffffffffffffffffffffffffffc7634d81581a0db248b0a77aecec196accc52973", 16);
+        //g
+        ECCurve.Fp curve_p384 = new ECCurve.Fp(q_p384, a_p384, b_p384, n_p384, h_p384);
+        ECPoint g_p384 = curve_p384.createPoint(
+            new BigInteger("aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7", 16),
+            new BigInteger("3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f", 16));
+
+        NIST_P384 = new ECJPAKECurve(a_p384, b_p384, q_p384, h_p384, n_p384, g_p384, curve_p384, true);
+    }
+
+    /**
+     * From NIST.
+     * 128-bit security.
+     */
+    public static final ECJPAKECurve NIST_P521;
+
+    static{
+        //a
+        BigInteger a_p521 = new BigInteger("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc", 16);
+        //b
+        BigInteger b_p521 = new BigInteger("b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef", 16);
+        //q
+        BigInteger q_p521 = new BigInteger("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff", 16);
+        //h
+        BigInteger h_p521 = BigInteger.ONE;
+        //n
+        BigInteger n_p521 = new BigInteger("ffffffffffffffffffffffffffffffffc7634d81581a0db248b0a77aecec196accc52973", 16);
+        //g
+        ECCurve.Fp curve_p521 = new ECCurve.Fp(q_p521, a_p521, b_p521, n_p521, h_p521);
+        ECPoint g_p521 = curve_p521.createPoint(
+            new BigInteger("aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7", 16),
+            new BigInteger("3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f", 16));
+
+        NIST_P521 = new ECJPAKECurve(a_p521, b_p521, q_p521, h_p521, n_p521, g_p521, curve_p521, true);
+    }
+
+
+}

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKEParticipant.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKEParticipant.java
@@ -1,0 +1,568 @@
+package org.bouncycastle.crypto.agreement.ecjpake;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.CryptoException;
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.math.ec.ECCurve;
+import org.bouncycastle.math.ec.ECPoint;
+import org.bouncycastle.util.Exceptions;
+import org.bouncycastle.crypto.CryptoServicesRegistrar;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+
+/**
+ * A participant in a Password Authenticated Key Exchange by Juggling (J-PAKE) exchange.
+ * <p>
+ * The J-PAKE exchange is defined by Feng Hao and Peter Ryan in the paper
+ * <a href="https://eprint.iacr.org/2010/190.pdf">
+ * "J-PAKE: Authenticated Key Exchange Without PKI."</a>
+ * <p>
+ * The J-PAKE protocol is symmetric.
+ * There is no notion of a <i>client</i> or <i>server</i>, but rather just two <i>participants</i>.
+ * An instance of {@link ECJPAKEParticipant} represents one participant, and
+ * is the primary interface for executing the exchange.
+ * <p>
+ * To execute an exchange, construct a {@link ECJPAKEParticipant} on each end,
+ * and call the following 7 methods
+ * (once and only once, in the given order, for each participant, sending messages between them as described):
+ * <ol>
+ * <li>{@link #createRound1PayloadToSend()} - and send the payload to the other participant</li>
+ * <li>{@link #validateRound1PayloadReceived(ECJPAKERound1Payload)} - use the payload received from the other participant</li>
+ * <li>{@link #createRound2PayloadToSend()} - and send the payload to the other participant</li>
+ * <li>{@link #validateRound2PayloadReceived(ECJPAKERound2Payload)} - use the payload received from the other participant</li>
+ * <li>{@link #calculateKeyingMaterial()}</li>
+ * <li>{@link #createRound3PayloadToSend(BigInteger)} - and send the payload to the other participant</li>
+ * <li>{@link #validateRound3PayloadReceived(ECJPAKERound3Payload, BigInteger)} - use the payload received from the other participant</li>
+ * </ol>
+ * <p>
+ * Each side should derive a session key from the keying material returned by {@link #calculateKeyingMaterial()}.
+ * The caller is responsible for deriving the session key using a secure key derivation function (KDF).
+ * <p>
+ * Round 3 is an optional key confirmation process.
+ * If you do not execute round 3, then there is no assurance that both participants are using the same key.
+ * (i.e. if the participants used different passwords, then their session keys will differ.)
+ * <p>
+ * If the round 3 validation succeeds, then the keys are guaranteed to be the same on both sides.
+ * <p>
+ * The symmetric design can easily support the asymmetric cases when one party initiates the communication.
+ * e.g. Sometimes the round1 payload and round2 payload may be sent in one pass.
+ * Also, in some cases, the key confirmation payload can be sent together with the round2 payload.
+ * These are the trivial techniques to optimize the communication.
+ * <p>
+ * The key confirmation process is implemented as specified in
+ * <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf">NIST SP 800-56A Revision 3</a>,
+ * Section 5.9.1 Unilateral Key Confirmation for Key Agreement Schemes.
+ * <p>
+ * This class is stateful and NOT threadsafe.
+ * Each instance should only be used for ONE complete J-PAKE exchange
+ * (i.e. a new {@link ECJPAKEParticipant} should be constructed for each new J-PAKE exchange).
+ * <p>
+ */
+
+
+public class ECJPAKEParticipant {
+
+    /*
+     * Possible internal states.  Used for state checking.
+     */
+
+    public static final int STATE_INITIALIZED = 0;
+    public static final int STATE_ROUND_1_CREATED = 10;
+    public static final int STATE_ROUND_1_VALIDATED = 20;
+    public static final int STATE_ROUND_2_CREATED = 30;
+    public static final int STATE_ROUND_2_VALIDATED = 40;
+    public static final int STATE_KEY_CALCULATED = 50;
+    public static final int STATE_ROUND_3_CREATED = 60;
+    public static final int STATE_ROUND_3_VALIDATED = 70;
+
+    /**
+     * Unique identifier of this participant.
+     * The two participants in the exchange must NOT share the same id.
+     */
+    private final String participantId;
+
+    /**
+     * Shared secret.  This only contains the secret between construction
+     * and the call to {@link #calculateKeyingMaterial()}.
+     * <p>
+     * i.e. When {@link #calculateKeyingMaterial()} is called, this buffer overwritten with 0's,
+     * and the field is set to null.
+     * </p>
+     */
+    private char[] password;
+
+    /**
+     * Digest to use during calculations.
+     */
+    private final Digest digest;
+
+    /**
+     * Source of secure random data.
+     */
+    private final SecureRandom random;
+
+    /**
+     * The participantId of the other participant in this exchange.
+     */
+    private String partnerParticipantId;
+
+    private ECCurve.Fp ecCurve;
+	private BigInteger ecca;
+	private BigInteger eccb;
+	private BigInteger q;
+	private BigInteger h;
+	private BigInteger n;
+	private ECPoint g;
+
+    /**
+     * Alice's x1 or Bob's x3.
+     */
+    private BigInteger x1;
+    /**
+     * Alice's x2 or Bob's x4.
+     */
+    private BigInteger x2;
+    /**
+     * Alice's g^x1 or Bob's g^x3.
+     */
+    private ECPoint gx1;
+    /**
+     * Alice's g^x2 or Bob's g^x4.
+     */
+    private ECPoint gx2;
+    /**
+     * Alice's g^x3 or Bob's g^x1.
+     */
+    private ECPoint gx3;
+    /**
+     * Alice's g^x4 or Bob's g^x2.
+     */
+    private ECPoint gx4;
+    /**
+     * Alice's B or Bob's A.
+     */
+    private ECPoint b;
+
+    /**
+     * The current state.
+     * See the <tt>STATE_*</tt> constants for possible values.
+     */
+    private int state;
+
+    /**
+     * Convenience constructor for a new {@link ECJPAKEParticipant} that uses
+     * the {@link ECJPAKECurves.NIST_P256} elliptic curve,
+     * a SHA-256 digest, and a default {@link SecureRandom} implementation.
+     * <p>
+     * After construction, the {@link #getState() state} will be  {@link #STATE_INITIALIZED}.
+     *
+     * @param participantId unique identifier of this participant.
+     *                      The two participants in the exchange must NOT share the same id.
+     * @param password      shared secret.
+     *                      A defensive copy of this array is made (and cleared once {@link #calculateKeyingMaterial()} is called).
+     *                      Caller should clear the input password as soon as possible.
+     * @throws NullPointerException if any argument is null
+     * @throws IllegalArgumentException if password is empty
+     */
+    public ECJPAKEParticipant(
+        String participantId,
+        char[] password)
+    {
+        this(
+            participantId,
+            password,
+            ECJPAKECurves.NIST_P256);
+    }
+
+    /**
+     * Convenience constructor for a new {@link ECJPAKEParticipant} that uses
+     * a SHA-256 digest and a default {@link SecureRandom} implementation.
+     * <p>
+     * After construction, the {@link #getState() state} will be  {@link #STATE_INITIALIZED}.
+     *
+     * @param participantId unique identifier of this participant.
+     *                      The two participants in the exchange must NOT share the same id.
+     * @param password      shared secret.
+     *                      A defensive copy of this array is made (and cleared once {@link #calculateKeyingMaterial()} is called).
+     *                      Caller should clear the input password as soon as possible.
+     * @param curve         elliptic curve
+     *                      See {@link ECJPAKEPrimeOrderGroups} for standard groups
+     * @throws NullPointerException if any argument is null
+     * @throws IllegalArgumentException if password is empty
+     */
+    public ECJPAKEParticipant(
+        String participantId,
+        char[] password,
+        ECJPAKECurve curve)
+    {
+        this(
+            participantId,
+            password,
+            curve,
+            SHA256Digest.newInstance(),
+            CryptoServicesRegistrar.getSecureRandom());
+    }
+
+    /**
+     * Construct a new {@link ECJPAKEParticipant}.
+     * <p>
+     * After construction, the {@link #getState() state} will be  {@link #STATE_INITIALIZED}.
+     *
+     * @param participantId unique identifier of this participant.
+     *                      The two participants in the exchange must NOT share the same id.
+     * @param password      shared secret.
+     *                      A defensive copy of this array is made (and cleared once {@link #calculateKeyingMaterial()} is called).
+     *                      Caller should clear the input password as soon as possible.
+     * @param curve         elliptic curve.
+     *                      See {@link ECJPAKECurves} for standard groups
+     * @param digest        digest to use during zero knowledge proofs and key confirmation (SHA-256 or stronger preferred)
+     * @param random        source of secure random data for x1 and x2, and for the zero knowledge proofs
+     * @throws NullPointerException if any argument is null
+     * @throws IllegalArgumentException if password is empty
+     */
+    public ECJPAKEParticipant(
+        String participantId,
+        char[] password,
+        ECJPAKECurve curve,
+        Digest digest,
+        SecureRandom random)
+    {
+        ECJPAKEUtil.validateNotNull(participantId, "participantId");
+        ECJPAKEUtil.validateNotNull(password, "password");
+        ECJPAKEUtil.validateNotNull(curve, "curve params");
+        ECJPAKEUtil.validateNotNull(digest, "digest");
+        ECJPAKEUtil.validateNotNull(random, "random");
+        if (password.length == 0)
+        {
+            throw new IllegalArgumentException("Password must not be empty.");
+        }
+
+        this.participantId = participantId;
+        
+        /*
+         * Create a defensive copy so as to fully encapsulate the password.
+         * 
+         * This array will contain the password for the lifetime of this
+         * participant BEFORE {@link #calculateKeyingMaterial()} is called.
+         * 
+         * i.e. When {@link #calculateKeyingMaterial()} is called, the array will be cleared
+         * in order to remove the password from memory.
+         * 
+         * The caller is responsible for clearing the original password array
+         * given as input to this constructor.
+         */
+        this.password = Arrays.copyOf(password, password.length);
+
+        this.ecCurve = curve.getCurve();
+        this.ecca = curve.getA();
+        this.eccb = curve.getB();
+        this.g = curve.getG(); 
+        this.h = curve.getH();
+        this.n = curve.getN();
+        this.q = curve.getQ();
+
+        this.digest = digest;
+        this.random = random;
+
+        this.state = STATE_INITIALIZED;
+    }
+
+    /**
+     * Gets the current state of this participant.
+     * See the <tt>STATE_*</tt> constants for possible values.
+     */
+    public int getState()
+    {
+        return this.state;
+    }
+
+    /**
+     * Creates and returns the payload to send to the other participant during round 1.
+     * <p>
+     * After execution, the {@link #getState() state} will be  {@link #STATE_ROUND_1_CREATED}.
+     */
+    public ECJPAKERound1Payload createRound1PayloadToSend()
+    {
+        if (this.state >= STATE_ROUND_1_CREATED)
+        {
+            throw new IllegalStateException("Round1 payload already created for " + participantId);
+        }
+        
+        this.x1 = ECJPAKEUtil.generateX1(n, random);
+        this.x2 = ECJPAKEUtil.generateX1(n, random);
+
+        this.gx1 = ECJPAKEUtil.calculateGx(g, x1);
+        this.gx2 = ECJPAKEUtil.calculateGx(g, x2);
+
+        ECSchnorrZKP knowledgeProofForX1 = ECJPAKEUtil.calculateZeroKnowledgeProof(g, n, x1, gx1, digest, participantId, random);
+        ECSchnorrZKP knowledgeProofForX2 = ECJPAKEUtil.calculateZeroKnowledgeProof(g, n, x2, gx2, digest, participantId, random);
+
+        this.state = STATE_ROUND_1_CREATED;
+
+        return new ECJPAKERound1Payload(participantId, gx1, gx2, knowledgeProofForX1, knowledgeProofForX2);
+    }
+
+    /**
+     * Validates the payload received from the other participant during round 1.
+     * <p>
+     * Must be called prior to {@link #createRound2PayloadToSend()}.
+     * <p>
+     * After execution, the {@link #getState() state} will be  {@link #STATE_ROUND_1_VALIDATED}.
+     *
+     * @throws CryptoException if validation fails.
+     * @throws IllegalStateException if called multiple times.
+     */
+    public void validateRound1PayloadReceived(ECJPAKERound1Payload round1PayloadReceived)
+        throws CryptoException
+    {
+        if (this.state >= STATE_ROUND_1_VALIDATED)
+        {
+            throw new IllegalStateException("Validation already attempted for round1 payload for" + participantId);
+        }
+        this.partnerParticipantId = round1PayloadReceived.getParticipantId();
+        this.gx3 = round1PayloadReceived.getGx1();
+        this.gx4 = round1PayloadReceived.getGx2();
+
+        ECSchnorrZKP knowledgeProofForX3 = round1PayloadReceived.getKnowledgeProofForX1(); 
+        ECSchnorrZKP knowledgeProofForX4 = round1PayloadReceived.getKnowledgeProofForX2();
+
+        ECJPAKEUtil.validateParticipantIdsDiffer(participantId, round1PayloadReceived.getParticipantId());
+        ECJPAKEUtil.validateZeroKnowledgeProof(g, gx3, knowledgeProofForX3, q, n, ecCurve, h, round1PayloadReceived.getParticipantId(), digest);
+        ECJPAKEUtil.validateZeroKnowledgeProof(g, gx4, knowledgeProofForX4, q, n, ecCurve, h, round1PayloadReceived.getParticipantId(), digest);
+
+        this.state = STATE_ROUND_1_VALIDATED;
+    }
+
+    /**
+     * Creates and returns the payload to send to the other participant during round 2.
+     * <p>
+     * {@link #validateRound1PayloadReceived(ECJPAKERound1Payload)} must be called prior to this method.
+     * <p>
+     * After execution, the {@link #getState() state} will be  {@link #STATE_ROUND_2_CREATED}.
+     *
+     * @throws IllegalStateException if called prior to {@link #validateRound1PayloadReceived(ECJPAKERound1Payload)}, or multiple times
+     */
+    public ECJPAKERound2Payload createRound2PayloadToSend()
+    {
+        if (this.state >= STATE_ROUND_2_CREATED)
+        {
+            throw new IllegalStateException("Round2 payload already created for " + this.participantId);
+        }
+        if (this.state < STATE_ROUND_1_VALIDATED)
+        {
+            throw new IllegalStateException("Round1 payload must be validated prior to creating Round2 payload for " + this.participantId);
+        }
+        ECPoint gA = ECJPAKEUtil.calculateGA(gx1, gx3, gx4);
+        BigInteger s = calculateS();
+        BigInteger x2s = ECJPAKEUtil.calculateX2s(n, x2, s);
+        ECPoint A = ECJPAKEUtil.calculateA(gA, x2s);
+        ECSchnorrZKP knowledgeProofForX2s = ECJPAKEUtil.calculateZeroKnowledgeProof(gA, n, x2s, A, digest, participantId, random);
+
+        this.state = STATE_ROUND_2_CREATED;
+
+        return new ECJPAKERound2Payload(participantId, A, knowledgeProofForX2s);
+    }
+
+    /**
+     * Validates the payload received from the other participant during round 2.
+     * <p>
+     * Note that this DOES NOT detect a non-common password.
+     * The only indication of a non-common password is through derivation
+     * of different keys (which can be detected explicitly by executing round 3 and round 4)
+     * <p>
+     * Must be called prior to {@link #calculateKeyingMaterial()}.
+     * <p>
+     * After execution, the {@link #getState() state} will be  {@link #STATE_ROUND_2_VALIDATED}.
+     *
+     * @throws CryptoException if validation fails.
+     * @throws IllegalStateException if called prior to {@link #validateRound1PayloadReceived(ECJPAKERound1Payload)}, or multiple times
+     */
+    public void validateRound2PayloadReceived(ECJPAKERound2Payload round2PayloadReceived)
+        throws CryptoException
+    {
+        if (this.state >= STATE_ROUND_2_VALIDATED)
+        {
+            throw new IllegalStateException("Validation already attempted for round2 payload for" + participantId);
+        }
+        if (this.state < STATE_ROUND_1_VALIDATED)
+        {
+            throw new IllegalStateException("Round1 payload must be validated prior to validating Round2 payload for " + this.participantId);
+        }
+        ECPoint gB = ECJPAKEUtil.calculateGA(gx3, gx1, gx2);
+        this.b = round2PayloadReceived.getA();
+        ECSchnorrZKP knowledgeProofForX4s = round2PayloadReceived.getKnowledgeProofForX2s();
+
+        ECJPAKEUtil.validateParticipantIdsDiffer(participantId, round2PayloadReceived.getParticipantId());
+        ECJPAKEUtil.validateParticipantIdsEqual(this.partnerParticipantId, round2PayloadReceived.getParticipantId());
+        ECJPAKEUtil.validateZeroKnowledgeProof(gB, b, knowledgeProofForX4s, q, n, ecCurve, h, round2PayloadReceived.getParticipantId(), digest);
+
+        this.state = STATE_ROUND_2_VALIDATED;
+    }
+    /**
+     * Calculates and returns the key material.
+     * A session key must be derived from this key material using a secure key derivation function (KDF).
+     * The KDF used to derive the key is handled externally (i.e. not by {@link ECJPAKEParticipant}).
+     * <p>
+     * The keying material will be identical for each participant if and only if
+     * each participant's password is the same.  i.e. If the participants do not
+     * share the same password, then each participant will derive a different key.
+     * Therefore, if you immediately start using a key derived from
+     * the keying material, then you must handle detection of incorrect keys.
+     * If you want to handle this detection explicitly, you can optionally perform
+     * rounds 3 and 4.  See {@link ECJPAKEParticipant} for details on how to execute
+     * rounds 3 and 4.
+     * <p>
+     * The keying material will be in the range <tt>[0, n-1]</tt>.
+     * <p>
+     * {@link #validateRound2PayloadReceived(ECJPAKERound2Payload)} must be called prior to this method.
+     * <p>
+     * As a side effect, the internal {@link #password} array is cleared, since it is no longer needed.
+     * <p>
+     * After execution, the {@link #getState() state} will be  {@link #STATE_KEY_CALCULATED}.
+     *
+     * @throws IllegalStateException if called prior to {@link #validateRound2PayloadReceived(ECJPAKERound2Payload)},
+     * or if called multiple times.
+     */
+    public BigInteger calculateKeyingMaterial()
+    {
+        if (this.state >= STATE_KEY_CALCULATED)
+        {
+            throw new IllegalStateException("Key already calculated for " + participantId);
+        }
+        if (this.state < STATE_ROUND_2_VALIDATED)
+        {
+            throw new IllegalStateException("Round2 payload must be validated prior to creating key for " + participantId);
+        }
+        BigInteger s = calculateS();
+
+        /*
+         * Clear the password array from memory, since we don't need it anymore.
+         * 
+         * Also set the field to null as a flag to indicate that the key has already been calculated.
+         */
+        Arrays.fill(password, (char)0);
+        this.password = null;
+
+        BigInteger keyingMaterial = ECJPAKEUtil.calculateKeyingMaterial(n, gx4, x2, s, b);
+        
+        /*
+         * Clear the ephemeral private key fields as well.
+         * Note that we're relying on the garbage collector to do its job to clean these up.
+         * The old objects will hang around in memory until the garbage collector destroys them.
+         * 
+         * If the ephemeral private keys x1 and x2 are leaked,
+         * the attacker might be able to brute-force the password.
+         */
+        this.x1 = null;
+        this.x2 = null;
+        this.b = null;
+        
+        /*
+         * Do not clear gx* yet, since those are needed by round 3.
+         */
+
+        this.state = STATE_KEY_CALCULATED;
+
+        return keyingMaterial;
+    }
+
+    /**
+     * Creates and returns the payload to send to the other participant during round 3.
+     * <p>
+     * See {@link ECJPAKEParticipant} for more details on round 3.
+     * <p>
+     * After execution, the {@link #getState() state} will be  {@link #STATE_ROUND_3_CREATED}.
+     *
+     * @param keyingMaterial The keying material as returned from {@link #calculateKeyingMaterial()}.
+     * @throws IllegalStateException if called prior to {@link #calculateKeyingMaterial()}, or multiple times
+     */
+    public ECJPAKERound3Payload createRound3PayloadToSend(BigInteger keyingMaterial)
+    {
+        if (this.state >= STATE_ROUND_3_CREATED)
+        {
+            throw new IllegalStateException("Round3 payload already created for " + this.participantId);
+        }
+        if (this.state < STATE_KEY_CALCULATED)
+        {
+            throw new IllegalStateException("Keying material must be calculated prior to creating Round3 payload for " + this.participantId);
+        }
+
+        BigInteger macTag = ECJPAKEUtil.calculateMacTag(
+            this.participantId,
+            this.partnerParticipantId,
+            this.gx1,
+            this.gx2,
+            this.gx3,
+            this.gx4,
+            keyingMaterial,
+            this.digest);
+
+        this.state = STATE_ROUND_3_CREATED;
+
+        return new ECJPAKERound3Payload(participantId, macTag);
+    }
+
+    /**
+     * Validates the payload received from the other participant during round 3.
+     * <p>
+     * See {@link ECJPAKEParticipant} for more details on round 3.
+     * <p>
+     * After execution, the {@link #getState() state} will be {@link #STATE_ROUND_3_VALIDATED}.
+     *
+     * @param round3PayloadReceived The round 3 payload received from the other participant.
+     * @param keyingMaterial The keying material as returned from {@link #calculateKeyingMaterial()}.
+     * @throws CryptoException if validation fails.
+     * @throws IllegalStateException if called prior to {@link #calculateKeyingMaterial()}, or multiple times
+     */
+    public void validateRound3PayloadReceived(ECJPAKERound3Payload round3PayloadReceived, BigInteger keyingMaterial)
+        throws CryptoException
+    {
+        if (this.state >= STATE_ROUND_3_VALIDATED)
+        {
+            throw new IllegalStateException("Validation already attempted for round3 payload for" + participantId);
+        }
+        if (this.state < STATE_KEY_CALCULATED)
+        {
+            throw new IllegalStateException("Keying material must be calculated validated prior to validating Round3 payload for " + this.participantId);
+        }
+        ECJPAKEUtil.validateParticipantIdsDiffer(participantId, round3PayloadReceived.getParticipantId());
+        ECJPAKEUtil.validateParticipantIdsEqual(this.partnerParticipantId, round3PayloadReceived.getParticipantId());
+
+        ECJPAKEUtil.validateMacTag(
+            this.participantId,
+            this.partnerParticipantId,
+            this.gx1,
+            this.gx2,
+            this.gx3,
+            this.gx4,
+            keyingMaterial,
+            this.digest,
+            round3PayloadReceived.getMacTag());
+        
+        
+        /*
+         * Clear the rest of the fields.
+         */
+        this.gx1 = null;
+        this.gx2 = null;
+        this.gx3 = null;
+        this.gx4 = null;
+
+        this.state = STATE_ROUND_3_VALIDATED;
+    }
+
+    private BigInteger calculateS()
+    {
+        try
+        {
+            return ECJPAKEUtil.calculateS(n, password);
+        }
+        catch (CryptoException e)
+        {
+            throw Exceptions.illegalStateException(e.getMessage(), e);
+        }
+    }
+    
+}

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKEParticipant.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKEParticipant.java
@@ -60,8 +60,6 @@ import org.bouncycastle.crypto.digests.SHA256Digest;
  * (i.e. a new {@link ECJPAKEParticipant} should be constructed for each new J-PAKE exchange).
  * <p>
  */
-
-
 public class ECJPAKEParticipant {
 
     /*
@@ -188,7 +186,7 @@ public class ECJPAKEParticipant {
      *                      A defensive copy of this array is made (and cleared once {@link #calculateKeyingMaterial()} is called).
      *                      Caller should clear the input password as soon as possible.
      * @param curve         elliptic curve
-     *                      See {@link ECJPAKEPrimeOrderGroups} for standard groups
+     *                      See {@link ECJPAKECurves} for standard curves.
      * @throws NullPointerException if any argument is null
      * @throws IllegalArgumentException if password is empty
      */
@@ -216,7 +214,7 @@ public class ECJPAKEParticipant {
      *                      A defensive copy of this array is made (and cleared once {@link #calculateKeyingMaterial()} is called).
      *                      Caller should clear the input password as soon as possible.
      * @param curve         elliptic curve.
-     *                      See {@link ECJPAKECurves} for standard groups
+     *                      See {@link ECJPAKECurves} for standard curves
      * @param digest        digest to use during zero knowledge proofs and key confirmation (SHA-256 or stronger preferred)
      * @param random        source of secure random data for x1 and x2, and for the zero knowledge proofs
      * @throws NullPointerException if any argument is null
@@ -462,7 +460,6 @@ public class ECJPAKEParticipant {
         /*
          * Do not clear gx* yet, since those are needed by round 3.
          */
-
         this.state = STATE_KEY_CALCULATED;
 
         return keyingMaterial;

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKERound1Payload.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKERound1Payload.java
@@ -1,0 +1,97 @@
+package org.bouncycastle.crypto.agreement.ecjpake;
+
+import java.math.BigInteger;
+
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.math.ec.ECPoint;
+
+/**
+ * The payload sent/received during the first round of a EC J-PAKE exchange.
+ * <p>
+ * Each {@link ECJPAKEParticipant} creates and sends an instance
+ * of this payload to the other {@link ECJPAKEParticipant}.
+ * The payload to send should be created via
+ * {@link ECJPAKEParticipant#createRound1PayloadToSend()}.
+ * <p>
+ * Each {@link ECJPAKEParticipant} must also validate the payload
+ * received from the other {@link ECJPAKEParticipant}.
+ * The received payload should be validated via
+ * {@link ECJPAKEParticipant#validateRound1PayloadReceived(ECJPAKERound1Payload)}.
+ */
+public class ECJPAKERound1Payload
+{
+
+    private final String participantId;
+
+    /**
+     * The value of g^x1
+     */
+    private final ECPoint gx1;
+
+    /**
+     * The value of g^x2
+     */
+    private final ECPoint gx2;
+
+    /**
+     * The zero knowledge proof for x1.
+     * <p>
+     * This is a class {@link ECSchnorrZKP} with two fields, containing {g^v, r} for x1.
+     * </p>
+     */
+    private final ECSchnorrZKP knowledgeProofForX1;
+
+    /**
+     * The zero knowledge proof for x2.
+     * <p>
+     * This is a class {@link ECSchnorrZKP} with two fields, containing {g^v, r} for x2.
+     * </p>
+     */
+    private final ECSchnorrZKP knowledgeProofForX2;
+
+    public ECJPAKERound1Payload(
+        String participantId,
+        ECPoint gx1,
+        ECPoint gx2,
+        ECSchnorrZKP knowledgeProofForX1,
+        ECSchnorrZKP knowledgeProofForX2)
+    {
+        ECJPAKEUtil.validateNotNull(participantId, "participantId");
+        ECJPAKEUtil.validateNotNull(gx1, "gx1");
+        ECJPAKEUtil.validateNotNull(gx2, "gx2");
+        ECJPAKEUtil.validateNotNull(knowledgeProofForX1, "knowledgeProofForX1");
+        ECJPAKEUtil.validateNotNull(knowledgeProofForX2, "knowledgeProofForX2");
+
+        this.participantId = participantId;
+        this.gx1 = gx1;
+        this.gx2 = gx2;
+        this.knowledgeProofForX1 = knowledgeProofForX1;
+        this.knowledgeProofForX2 = knowledgeProofForX2;
+    }
+
+    public String getParticipantId()
+    {
+        return participantId;
+    }
+
+    public ECPoint getGx1()
+    {
+        return gx1;
+    }
+
+    public ECPoint getGx2()
+    {
+        return gx2;
+    }
+
+    public ECSchnorrZKP getKnowledgeProofForX1()
+    {
+        return knowledgeProofForX1;
+    }
+
+    public ECSchnorrZKP getKnowledgeProofForX2()
+    {
+        return knowledgeProofForX2;
+    }
+
+}

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKERound2Payload.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKERound2Payload.java
@@ -1,0 +1,71 @@
+package org.bouncycastle.crypto.agreement.ecjpake;
+
+import java.math.BigInteger;
+
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.math.ec.ECPoint;
+
+/**
+ * The payload sent/received during the second round of a EC J-PAKE exchange.
+ * <p>
+ * Each {@link ECJPAKEParticipant} creates and sends an instance
+ * of this payload to the other {@link ECJPAKEParticipant}.
+ * The payload to send should be created via
+ * {@link ECJPAKEParticipant#createRound2PayloadToSend()}
+ * <p>
+ * Each {@link ECJPAKEParticipant} must also validate the payload
+ * received from the other {@link ECJPAKEParticipant}.
+ * The received payload should be validated via
+ * {@link ECJPAKEParticipant#validateRound2PayloadReceived(JPAKERound2Payload)}
+ */
+public class ECJPAKERound2Payload
+{
+
+    /**
+     * The id of the {@link ECJPAKEParticipant} who created/sent this payload.
+     */
+    private final String participantId;
+
+    /**
+     * The value of A, as computed during round 2.
+     */
+    private final ECPoint a;
+
+    /**
+     * The zero knowledge proof for x2 * s.
+     * <p>
+     * This is a class {@link ECSchnorrZKP} with two fields, containing {g^v, r} for x2 * s.
+     * </p>
+     */
+    private final ECSchnorrZKP knowledgeProofForX2s;
+
+    public ECJPAKERound2Payload(
+        String participantId,
+        ECPoint a,
+        ECSchnorrZKP knowledgeProofForX2s)
+    {
+        ECJPAKEUtil.validateNotNull(participantId, "participantId");
+        ECJPAKEUtil.validateNotNull(a, "a");
+        ECJPAKEUtil.validateNotNull(knowledgeProofForX2s, "knowledgeProofForX2s");
+
+        this.participantId = participantId;
+        this.a = a;
+        this.knowledgeProofForX2s = knowledgeProofForX2s;
+    }
+
+    public String getParticipantId()
+    {
+        return participantId;
+    }
+
+    public ECPoint getA()
+    {
+        return a;
+    }
+
+    public ECSchnorrZKP getKnowledgeProofForX2s()
+    {
+        return knowledgeProofForX2s;
+    }
+
+}

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKERound2Payload.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKERound2Payload.java
@@ -16,7 +16,7 @@ import org.bouncycastle.math.ec.ECPoint;
  * Each {@link ECJPAKEParticipant} must also validate the payload
  * received from the other {@link ECJPAKEParticipant}.
  * The received payload should be validated via
- * {@link ECJPAKEParticipant#validateRound2PayloadReceived(JPAKERound2Payload)}
+ * {@link ECJPAKEParticipant#validateRound2PayloadReceived(ECJPAKERound2Payload)}
  */
 public class ECJPAKERound2Payload
 {

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKERound3Payload.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKERound3Payload.java
@@ -1,0 +1,50 @@
+package org.bouncycastle.crypto.agreement.ecjpake;
+
+import java.math.BigInteger;
+
+/**
+ * The payload sent/received during the optional third round of a EC J-PAKE exchange,
+ * which is for explicit key confirmation.
+ * <p>
+ * Each {@link ECJPAKEParticipant} creates and sends an instance
+ * of this payload to the other {@link ECJPAKEParticipant}.
+ * The payload to send should be created via
+ * {@link ECJPAKEParticipant#createRound3PayloadToSend(BigInteger)}
+ * <p>
+ * Each {@link ECJPAKEParticipant} must also validate the payload
+ * received from the other {@link ECJPAKEParticipant}.
+ * The received payload should be validated via
+ * {@link ECJPAKEParticipant#validateRound3PayloadReceived(ECJPAKERound3Payload, BigInteger)}
+ */
+public class ECJPAKERound3Payload
+{
+
+    /**
+     * The id of the {@link ECJPAKEParticipant} who created/sent this payload.
+     */
+    private final String participantId;
+
+    /**
+     * The value of MacTag, as computed by round 3.
+     *
+     * @see ECJPAKEUtil#calculateMacTag(String, String, ECPoint, ECPoint, ECPoint, ECPoint, BigInteger, org.bouncycastle.crypto.Digest)
+     */
+    private final BigInteger macTag;
+
+    public ECJPAKERound3Payload(String participantId, BigInteger magTag)
+    {
+        this.participantId = participantId;
+        this.macTag = magTag;
+    }
+
+    public String getParticipantId()
+    {
+        return participantId;
+    }
+
+    public BigInteger getMacTag()
+    {
+        return macTag;
+    }
+
+}

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKEUtil.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKEUtil.java
@@ -1,0 +1,509 @@
+package org.bouncycastle.crypto.agreement.ecjpake;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.CryptoException;
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.Mac;
+import org.bouncycastle.crypto.macs.HMac;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.BigIntegers;
+import org.bouncycastle.util.Strings;
+import org.bouncycastle.math.ec.ECCurve;
+import org.bouncycastle.math.ec.ECPoint;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+
+/**
+ * Primitives needed for a EC J-PAKE exchange.
+ * <p>
+ * The recommended way to perform a J-PAKE exchange is by using
+ * two {@link ECJPAKEParticipant}s.  Internally, those participants
+ * call these primitive operations in {@link ECJPAKEUtil}.
+ * <p>
+ * The primitives, however, can be used without a {@link ECJPAKEParticipant}
+ * if needed.
+ */
+public class ECJPAKEUtil
+{
+    static final BigInteger ZERO = BigInteger.valueOf(0);
+    static final BigInteger ONE = BigInteger.valueOf(1);
+
+    /**
+     * Return a value that can be used as x1, x2, x3 or x4 during round 1.
+     * <p>
+     * The returned value is a random value in the range <tt>[1, n-1]</tt>.
+     */
+    public static BigInteger generateX1(  
+        BigInteger n, 
+        SecureRandom random)  
+        {    
+        BigInteger min = ONE;
+        BigInteger max = n.subtract(ONE);
+        return BigIntegers.createRandomInRange(min, max, random);
+    }
+
+    /**
+     * Converts the given password to a {@link BigInteger} mod n.
+     */
+    public static BigInteger calculateS(
+        BigInteger n, 
+        byte[] password)
+        throws CryptoException
+    {
+        BigInteger s = new BigInteger(1, password).mod(n);
+        if (s.signum() == 0)
+        {
+            throw new CryptoException("MUST ensure s is not equal to 0 modulo n");
+        }
+        return s;
+    }
+
+    /**
+     * Converts the given password to a {@link BigInteger} mod n.
+     */
+    public static BigInteger calculateS(
+        BigInteger n, 
+        char[] password)
+        throws CryptoException
+    {
+        return calculateS(n, Strings.toUTF8ByteArray(password));
+    }
+
+    /**
+     * Calculate g^x as done in round 1.
+     */
+    public static ECPoint calculateGx(
+        ECPoint g,
+        BigInteger x)
+    {
+        return g.multiply(x);
+    }
+
+    /**
+     * Calculate ga as done in round 2.
+     */
+    public static ECPoint calculateGA(
+        ECPoint gx1,
+        ECPoint gx3,
+        ECPoint gx4)
+    {
+        // ga = g^(x1+x3+x4) = g^x1 * g^x3 * g^x4 
+        return gx1.add(gx3).add(gx4);
+    }
+
+
+    /**
+     * Calculate x2 * s as done in round 2.
+     */
+    public static BigInteger calculateX2s(
+        BigInteger n,
+        BigInteger x2,
+        BigInteger s)
+    {
+        return x2.multiply(s).mod(n);
+    }
+
+
+    /**
+     * Calculate A as done in round 2.
+     */
+    public static ECPoint calculateA(
+        ECPoint gA,
+        BigInteger x2s)
+    {
+        // A = ga^(x*s)
+        return gA.multiply(x2s);
+    }
+
+    /**
+     * Calculate a zero knowledge proof of x using Schnorr's signature.
+     * The returned object has two fields {g^v, r = v-x*h} for x.
+     */
+    public static ECSchnorrZKP calculateZeroKnowledgeProof (
+        ECPoint generator, 
+        BigInteger n,
+        BigInteger x,
+        ECPoint X, 
+        Digest digest, 
+        String userID, 
+        SecureRandom random) {
+
+        /* Generate a random v from [1, n-1], and compute V = G*v */
+        BigInteger v = BigIntegers.createRandomInRange(BigInteger.ONE, n.subtract(BigInteger.ONE), random);
+        ECPoint V = generator.multiply(v);
+        BigInteger h = calculateHashForZeroKnowledgeProof(generator, V, X, userID, digest); // h
+        // r = v-x*h mod n   
+
+        return new ECSchnorrZKP(V, v.subtract(x.multiply(h)).mod(n));
+    }
+
+    private static BigInteger calculateHashForZeroKnowledgeProof(
+        ECPoint g,
+        ECPoint v,
+        ECPoint x,
+        String participantId,
+        Digest digest)
+    {
+        digest.reset();
+
+        updateDigestIncludingSize(digest, g);
+
+        updateDigestIncludingSize(digest, v);
+
+        updateDigestIncludingSize(digest, x);
+
+        updateDigestIncludingSize(digest, participantId);
+
+        byte[] output = new byte[digest.getDigestSize()];
+        digest.doFinal(output, 0);
+
+        return new BigInteger(output);
+    }
+
+    private static void updateDigestIncludingSize(
+        Digest digest, 
+        ECPoint ecPoint)
+    {
+        byte[] byteArray = ecPoint.getEncoded(true);
+        digest.update(intToByteArray(byteArray.length), 0, 4);
+        digest.update(byteArray, 0, byteArray.length);
+        Arrays.fill(byteArray, (byte)0);
+    }
+
+    private static void updateDigestIncludingSize(
+        Digest digest, 
+        String string)
+    {
+        byte[] byteArray = Strings.toUTF8ByteArray(string);
+        digest.update(intToByteArray(byteArray.length), 0, 4);
+        digest.update(byteArray, 0, byteArray.length);
+        Arrays.fill(byteArray, (byte)0);
+    }
+
+    /**
+     * Validates the zero knowledge proof (generated by
+     * {@link #calculateZeroKnowledgeProof(ECPoint, BigInteger, BigInteger, ECPoint, BigInteger, Digest, String, SecureRandom)})
+     * is correct.
+     *
+     * @throws CryptoException if the zero knowledge proof is not correct
+     */
+    public static void validateZeroKnowledgeProof(
+        ECPoint generator, 
+        ECPoint X, 
+        ECSchnorrZKP zkp,
+        BigInteger q,
+        BigInteger n,
+        ECCurve curve,
+        BigInteger coFactor,
+        String userID,
+        Digest digest)
+        throws CryptoException
+    {
+        ECPoint V = zkp.getV();
+        BigInteger r = zkp.getr();
+    	/* ZKP: {V=G*v, r} */    	    	
+    	BigInteger h = calculateHashForZeroKnowledgeProof(generator, V, X, userID, digest);
+    	
+    	/* Public key validation based on the following paper (Sec 3)
+         * Antipa A., Brown D., Menezes A., Struik R. and Vanstone S.
+         * "Validation of elliptic curve public keys", PKC, 2002
+         * https://iacr.org/archive/pkc2003/25670211/25670211.pdf 
+         */
+    	
+    	// 1. X != infinity
+    	if (X.isInfinity())
+        {
+            throw new CryptoException("Zero-knowledge proof validation failed: X cannot equal infinity");
+        }
+    	
+        ECPoint x_normalized = X.normalize();
+    	// 2. Check x and y coordinates are in Fq, i.e., x, y in [0, q-1]
+    	if (x_normalized.getAffineXCoord().toBigInteger().compareTo(BigInteger.ZERO) == -1 ||
+    			x_normalized.getAffineXCoord().toBigInteger().compareTo(q.subtract(BigInteger.ONE)) == 1 ||
+    			x_normalized.getAffineYCoord().toBigInteger().compareTo(BigInteger.ZERO) == -1 ||
+    			x_normalized.getAffineYCoord().toBigInteger().compareTo(q.subtract(BigInteger.ONE)) == 1) 
+        {
+            throw new CryptoException("Zero-knowledge proof validation failed: x and y are not in the field");
+        }
+    				
+    	// 3. Check X lies on the curve
+    	try {
+    		curve.decodePoint(X.getEncoded(true));
+    	}
+    	catch(Exception e){
+            throw new CryptoException("Zero-knowledge proof validation failed: x does not lie on the curve", e);
+        }
+    	
+    	// 4. Check that nX = infinity.
+    	// It is equivalent - but more more efficient - to check the coFactor*X is not infinity
+    	if (X.multiply(coFactor).isInfinity()) 
+        {
+            throw new CryptoException("Zero-knowledge proof validation failed: Nx cannot be infinity");
+        }
+    	// Now check if V = G*r + X*h. 
+    	// Given that {G, X} are valid points on curve, the equality implies that V is also a point on curve.
+    	if (!V.equals(generator.multiply(r).add(X.multiply(h.mod(n))))) 
+        {
+            throw new CryptoException("Zero-knowledge proof validation failed: V must be a point on the curve");
+        }
+    	
+    }
+
+    /**
+     * Validates that the given participant ids are not equal.
+     * (For the J-PAKE exchange, each participant must use a unique id.)
+     *
+     * @throws CryptoException if the participantId strings are equal.
+     */
+    public static void validateParticipantIdsDiffer(
+        String participantId1, 
+        String participantId2)
+        throws CryptoException
+    {
+        if (participantId1.equals(participantId2))
+        {
+            throw new CryptoException(
+                "Both participants are using the same participantId ("
+                    + participantId1
+                    + "). This is not allowed. "
+                    + "Each participant must use a unique participantId.");
+        }
+    }
+
+    /**
+     * Validates that the given participant ids are equal.
+     * This is used to ensure that the payloads received from
+     * each round all come from the same participant.
+     *
+     * @throws CryptoException if the participantId strings are equal.
+     */
+    public static void validateParticipantIdsEqual(
+        String expectedParticipantId, 
+        String actualParticipantId)
+        throws CryptoException
+    {
+        if (!expectedParticipantId.equals(actualParticipantId))
+        {
+            throw new CryptoException(
+                "Received payload from incorrect partner ("
+                    + actualParticipantId
+                    + "). Expected to receive payload from "
+                    + expectedParticipantId
+                    + ".");
+        }
+    }
+
+    /**
+     * Validates that the given object is not null.
+     *
+     *  @param object object in question
+     * @param description name of the object (to be used in exception message)
+     * @throws NullPointerException if the object is null.
+     */
+    public static void validateNotNull(
+        Object object, 
+        String description)
+    {
+        if (object == null)
+        {
+            throw new NullPointerException(description + " must not be null");
+        }
+    }
+
+    /**
+     * Calculates the keying material, which can be done after round 2 has completed.
+     * A session key must be derived from this key material using a secure key derivation function (KDF).
+     * The KDF used to derive the key is handled externally (i.e. not by {@link ECJPAKEParticipant}).
+     * <pre>
+     * KeyingMaterial = (B/g^{x2*x4*s})^x2
+     * </pre>
+     */
+    public static BigInteger calculateKeyingMaterial(
+        BigInteger n,
+        ECPoint gx4,
+        BigInteger x2,
+        BigInteger s,
+        ECPoint B)
+    {
+        ECPoint k = ((B.subtract(gx4.multiply(x2.multiply(s).mod(n)))).multiply(x2));
+        k = k.normalize();
+
+        return k.getAffineXCoord().toBigInteger();
+    }
+
+    /**
+     * Calculates the MacTag (to be used for key confirmation), as defined by
+     * <a href= "https://csrc.nist.gov/pubs/sp/800/56/a/r3/final">NIST SP 800-56A Revision 3</a>,
+     * Section 5.9.1 Unilateral Key Confirmation for Key Agreement Schemes.
+     * <pre>
+     * MacTag = HMAC(MacKey, MacLen, MacData)
+     *
+     * MacKey = H(K || "ECJPAKE_KC")
+     *
+     * MacData = "KC_1_U" || participantId || partnerParticipantId || gx1 || gx2 || gx3 || gx4
+     *
+     * Note that both participants use "KC_1_U" because the sender of the round 3 message
+     * is always the initiator for key confirmation.
+     *
+     * HMAC = {@link HMac} used with the given {@link Digest}
+     * H = The given {@link Digest}
+     * MacOutputBits = MacTagBits, hence truncation function omitted.
+     * MacLen = length of MacTag
+     * </pre>
+     */
+    public static BigInteger calculateMacTag(
+        String participantId,
+        String partnerParticipantId,
+        ECPoint gx1,
+        ECPoint gx2,
+        ECPoint gx3,
+        ECPoint gx4,
+        BigInteger keyingMaterial,
+        Digest digest)
+    {
+        byte[] macKey = calculateMacKey(
+            keyingMaterial,
+            digest);
+
+        HMac mac = new HMac(digest);
+        byte[] macOutput = new byte[mac.getMacSize()];
+        mac.init(new KeyParameter(macKey));
+        
+        /*
+         * MacData = "KC_1_U" || participantId_Alice || participantId_Bob || gx1 || gx2 || gx3 || gx4.
+         */
+        updateMac(mac, "KC_1_U");
+        updateMac(mac, participantId);
+        updateMac(mac, partnerParticipantId);
+        updateMac(mac, gx1);
+        updateMac(mac, gx2);
+        updateMac(mac, gx3);
+        updateMac(mac, gx4);
+
+        mac.doFinal(macOutput, 0);
+
+        Arrays.fill(macKey, (byte)0);
+
+        return new BigInteger(macOutput);
+
+    }
+
+    /**
+     * Calculates the MacKey (i.e. the key to use when calculating the MagTag for key confirmation).
+     * <pre>
+     * MacKey = H(K || "ECJPAKE_KC")
+     * </pre>
+     */
+    private static byte[] calculateMacKey(
+        BigInteger keyingMaterial, 
+        Digest digest)
+    {
+        digest.reset();
+
+        updateDigest(digest, keyingMaterial);
+        /*
+         * This constant is used to ensure that the macKey is NOT the same as the derived key.
+         */
+        updateDigest(digest, "ECJPAKE_KC");
+
+        byte[] output = new byte[digest.getDigestSize()];
+        digest.doFinal(output, 0);
+
+        return output;
+    }
+
+    /**
+     * Validates the MacTag received from the partner participant.
+     *
+     * @param partnerMacTag the MacTag received from the partner.
+     * @throws CryptoException if the participantId strings are equal.
+     */
+    public static void validateMacTag(
+        String participantId,
+        String partnerParticipantId,
+        ECPoint gx1,
+        ECPoint gx2,
+        ECPoint gx3,
+        ECPoint gx4,
+        BigInteger keyingMaterial,
+        Digest digest,
+        BigInteger partnerMacTag)
+        throws CryptoException
+    {
+        /*
+         * Calculate the expected MacTag using the parameters as the partner
+         * would have used when the partner called calculateMacTag.
+         * 
+         * i.e. basically all the parameters are reversed.
+         * participantId <-> partnerParticipantId
+         *            x1 <-> x3
+         *            x2 <-> x4
+         */
+        BigInteger expectedMacTag = calculateMacTag(
+            partnerParticipantId,
+            participantId,
+            gx3,
+            gx4,
+            gx1,
+            gx2,
+            keyingMaterial,
+            digest);
+
+        if (!expectedMacTag.equals(partnerMacTag))
+        {
+            throw new CryptoException(
+                "Partner MacTag validation failed. "
+                    + "Therefore, the password, MAC, or digest algorithm of each participant does not match.");
+        }
+    }
+
+    private static void updateMac(Mac mac, ECPoint ecPoint)
+    {
+        byte[] byteArray = ecPoint.getEncoded(true);
+        mac.update(byteArray, 0, byteArray.length);
+        Arrays.fill(byteArray, (byte)0);
+    }
+
+    private static void updateMac(Mac mac, String string)
+    {
+        byte[] byteArray = Strings.toUTF8ByteArray(string);
+        mac.update(byteArray, 0, byteArray.length);
+        Arrays.fill(byteArray, (byte)0);
+    }
+
+    private static void updateDigest(Digest digest, ECPoint ecPoint)
+    {
+        byte[] byteArray = ecPoint.getEncoded(true);
+        digest.update(byteArray, 0, byteArray.length);
+        Arrays.fill(byteArray, (byte)0);
+    }
+
+    private static void updateDigest(Digest digest, String string)
+    {
+        byte[] byteArray = Strings.toUTF8ByteArray(string);
+        digest.update(byteArray, 0, byteArray.length);
+        Arrays.fill(byteArray, (byte)0);
+    }
+
+    private static void updateDigest(Digest digest, BigInteger bigInteger)
+    {
+        byte[] byteArray = BigIntegers.asUnsignedByteArray(bigInteger);
+        digest.update(byteArray, 0, byteArray.length);
+        Arrays.fill(byteArray, (byte)0);
+    }
+
+    private static byte[] intToByteArray(int value)
+    {
+        return new byte[]{
+            (byte)(value >>> 24),
+            (byte)(value >>> 16),
+            (byte)(value >>> 8),
+            (byte)value
+        };
+    }
+
+}

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKEUtil.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECJPAKEUtil.java
@@ -20,7 +20,7 @@ import java.security.MessageDigest;
 /**
  * Primitives needed for a EC J-PAKE exchange.
  * <p>
- * The recommended way to perform a J-PAKE exchange is by using
+ * The recommended way to perform an EC J-PAKE exchange is by using
  * two {@link ECJPAKEParticipant}s.  Internally, those participants
  * call these primitive operations in {@link ECJPAKEUtil}.
  * <p>
@@ -213,7 +213,6 @@ public class ECJPAKEUtil
          * "Validation of elliptic curve public keys", PKC, 2002
          * https://iacr.org/archive/pkc2003/25670211/25670211.pdf 
          */
-    	
     	// 1. X != infinity
     	if (X.isInfinity())
         {

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECSchnorrZKP.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECSchnorrZKP.java
@@ -1,0 +1,25 @@
+package org.bouncycastle.crypto.agreement.ecjpake;
+
+import java.math.BigInteger;
+import org.bouncycastle.math.ec.ECPoint;
+
+
+class ECSchnorrZKP {
+    
+    private final ECPoint V;
+    private final BigInteger r;
+
+    ECSchnorrZKP(ECPoint V, BigInteger r) 
+    {
+        this.V = V;
+        this.r = r;
+    }
+    
+    ECPoint getV() {
+        return V;
+    }
+    
+    BigInteger getr() {
+        return r;
+    }
+}

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECSchnorrZKP.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECSchnorrZKP.java
@@ -3,7 +3,13 @@ package org.bouncycastle.crypto.agreement.ecjpake;
 import java.math.BigInteger;
 import org.bouncycastle.math.ec.ECPoint;
 
-
+/**
+ * Package protected class for the zero knowledge proof, for an EC J-PAKE exchange.
+ * <p>
+ * V = G x [v]
+ * r = v - d * c mod n
+ * <p>
+ */
 class ECSchnorrZKP {
     
     private final ECPoint V;

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECSchnorrZKP.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECSchnorrZKP.java
@@ -4,15 +4,21 @@ import java.math.BigInteger;
 import org.bouncycastle.math.ec.ECPoint;
 
 /**
- * Package protected class for the zero knowledge proof, for an EC J-PAKE exchange.
- * <p>
- * V = G x [v]
- * r = v - d * c mod n
- * <p>
- */
+ * Package protected class containing zero knowledge proof, for an EC J-PAKE exchange.
+ *</p>
+ *
+ *
+ */ 
 class ECSchnorrZKP {
-    
+
+    /**
+     * The value of V = G x [v].
+     */
     private final ECPoint V;
+
+    /**
+     * The value of r = v - d * c mod n
+     */
     private final BigInteger r;
 
     ECSchnorrZKP(ECPoint V, BigInteger r) 

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECSchnorrZKP.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECSchnorrZKP.java
@@ -5,6 +5,10 @@ import org.bouncycastle.math.ec.ECPoint;
 
 /**
  * Package protected class containing zero knowledge proof, for an EC J-PAKE exchange.
+ * <p>
+ * This class encapsulates the values involved in the Schnorr
+ * zero-knowledge proof used in the EC J-PAKE protocol.
+ * <p>
  */ 
 class ECSchnorrZKP {
 

--- a/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECSchnorrZKP.java
+++ b/core/src/main/java/org/bouncycastle/crypto/agreement/ecjpake/ECSchnorrZKP.java
@@ -5,9 +5,6 @@ import org.bouncycastle.math.ec.ECPoint;
 
 /**
  * Package protected class containing zero knowledge proof, for an EC J-PAKE exchange.
- *</p>
- *
- *
  */ 
 class ECSchnorrZKP {
 

--- a/core/src/main/java/org/bouncycastle/crypto/examples/ECJPAKEExample.java
+++ b/core/src/main/java/org/bouncycastle/crypto/examples/ECJPAKEExample.java
@@ -1,0 +1,224 @@
+package org.bouncycastle.crypto.examples;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+import org.bouncycastle.math.ec.ECCurve;
+import org.bouncycastle.math.ec.ECPoint;
+import org.bouncycastle.crypto.CryptoException;
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.SavableDigest;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKEParticipant;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKECurve;
+import org.bouncycastle.crypto.agreement.ecjpake.ECSCchnorrZKP;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKECurves;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKERound1Payload;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKERound2Payload;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKERound3Payload;
+
+/**
+ * An example of a J-PAKE exchange.
+ * <p>
+ * 
+ * In this example, both Alice and Bob are on the same computer (in the same JVM, in fact).
+ * In reality, Alice and Bob would be in different locations,
+ * and would be sending their generated payloads to each other.
+ */
+public class ECJPAKEExample {
+
+    public static void main(String args[]) throws CryptoException
+    {
+        /*
+         * Initialization
+         * 
+         * Pick an appropriate elliptic curve to use throughout the exchange.
+         * Note that both participants must use the same group.
+         */
+        ECJPAKECurve curve = ECJPAKECurves.NIST_P256;
+
+        ECCurve ecCurve = curve.getCurve();
+        BigInteger a = curve.getA();
+        BigInteger b = curve.getB();
+        ECPoint g = curve.getG(); 
+        BigInteger h = curve.getH();
+        BigInteger n = curve.getN();
+        BigInteger q = curve.getQ();
+
+        String alicePassword = "password";
+        String bobPassword = "password";
+
+        System.out.println("********* Initialization **********");
+        System.out.println("Public parameters for the elliptic curve over prime field:");
+    	System.out.println("Curve param a (" + a.bitLength() + " bits): "+ a.toString(16));
+    	System.out.println("Curve param b (" + b.bitLength() + " bits): "+ b.toString(16));    	    	
+    	System.out.println("Co-factor h (" + h.bitLength() + " bits): " + h.toString(16));
+    	System.out.println("Base point G (" + g.getEncoded(true).length + " bytes): " + new BigInteger(g.getEncoded(true)).toString(16));
+    	System.out.println("X coord of G (G not normalised) (" + g.getXCoord().toBigInteger().bitLength() + " bits): " + g.getXCoord().toBigInteger().toString(16));
+    	System.out.println("y coord of G (G not normalised) (" + g.getYCoord().toBigInteger().bitLength() + " bits): " + g.getYCoord().toBigInteger().toString(16));
+    	System.out.println("Order of the base point n (" + n.bitLength() + " bits): "+ n.toString(16));
+    	System.out.println("Prime field q (" + q.bitLength() + " bits): "+ q.toString(16));
+        System.out.println("");
+
+        System.out.println("(Secret passwords used by Alice and Bob: " +
+                "\"" + alicePassword + "\" and \"" + bobPassword + "\")\n");
+
+        /*
+         * Both participants must use the same hashing algorithm.
+         */
+        Digest digest = SHA256Digest.newInstance();
+        SecureRandom random = new SecureRandom();
+
+        ECJPAKEParticipant alice = new ECJPAKEParticipant("alice", alicePassword.toCharArray(), curve, digest, random);
+        ECJPAKEParticipant bob = new ECJPAKEParticipant("bob", bobPassword.toCharArray(), curve, digest, random);
+
+        /*
+         * Round 1
+         * 
+         * Alice and Bob each generate a round 1 payload, and send it to each other.
+         */
+
+        ECJPAKERound1Payload aliceRound1Payload = alice.createRound1PayloadToSend();
+        ECJPAKERound1Payload bobRound1Payload = bob.createRound1PayloadToSend();
+
+        System.out.println("************ Round 1 **************");
+        System.out.println("Alice sends to Bob: ");
+        System.out.println("g^{x1}=" + new BigInteger(aliceRound1Payload.getGx1().getEncoded(true)).toString(16));
+        System.out.println("g^{x2}=" + new BigInteger(aliceRound1Payload.getGx2().getEncoded(true)).toString(16));
+   	    System.out.println("KP{x1}: {V="+new BigInteger(aliceRound1Payload.getKnowledgeProofForX1().getV().getEncoded(true)).toString(16)+"; r="+aliceRound1Payload.getKnowledgeProofForX1().getr().toString(16)+"}");
+    	System.out.println("KP{x2}: {V="+new BigInteger(aliceRound1Payload.getKnowledgeProofForX2().getV().getEncoded(true)).toString(16)+"; r="+aliceRound1Payload.getKnowledgeProofForX2().getr().toString(16)+"}");
+        System.out.println("");
+
+        System.out.println("Bob sends to Alice: ");
+        System.out.println("g^{x3}=" + new BigInteger(bobRound1Payload.getGx1().getEncoded(true)).toString(16));
+        System.out.println("g^{x4}=" + new BigInteger(bobRound1Payload.getGx2().getEncoded(true)).toString(16));
+   	    System.out.println("KP{x3}: {V="+new BigInteger(bobRound1Payload.getKnowledgeProofForX1().getV().getEncoded(true)).toString(16)+"; r="+bobRound1Payload.getKnowledgeProofForX1().getr().toString(16)+"}");
+    	System.out.println("KP{x4}: {V="+new BigInteger(bobRound1Payload.getKnowledgeProofForX2().getV().getEncoded(true)).toString(16)+"; r="+bobRound1Payload.getKnowledgeProofForX2().getr().toString(16)+"}");
+        System.out.println("");
+
+        /*
+         * Each participant must then validate the received payload for round 1
+         */
+
+        alice.validateRound1PayloadReceived(bobRound1Payload);
+        System.out.println("Alice checks g^{x4}!=1: OK");
+        System.out.println("Alice checks KP{x3}: OK");
+        System.out.println("Alice checks KP{x4}: OK");
+        System.out.println("");
+
+        bob.validateRound1PayloadReceived(aliceRound1Payload);
+        System.out.println("Bob checks g^{x2}!=1: OK");
+        System.out.println("Bob checks KP{x1},: OK");
+        System.out.println("Bob checks KP{x2},: OK");
+        System.out.println("");
+
+        /*
+         * Round 2
+         * 
+         * Alice and Bob each generate a round 2 payload, and send it to each other.
+         */
+
+        ECJPAKERound2Payload aliceRound2Payload = alice.createRound2PayloadToSend();
+        ECJPAKERound2Payload bobRound2Payload = bob.createRound2PayloadToSend();
+
+        System.out.println("************ Round 2 **************");
+        System.out.println("Alice sends to Bob: ");
+    	System.out.println("A="+new BigInteger(aliceRound2Payload.getA().getEncoded(true)).toString(16));
+    	System.out.println("KP{x2*s}: {V="+new BigInteger(aliceRound2Payload.getKnowledgeProofForX2s().getV().getEncoded(true)).toString(16)+", r="+aliceRound2Payload.getKnowledgeProofForX2s().getr().toString(16)+"}");
+        System.out.println("");
+
+        System.out.println("Bob sends to Alice");
+   	    System.out.println("B="+new BigInteger(bobRound2Payload.getA().getEncoded(true)).toString(16));
+    	System.out.println("KP{x4*s}: {V="+new BigInteger(bobRound2Payload.getKnowledgeProofForX2s().getV().getEncoded(true)).toString(16)+", r="+bobRound2Payload.getKnowledgeProofForX2s().getr().toString(16)+"}");
+        System.out.println("");
+
+        /*
+         * Each participant must then validate the received payload for round 2
+         */
+
+        alice.validateRound2PayloadReceived(bobRound2Payload);
+        System.out.println("Alice checks KP{x4*s}: OK\n");
+
+        bob.validateRound2PayloadReceived(aliceRound2Payload);
+        System.out.println("Bob checks KP{x2*s}: OK\n");
+
+        /*
+         * After round 2, each participant computes the keying material.
+         */
+
+        BigInteger aliceKeyingMaterial = alice.calculateKeyingMaterial();
+        BigInteger bobKeyingMaterial = bob.calculateKeyingMaterial();
+
+        System.out.println("********* After round 2 ***********");
+        System.out.println("Alice computes key material \t K=" + aliceKeyingMaterial.toString(16));
+        System.out.println("Bob computes key material \t K=" + bobKeyingMaterial.toString(16));
+        System.out.println();
+        
+        
+        /*
+         * You must derive a session key from the keying material applicable
+         * to whatever encryption algorithm you want to use.
+         */
+        
+        BigInteger aliceKey = deriveSessionKey(aliceKeyingMaterial);
+        BigInteger bobKey = deriveSessionKey(bobKeyingMaterial);
+        
+        /*
+         * At this point, you can stop and use the session keys if you want.
+         * This is implicit key confirmation.
+         * 
+         * If you want to explicitly confirm that the key material matches,
+         * you can continue on and perform round 3.
+         */
+        
+        /*
+         * Round 3
+         * 
+         * Alice and Bob each generate a round 3 payload, and send it to each other.
+         */
+
+        ECJPAKERound3Payload aliceRound3Payload = alice.createRound3PayloadToSend(aliceKeyingMaterial);
+        ECJPAKERound3Payload bobRound3Payload = bob.createRound3PayloadToSend(bobKeyingMaterial);
+
+        System.out.println("************ Round 3 **************");
+        System.out.println("Alice sends to Bob: ");
+        System.out.println("MacTag=" + aliceRound3Payload.getMacTag().toString(16));
+        System.out.println("");
+        System.out.println("Bob sends to Alice: ");
+        System.out.println("MacTag=" + bobRound3Payload.getMacTag().toString(16));
+        System.out.println("");
+
+        /*
+         * Each participant must then validate the received payload for round 3
+         */
+
+        alice.validateRound3PayloadReceived(bobRound3Payload, aliceKeyingMaterial);
+        System.out.println("Alice checks MacTag: OK\n");
+
+        bob.validateRound3PayloadReceived(aliceRound3Payload, bobKeyingMaterial);
+        System.out.println("Bob checks MacTag: OK\n");
+
+        System.out.println();
+        System.out.println("MacTags validated, therefore the keying material matches.");
+    }
+
+    private static BigInteger deriveSessionKey(BigInteger keyingMaterial)
+    {
+        /*
+         * You should use a secure key derivation function (KDF) to derive the session key.
+         * 
+         * For the purposes of this example, I'm just going to use a hash of the keying material.
+         */
+        SavableDigest digest = SHA256Digest.newInstance();
+        
+        byte[] keyByteArray = keyingMaterial.toByteArray();
+        
+        byte[] output = new byte[digest.getDigestSize()];
+        
+        digest.update(keyByteArray, 0, keyByteArray.length);
+
+        digest.doFinal(output, 0);
+
+        return new BigInteger(output);
+    }
+}

--- a/core/src/test/java/org/bouncycastle/crypto/agreement/test/ECJPAKECurveTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/agreement/test/ECJPAKECurveTest.java
@@ -1,0 +1,80 @@
+package org.example;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKECurve;
+import org.bouncycastle.math.ec.ECCurve;
+import org.bouncycastle.math.ec.ECPoint;
+import org.junit.jupiter.api.Test;
+import org.bouncycastle.crypto.CryptoException;
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+
+
+public class ECJPAKECurveTest {
+
+    @Test
+    public void testConstruction() 
+    throws CryptoException
+    {
+        BigInteger a = new BigInteger("ffffffff00000001000000000000000000000000fffffffffffffffffffffffc", 16);
+        //b
+        BigInteger b = new BigInteger("5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b", 16);
+        //q
+        BigInteger q = new BigInteger("ffffffff00000001000000000000000000000000ffffffffffffffffffffffff", 16);
+        //h
+        BigInteger h = BigInteger.ONE;
+        //n
+        BigInteger n = new BigInteger("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551", 16);
+        //g
+        ECCurve.Fp curve = new ECCurve.Fp(q, a, b, n, h);
+        ECPoint g = curve.createPoint(
+            new BigInteger("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296", 16),
+            new BigInteger("4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5", 16)
+        );
+
+        // q not prime
+        assertThrows( IllegalArgumentException.class, () -> { 
+            new ECJPAKECurve(a, b, BigInteger.valueOf(15), h, n, g, curve);
+        });
+
+        // n is not prime
+        assertThrows( IllegalArgumentException.class, () -> { 
+            new ECJPAKECurve(a, b, q, h, BigInteger.valueOf(15), g, curve);
+        });
+
+        // Discriminant is zero
+        assertThrows( IllegalArgumentException.class, () -> { 
+            new ECJPAKECurve(BigInteger.ZERO, BigInteger.ZERO, q, h, n, g, curve);
+        });
+
+        // G is not on the curve
+        assertThrows( IllegalArgumentException.class, () -> { 
+            new ECJPAKECurve(a, b, q, h, n, curve.createPoint(BigInteger.valueOf(2), BigInteger.valueOf(3)), curve);
+        });
+
+        // n is not equal to the order to the curve
+        assertThrows( IllegalArgumentException.class, () -> { 
+            new ECJPAKECurve(a, b, q, BigInteger.valueOf(2), n, g, curve);
+        });
+
+        // a is not in the field [0,q-1]
+        assertThrows( IllegalArgumentException.class, () -> { 
+            new ECJPAKECurve(BigInteger.valueOf(-1), b, q, h, n, g, curve);
+        });
+
+        // b is not in the field [0,q-1]
+        assertThrows( IllegalArgumentException.class, () -> { 
+            new ECJPAKECurve(a, BigInteger.valueOf(-1), q, h, n, g, curve);
+        });
+
+        // should work
+        new ECJPAKECurve(a, b, q, h, n, g, curve);
+
+    }
+
+}
+

--- a/core/src/test/java/org/bouncycastle/crypto/agreement/test/ECJPAKEParticipantTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/agreement/test/ECJPAKEParticipantTest.java
@@ -1,0 +1,385 @@
+package org.bouncycastle.crypto.agreement.test;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKEParticipant;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKECurve;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKECurves;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKERound1Payload;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKERound2Payload;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKERound3Payload;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKEUtil;
+import org.bouncycastle.math.ec.ECCurve;
+import org.junit.jupiter.api.Test;
+import org.bouncycastle.crypto.CryptoException;
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+
+public class ECJPAKEParticipantTest {
+
+    @Test
+    public void testConstruction() 
+    throws CryptoException
+    {
+        ECJPAKECurve curve = ECJPAKECurves.NIST_P256;
+        SecureRandom random = new SecureRandom();
+        Digest digest = new SHA256Digest();
+        String participantId = "participantId";
+        char[] password = "password".toCharArray();
+
+        new ECJPAKEParticipant(participantId, password, curve, digest, random);
+
+        // null participantID
+        assertThrows(NullPointerException.class, () -> {
+            new ECJPAKEParticipant(null, password, curve, digest, random);
+        });
+
+        // null password
+        assertThrows(NullPointerException.class, () -> {
+            new ECJPAKEParticipant(participantId, null, curve, digest, random);
+        });
+
+        // empty password
+        assertThrows(IllegalArgumentException.class, () -> {
+            new ECJPAKEParticipant(participantId, "".toCharArray(), curve, digest, random);
+        });
+
+        // null curve
+        assertThrows(NullPointerException.class, () -> {
+            new ECJPAKEParticipant(participantId, password, null, digest, random);
+        });
+
+        // null digest
+        assertThrows(NullPointerException.class, () -> {
+            new ECJPAKEParticipant(participantId, password, curve, null, random);
+        });
+
+        // null random
+        assertThrows(NullPointerException.class, () -> {
+            new ECJPAKEParticipant(participantId, password, curve, digest, null);
+        });
+    }
+
+    @Test 
+    public void testSuccessfulExchange()
+    throws CryptoException
+    {
+
+        ECJPAKEParticipant alice = createAlice();
+        ECJPAKEParticipant bob = createBob();
+
+        ExchangeAfterRound2Creation exchange = runExchangeUntilRound2Creation(alice, bob);
+
+        alice.validateRound2PayloadReceived(exchange.bobRound2Payload);
+        bob.validateRound2PayloadReceived(exchange.aliceRound2Payload);
+
+        BigInteger aliceKeyingMaterial = alice.calculateKeyingMaterial();
+        BigInteger bobKeyingMaterial = bob.calculateKeyingMaterial();
+
+        ECJPAKERound3Payload aliceRound3Payload = alice.createRound3PayloadToSend(aliceKeyingMaterial);
+        ECJPAKERound3Payload bobRound3Payload = bob.createRound3PayloadToSend(bobKeyingMaterial);
+
+        alice.validateRound3PayloadReceived(bobRound3Payload, aliceKeyingMaterial);
+        bob.validateRound3PayloadReceived(aliceRound3Payload, bobKeyingMaterial);
+
+        assertEquals(aliceKeyingMaterial, bobKeyingMaterial);
+
+    }
+
+    @Test
+    public void testIncorrectPassword() 
+    throws CryptoException
+    {
+        ECJPAKEParticipant alice = createAlice();
+        ECJPAKEParticipant bob = createBobWithWrongPassword();
+
+        ExchangeAfterRound2Creation exchange = runExchangeUntilRound2Creation(alice, bob);
+
+        alice.validateRound2PayloadReceived(exchange.bobRound2Payload);
+        bob.validateRound2PayloadReceived(exchange.aliceRound2Payload);
+
+        BigInteger aliceKeyingMaterial = alice.calculateKeyingMaterial();
+        BigInteger bobKeyingMaterial = bob.calculateKeyingMaterial();
+
+        ECJPAKERound3Payload aliceRound3Payload = alice.createRound3PayloadToSend(aliceKeyingMaterial);
+        ECJPAKERound3Payload bobRound3Payload = bob.createRound3PayloadToSend(bobKeyingMaterial);
+
+        // Validate incorrect passwords result in a CryptoException
+        assertThrows(CryptoException.class, () -> {
+            alice.validateRound3PayloadReceived(bobRound3Payload, aliceKeyingMaterial);
+        });
+
+        assertThrows(CryptoException.class, () -> {
+            bob.validateRound3PayloadReceived(aliceRound3Payload, bobKeyingMaterial);
+        });
+    }
+
+    @Test
+    public void testStateValidation() 
+    throws CryptoException
+    {
+
+        ECJPAKEParticipant alice = createAlice();
+        ECJPAKEParticipant bob = createBob();
+
+        // We're testing alice here. Bob is just used for help.
+
+        // START ROUND 1 CHECKS
+
+        assertEquals(ECJPAKEParticipant.STATE_INITIALIZED, alice.getState());
+
+        // create round 2 before round 1
+        assertThrows(IllegalStateException.class, () -> {
+            alice.createRound2PayloadToSend();
+        });
+
+        ECJPAKERound1Payload aliceRound1Payload = alice.createRound1PayloadToSend();
+
+        assertEquals(ECJPAKEParticipant.STATE_ROUND_1_CREATED, alice.getState());
+
+        // create round 1 payload twice
+        assertThrows(IllegalStateException.class, () -> {
+            alice.createRound1PayloadToSend();
+        });
+
+        // create round 2 before validating round 1
+        assertThrows(IllegalStateException.class, () -> {
+            alice.createRound2PayloadToSend();
+        });
+
+        // validate round 2 before validating round 1
+        assertThrows(IllegalStateException.class, () -> {
+            alice.validateRound2PayloadReceived(null);
+        });
+
+        ECJPAKERound1Payload bobRound1Payload = bob.createRound1PayloadToSend();
+
+        alice.validateRound1PayloadReceived(bobRound1Payload);
+
+        assertEquals(ECJPAKEParticipant.STATE_ROUND_1_VALIDATED, alice.getState());
+
+        // validate round 1 payload twice
+        assertThrows(IllegalStateException.class, () -> {
+            alice.validateRound1PayloadReceived(bobRound1Payload);
+        });
+
+        bob.validateRound1PayloadReceived(aliceRound1Payload);
+
+        // START ROUND 2 CHECKS
+
+        ECJPAKERound2Payload aliceRound2Payload = alice.createRound2PayloadToSend();
+
+        assertEquals(ECJPAKEParticipant.STATE_ROUND_2_CREATED, alice.getState());
+
+        // create round 2 payload twice
+        assertThrows(IllegalStateException.class, () -> {
+            alice.createRound2PayloadToSend();
+        });
+
+        // create key before validating round 2
+        assertThrows(IllegalStateException.class, () -> {
+            alice.calculateKeyingMaterial();
+        });
+
+        // validate round 3 before validating round 2
+        assertThrows(IllegalStateException.class, () -> {
+            alice.validateRound3PayloadReceived(null, null);
+        });
+
+        ECJPAKERound2Payload bobRound2Payload = bob.createRound2PayloadToSend();
+
+        alice.validateRound2PayloadReceived(bobRound2Payload);
+
+        assertEquals(ECJPAKEParticipant.STATE_ROUND_2_VALIDATED, alice.getState());
+
+        // validate round 2 payload twice
+        assertThrows(IllegalStateException.class, () -> {
+            alice.validateRound2PayloadReceived(bobRound2Payload);
+        });
+
+        bob.validateRound2PayloadReceived(aliceRound2Payload);
+
+        // create round 3 before calculating key
+        assertThrows(IllegalStateException.class, () -> {
+            alice.createRound3PayloadToSend(BigInteger.ONE);
+        });
+
+        // START KEY CALCULATION CHECKS
+
+        BigInteger aliceKeyingMaterial = alice.calculateKeyingMaterial();
+
+        assertEquals(ECJPAKEParticipant.STATE_KEY_CALCULATED, alice.getState());
+
+        // calculate key twice
+        assertThrows(IllegalStateException.class, () -> {
+            alice.calculateKeyingMaterial();
+        });
+
+        BigInteger bobKeyingMaterial = bob.calculateKeyingMaterial();
+
+        // START ROUND 3 CHECKS
+
+        ECJPAKERound3Payload aliceRound3Payload = alice.createRound3PayloadToSend(aliceKeyingMaterial);
+
+        assertEquals(ECJPAKEParticipant.STATE_ROUND_3_CREATED, alice.getState());
+
+        // create round 3 payload twice
+        assertThrows(IllegalStateException.class, () -> {
+            alice.createRound3PayloadToSend(aliceKeyingMaterial);
+        });
+
+        ECJPAKERound3Payload bobRound3Payload = bob.createRound3PayloadToSend(bobKeyingMaterial);
+
+        alice.validateRound3PayloadReceived(bobRound3Payload, aliceKeyingMaterial);
+
+        assertEquals(ECJPAKEParticipant.STATE_ROUND_3_VALIDATED, alice.getState());
+
+        // validate round 3 payload twice
+        assertThrows(IllegalStateException.class, () -> {
+            alice.validateRound3PayloadReceived(bobRound3Payload, aliceKeyingMaterial);
+        });
+
+        bob.validateRound3PayloadReceived(aliceRound3Payload, bobKeyingMaterial);
+
+
+    }
+
+    @Test
+    public void testValidateRound1PayloadReceived() 
+    throws CryptoException
+    {
+
+        // We're testing alice here. Bob is just used for help.
+        ECJPAKERound1Payload bobRound1Payload = createBob().createRound1PayloadToSend();
+
+        // should succeed
+        createAlice().validateRound1PayloadReceived(bobRound1Payload);
+
+        // alice verifies alice's payload
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEParticipant alice = createAlice();
+            alice.validateRound1PayloadReceived(alice.createRound1PayloadToSend());
+        });
+
+        // g^x4 = infinity
+        ECJPAKECurve curve = ECJPAKECurves.NIST_P256;
+        assertThrows(CryptoException.class, () -> {
+            createAlice().validateRound1PayloadReceived(new ECJPAKERound1Payload(
+                bobRound1Payload.getParticipantId(),
+                bobRound1Payload.getGx1(),
+                curve.getCurve().getInfinity(),
+                bobRound1Payload.getKnowledgeProofForX1(),
+                bobRound1Payload.getKnowledgeProofForX2()));
+        });
+
+        // zero knowledge proof for x3 fails
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKERound1Payload bobRound1Payload2 = createBob().createRound1PayloadToSend();
+            createAlice().validateRound1PayloadReceived(new ECJPAKERound1Payload(
+                bobRound1Payload.getParticipantId(),
+                bobRound1Payload.getGx1(),
+                bobRound1Payload.getGx2(),
+                bobRound1Payload2.getKnowledgeProofForX1(),
+                bobRound1Payload.getKnowledgeProofForX2()));
+        });
+
+        // zero knowledge proof for x4 fails
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKERound1Payload bobRound1Payload2 = createBob().createRound1PayloadToSend();
+            createAlice().validateRound1PayloadReceived(new ECJPAKERound1Payload(
+                bobRound1Payload.getParticipantId(),
+                bobRound1Payload.getGx1(),
+                bobRound1Payload.getGx2(),
+                bobRound1Payload.getKnowledgeProofForX1(),
+                bobRound1Payload2.getKnowledgeProofForX2()));
+        });
+    }
+
+    @Test
+    public void testValidateRound2PayloadReceived() 
+    throws CryptoException
+    {
+
+        // We're testing alice here. Bob is just used for help.
+
+        // should succeed
+        ExchangeAfterRound2Creation exchange1 = runExchangeUntilRound2Creation(createAlice(), createBob());
+        exchange1.alice.validateRound2PayloadReceived(exchange1.bobRound2Payload);
+
+        // alice verifies alice's payload
+        ExchangeAfterRound2Creation exchange2 = runExchangeUntilRound2Creation(createAlice(), createBob());
+        assertThrows(CryptoException.class, () -> {
+            exchange2.alice.validateRound2PayloadReceived(exchange2.aliceRound2Payload);
+        });
+
+        // wrong z
+        ExchangeAfterRound2Creation exchange3 = runExchangeUntilRound2Creation(createAlice(), createBob());
+        ExchangeAfterRound2Creation exchange4 = runExchangeUntilRound2Creation(createAlice(), createBob());
+        assertThrows(CryptoException.class, () -> {
+            exchange3.alice.validateRound2PayloadReceived(exchange4.bobRound2Payload);
+        });
+    }
+
+    private static class ExchangeAfterRound2Creation {
+
+        public ECJPAKEParticipant alice;
+        public ECJPAKERound2Payload aliceRound2Payload;
+        public ECJPAKERound2Payload bobRound2Payload;
+
+        public ExchangeAfterRound2Creation(
+            ECJPAKEParticipant alice,
+            ECJPAKERound2Payload aliceRound2Payload,
+            ECJPAKERound2Payload bobRound2Payload)
+        {
+            this.alice = alice;
+            this.aliceRound2Payload = aliceRound2Payload;
+            this.bobRound2Payload = bobRound2Payload;
+        }
+
+    }
+
+    private ExchangeAfterRound2Creation runExchangeUntilRound2Creation(ECJPAKEParticipant alice, ECJPAKEParticipant bob) 
+    throws CryptoException
+    {
+        
+        ECJPAKERound1Payload aliceRound1Payload = alice.createRound1PayloadToSend();
+        ECJPAKERound1Payload bobRound1Payload = bob.createRound1PayloadToSend();
+
+        alice.validateRound1PayloadReceived(bobRound1Payload);
+        bob.validateRound1PayloadReceived(aliceRound1Payload);
+
+        ECJPAKERound2Payload aliceRound2Payload = alice.createRound2PayloadToSend();
+        ECJPAKERound2Payload bobRound2Payload = bob.createRound2PayloadToSend();
+
+        return new ExchangeAfterRound2Creation(
+            alice,
+            aliceRound2Payload,
+            bobRound2Payload);
+    }
+
+    private ECJPAKEParticipant createAlice()
+    {
+        return createParticipant("alice", "password");
+    }
+
+    private ECJPAKEParticipant createBob()
+    {
+        return createParticipant("bob", "password");
+    }
+
+    private ECJPAKEParticipant createBobWithWrongPassword()
+    {
+        return createParticipant("bob", "wrong");
+    }
+
+    private ECJPAKEParticipant createParticipant(String participantId, String password)
+    {
+        return new ECJPAKEParticipant(
+            participantId,
+            password.toCharArray(),
+            ECJPAKECurves.NIST_P256);
+    }
+}

--- a/core/src/test/java/org/bouncycastle/crypto/agreement/test/ECJPAKEUtilTest.java
+++ b/core/src/test/java/org/bouncycastle/crypto/agreement/test/ECJPAKEUtilTest.java
@@ -1,0 +1,199 @@
+package org.bouncycastle.crypto.agreement.test;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.CryptoException;
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.digests.SHA1Digest;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.math.ec.ECCurve;
+import org.bouncycastle.math.ec.ECPoint;
+import org.bouncycastle.math.ec.ECFieldElement;
+import org.junit.jupiter.api.Test;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKEUtil;
+import org.bouncycastle.crypto.agreement.ecjpake.ECSchnorrZKP;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKECurves;
+import org.bouncycastle.crypto.agreement.ecjpake.ECJPAKECurve;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ECJPAKEUtilTest
+{
+    private static final BigInteger TEN = BigInteger.valueOf(10);
+    private static final BigInteger ONE = BigInteger.valueOf(1);
+
+    @Test
+    public void testValidateParticipantIdsDiffer()
+    throws CryptoException
+    {
+        ECJPAKEUtil.validateParticipantIdsDiffer("a", "b");
+        ECJPAKEUtil.validateParticipantIdsDiffer("a", "A");
+
+        CryptoException exception = assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateParticipantIdsDiffer("a", "a");
+        });
+    }
+
+    @Test
+    public void testValidateParticipantIdsEqual()
+    throws CryptoException
+    {
+        ECJPAKEUtil.validateParticipantIdsEqual("a", "a");
+
+        CryptoException exception = assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateParticipantIdsEqual("a", "b");
+        });
+    }
+
+    @Test
+    public void testValidateMacTag()
+    throws CryptoException
+    {
+        ECJPAKECurve curve1 = ECJPAKECurves.NIST_P256;
+
+        SecureRandom random = new SecureRandom();
+        Digest digest = SHA256Digest.newInstance();
+
+        BigInteger x1 = ECJPAKEUtil.generateX1(curve1.getN(), random);
+        BigInteger x2 = ECJPAKEUtil.generateX1(curve1.getN(), random);
+        BigInteger x3 = ECJPAKEUtil.generateX1(curve1.getN(), random);
+        BigInteger x4 = ECJPAKEUtil.generateX1(curve1.getN(), random);
+
+        ECPoint gx1 = ECJPAKEUtil.calculateGx(curve1.getG(), x1);
+        ECPoint gx2 = ECJPAKEUtil.calculateGx(curve1.getG(), x2);
+        ECPoint gx3 = ECJPAKEUtil.calculateGx(curve1.getG(), x3);
+        ECPoint gx4 = ECJPAKEUtil.calculateGx(curve1.getG(), x4);
+
+        ECPoint gB = ECJPAKEUtil.calculateGA(gx3, gx1, gx2);
+
+        BigInteger s = ECJPAKEUtil.calculateS(curve1.getN(), "password".toCharArray());
+
+        BigInteger xs = ECJPAKEUtil.calculateX2s(curve1.getN(), x4, s);
+
+        ECPoint B = ECJPAKEUtil.calculateA(gB, xs);
+
+        BigInteger keyingMaterial = ECJPAKEUtil.calculateKeyingMaterial(curve1.getN(), gx4, x2, s, B);
+
+        BigInteger macTag = ECJPAKEUtil.calculateMacTag("participantId", "partnerParticipantId", gx1, gx2, gx3, gx4, keyingMaterial, digest);
+
+        ECJPAKEUtil.validateMacTag("partnerParticipantId", "participantId", gx3, gx4, gx1, gx2, keyingMaterial, digest, macTag);
+
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateMacTag("participantId", "partnerParticipantId", gx1, gx2, gx3, gx4, keyingMaterial, digest, macTag);
+        });
+
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateMacTag("participantId", "partnerParticipantId", gx3, gx4, gx1, gx2, keyingMaterial, digest, macTag);
+        });
+    }
+
+    @Test
+    public void testValidateNotNull()
+    throws CryptoException
+    {
+        ECJPAKEUtil.validateNotNull("a", "description");
+
+        assertThrows(NullPointerException.class, () -> {
+            ECJPAKEUtil.validateNotNull(null, "description");
+        });
+    }
+
+    public void testValidateZeroKnowledgeProof()
+    throws CryptoException
+    {
+        ECJPAKECurve curve1 = ECJPAKECurves.NIST_P256;
+
+        SecureRandom random = new SecureRandom();
+        Digest digest1 = SHA256Digest.newInstance();
+
+        BigInteger x1 = ECJPAKEUtil.generateX1(curve1.getN(), random);
+        ECPoint gx1 = ECJPAKEUtil.calculateGx(curve1.getG(), x1);
+        String participantId1 = "participant1";
+
+        ECSchnorrZKP zkp1 = ECJPAKEUtil.calculateZeroKnowledgeProof(curve1.getG(), curve1.getN(), x1, gx1, digest1, participantId1, random);
+
+        // should succeed
+        ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), gx1, zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId1, digest1);
+
+        // wrong group
+        ECJPAKECurve curve2 = ECJPAKECurves.NIST_P256; // make sure to change this to an incorrect group
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve2.getG(), gx1, zkp1, curve2.getQ(), curve2.getN(), curve2.getCurve(), curve2.getH(), participantId1, digest1);
+        });
+
+        // wrong digest
+        Digest digest2 = new SHA1Digest();
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), gx1, zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId1, digest2);
+        });
+
+        // wrong participant
+        String participantId2 = "participant2";
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), gx1, zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId2, digest1);
+        });
+
+        // wrong gx
+        BigInteger x2 = ECJPAKEUtil.generateX1(curve1.getN(), random);
+        ECPoint gx2 = ECJPAKEUtil.calculateGx(curve1.getG(), x2);
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), gx2, zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId1, digest1);
+        });
+
+
+        // wrong zkp, we need to change the zkp in some way to test if it catches it
+        ECSchnorrZKP zkp2 = ECJPAKEUtil.calculateZeroKnowledgeProof(curve1.getG(), curve1.getN(), x2, gx2, digest1, participantId1, random);        
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), gx1, zkp2, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId1, digest1);
+        });
+
+        // gx <= Infinity
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), curve1.getCurve().getInfinity(), zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId1, digest1);
+        });
+        
+        // (x,y) elements for Gx are not in Fq ie: not in [0,q-1]
+        ECCurve.Fp curve = (ECCurve.Fp) curve1.getCurve();
+        ECPoint invalidGx_1 = curve.createPoint(ONE.negate(), ONE);
+        ECPoint invalidGx_2 = curve.createPoint(ONE, ONE.negate());
+        ECPoint invalidGx_3 = curve.createPoint(curve1.getQ(), ONE);
+        ECPoint invalidGx_4 = curve.createPoint(ONE, curve1.getQ());
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), invalidGx_1, zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId1, digest1);
+        });
+
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), invalidGx_2, zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId1, digest1);
+        });
+
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), invalidGx_3, zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId1, digest1);
+        });
+
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), invalidGx_4, zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId1, digest1);
+        });
+
+        // gx is not on the curve
+        ECPoint invalidPoint = curve.createPoint(ONE, ONE);//Must come back and test this since (1,1) may exist on certain curves. Not for p256 though.
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), invalidPoint, zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId2, digest1);
+        });
+    
+        /*  gx is such that n*gx == infinity
+         *  Taking gx as any multiple of the generator G will create such a point
+        */
+
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), curve1.getG(), zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId2, digest1);
+        });
+
+        /*  V is not a point on the curve
+         *  i.e. V != G*r + X*h
+        */
+
+        assertThrows(CryptoException.class, () -> {
+            ECJPAKEUtil.validateZeroKnowledgeProof(curve1.getG(), curve.createPoint(ONE, ONE), zkp1, curve1.getQ(), curve1.getN(), curve1.getCurve(), curve1.getH(), participantId2, digest1);
+        });
+    }
+}

--- a/core/src/test/java/org/bouncycastle/crypto/agreement/test/EC_AllTests.java
+++ b/core/src/test/java/org/bouncycastle/crypto/agreement/test/EC_AllTests.java
@@ -1,0 +1,32 @@
+package org.bouncycastle.crypto.agreement.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+@SelectClasses({
+    ECJPAKEParticipantTest.class,
+    ECJPAKECurveTest.class,
+    ECJPAKEUtilTest.class
+})
+public class EC_AllTests
+{
+    @BeforeAll
+    public void setUp()
+    {
+        // Any setup logic before running the tests
+    }
+
+    @AfterAll
+    public void tearDown()
+    {
+        // Any teardown logic after running the tests
+    }
+}


### PR DESCRIPTION
Took the current JPAKE implementation in Bouncy Castle using prime order groups and adjusted it to work with elliptic curves instead, specifically curves of short-weierstrass form. 

I have included and example use case of the ecjpake implementation, as well as test files files.