### PR TITLE
System property for enabling GCM ciphers for FIPS

### DIFF
--- a/tls/src/main/java/org/bouncycastle/jsse/provider/FipsUtils.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/FipsUtils.java
@@ -15,7 +15,8 @@ abstract class FipsUtils
      * A.5 (when GCM is used in TLS 1.2) and a mechanism has been integrated into this API accordingly to
      * ensure that is the case.
      */
-    private static final boolean provAllowGCMCiphersIn12 = false;
+    private static final boolean provAllowGCMCiphersIn12 = PropertyUtils
+        .getBooleanSystemProperty("org.bouncycastle.jsse.fips.allowGCMCiphersIn12", false);
 
     private static final boolean provAllowRSAKeyExchange = PropertyUtils
         .getBooleanSystemProperty("org.bouncycastle.jsse.fips.allowRSAKeyExchange", false);


### PR DESCRIPTION
This property allows enabling the use of GCM ciphers with BouncyCastleJsseProvider in FIPS mode. For use by those who are certain their cryptographic provider has FIPS validated support for GCM ciphers.

For developers who are using a provider with FIPS validated support for GCM ciphers, with this commit, you can set a Java system property `org.bouncycastle.jsse.fips.allowGCMCiphersIn12` to "true" which will add GCM ciphers as defined in [FipsUtils.java](https://github.com/bcgit/bc-java/blob/main/tls/src/main/java/org/bouncycastle/jsse/provider/FipsUtils.java)


