### PR TITLE
Operator fixes

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PBEKeyEncryptionMethodGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PBEKeyEncryptionMethodGenerator.java
@@ -14,8 +14,7 @@ import org.bouncycastle.util.Arrays;
  * PGP style PBE encryption method.
  * <p>
  * A pass phrase is used to generate an encryption key using the PGP {@link S2K string-to-key}
- * method. This class always uses the {@link S2K#SALTED_AND_ITERATED salted and iterated form of the
- * S2K algorithm}.
+ * method.
  * </p><p>
  * Note that the iteration count provided to this method is a single byte as described by the
  * {@link S2K} algorithm, and the actual iteration count ranges exponentially from

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPBEDataDecryptorFactory.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPBEDataDecryptorFactory.java
@@ -16,6 +16,7 @@ import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPSessionKey;
 import org.bouncycastle.openpgp.operator.PBEDataDecryptorFactory;
 import org.bouncycastle.openpgp.operator.PGPDataDecryptor;
+import org.bouncycastle.openpgp.operator.PGPDigestCalculatorProvider;
 
 /**
  * A {@link PBEDataDecryptorFactory} for handling PBE decryption operations using the Bouncy Castle
@@ -30,7 +31,7 @@ public class BcPBEDataDecryptorFactory
      * @param pass               the passphrase to use as the primary source of key material.
      * @param calculatorProvider a digest calculator provider to provide calculators to support the key generation calculation required.
      */
-    public BcPBEDataDecryptorFactory(char[] pass, BcPGPDigestCalculatorProvider calculatorProvider)
+    public BcPBEDataDecryptorFactory(char[] pass, PGPDigestCalculatorProvider calculatorProvider)
     {
         super(pass, calculatorProvider);
     }

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEKeyEncryptionMethodGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBEKeyEncryptionMethodGenerator.java
@@ -83,6 +83,11 @@ public class JcePBEKeyEncryptionMethodGenerator
         super(passPhrase, new SHA1PGPDigestCalculator(), s2kCount);
     }
 
+    public JcePBEKeyEncryptionMethodGenerator(char[] passPhrase, S2K.Argon2Params params)
+    {
+        super(passPhrase, params);
+    }
+
     /**
      * Sets the JCE provider to source cryptographic primitives from.
      *


### PR DESCRIPTION
This PR fixes small issues with the OpenPGP operator classes:
* In `BcPBEDataDecryptorFactory`, the `PGPDigestCalculatorProvider` argument was unnecessarily shadowed as `BcPGPDigestCalculatorProvider`
* `JcePBEKeyEncryptionMethodGenerator` did not expose the constructor taking Argon2 S2K parameters