### PR TITLE
Improve comparison logic during signature joining

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPublicKey.java
@@ -1227,7 +1227,8 @@ public class PGPPublicKey
             for (int i = 0; isNotNull && i < rlt.size(); i++)
             {
                 PGPSignature existingSubSig = (PGPSignature)rlt.get(i);
-                if (PGPSignature.isSignatureEncodingEqual(existingSubSig, copySubSig))
+                if (existingSubSig.getVersion() == copySubSig.getVersion() &&
+                        PGPSignature.isSignatureEncodingEqual(existingSubSig, copySubSig))
                 {
                     found = true;
                     // join existing sig with copy to apply modifications in unhashed subpackets

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -922,7 +922,13 @@ public class PGPSignature
     public static PGPSignature join(PGPSignature sig1, PGPSignature sig2)
         throws PGPException
     {
-        if (!isSignatureEncodingEqual(sig1, sig2))
+        if (sig1.getVersion() < SignaturePacket.VERSION_4) {
+            // Version 2/3 signatures have no subpackets, so don't need to get merged.
+            return sig1;
+        }
+
+        if (sig1.getVersion() != sig2.getVersion() ||
+                !isSignatureEncodingEqual(sig1, sig2))
         {
             throw new IllegalArgumentException("These are different signatures.");
         }


### PR DESCRIPTION
While playing with some tooling I built on top of BC/PGPainless, I noticed crashes when processing my whole GPG key ring (350+ keys).

Apparently the comparison code in `PGPSignature.join()` / `PGPPublicKey.join()` that checks, whether two signature objects represent the same signature is not specific enough.
I stumbled across a key, which carried two signatures with the same RSA signature value, but different signature versions (one was version 3, the other one version 4).

As a result, `PGPSignature.join()` failed when trying to merge the subpacket areas, due to v3 sigs not having subpackets, resulting in an NPE.

This patch hardens signature comparison by also taking the version number into account, and by preventing to join v2/v3 signatures.