### PR TITLE
Fix a probable a null pointer exception

### DIFF
--- a/prov/src/main/jdk1.3/org/bouncycastle/x509/ExtendedPKIXParameters.java
+++ b/prov/src/main/jdk1.3/org/bouncycastle/x509/ExtendedPKIXParameters.java
@@ -499,7 +499,6 @@ public class ExtendedPKIXParameters
     {
         if (trustedACIssuers == null)
         {
-            trustedACIssuers.clear();
             return;
         }
         for (Iterator it = trustedACIssuers.iterator(); it.hasNext();)


### PR DESCRIPTION
In file `ExtendedPKIXParameters.java`, inside method `setTrustedACIssuers`, there is a potential null pointer dereference. This is because a method is called on an object just after checking that the object is null.

https://github.com/bcgit/bc-java/blob/ada71e4cf20c990e045a57ee1d42378d84050e03/prov/src/main/jdk1.3/org/bouncycastle/x509/ExtendedPKIXParameters.java#L502

This is perhaps done by mistake. The bug was not triggered before, because the `setTrustedACIssuers` method was never called with a null `Set` in the code or in the test cases. It also appears as not intended to throw a null pointer exception deliberately. This is because JavaDoc comments note that the method may throw a `ClassCastException`, but the comments do not mention any null pointer exception. The JavaDoc says that the formal parameter should not be null, but there are no enforcement of that, and if someone wants to send a null, there is a null pointer exception.

This awkward code should be removed. The pull request suggests that removal.



**Sponsorship and Support:**

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.

