### PR TITLE
Add BOM

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id("java-platform")
+    id("maven-publish")
+}
+
+description = "BouncyCastle Bill of Materials (BOM)"
+
+dependencies {
+    constraints {
+        api(project(":core"))
+        api(project(":util"))
+        api(project(":pg"))
+        api(project(":pkix"))
+        api(project(":prov"))
+        api(project(":tls"))
+        api(project(":test"))
+        api(project(":mls"))
+        api(project(":mail"))
+        api(project(":jmail"))
+    }
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId = 'org.bouncycastle'
+            artifactId = "bc-bom-$vmrange"
+            from components.javaPlatform
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
 // this needs to go here, otherwise it can't find config
 apply plugin: 'io.spring.nohttp'
 
-allprojects {
+configure(allprojects.findAll {it.name != 'bom'}) {
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'checkstyle'
@@ -183,8 +183,7 @@ ext {
 
 }
 
-
-subprojects {
+configure(subprojects.findAll {it.name != 'bom'}) {
     apply plugin: 'eclipse'
     apply plugin: 'maven-publish'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
+include "bom"
 include "core"
 include "util"
 include "pg"


### PR DESCRIPTION
I have taken a stab at trying to fix #899. This will add a new subproject to produce a [BOM](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Bill_of_Materials_.28BOM.29_POMs) which includes all the other subprojects and their versions. The published BOM can be declared in `<dependencyManagement>` in a `pom.xml` like this:

```xml
<dependency>
    <groupId>org.bouncycastle</groupId>
    <artifactId>bc-bom-jdk18on</artifactId>
    <version>1.80-SNAPSHOT</version> <!-- Replace with release version -->
    <type>pom</type>
    <scope>import</scope>
</dependency>
```
And this will ensure all BouncyCastle artifacts included in the dependency graph to be managed to the same version, even though you may not explicitly depend on them in _your_ project, and your dependencies may themselves depend on different BouncyCastle _artifacts and versions_. Example:
<img width="460" alt="m2e-dependency-hierarchy" src="https://github.com/user-attachments/assets/3f463648-5e1b-42c2-a2db-c28a89a327e9">


<details>
  <summary><strong>Resulting published POM</strong></summary>
  <p>(Omitted the various XML declarations for brevity)</p>

```xml
<project>
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.bouncycastle</groupId>
  <artifactId>bc-bom-jdk18on</artifactId>
  <version>1.80-SNAPSHOT</version>
  <packaging>pom</packaging>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>org.bouncycastle</groupId>
        <artifactId>bccore-jdk18on</artifactId>
        <version>1.80-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>org.bouncycastle</groupId>
        <artifactId>bcutil-jdk18on</artifactId>
        <version>1.80-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>org.bouncycastle</groupId>
        <artifactId>bcpg-jdk18on</artifactId>
        <version>1.80-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>org.bouncycastle</groupId>
        <artifactId>bcpkix-jdk18on</artifactId>
        <version>1.80-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>org.bouncycastle</groupId>
        <artifactId>bcprov-jdk18on</artifactId>
        <version>1.80-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>org.bouncycastle</groupId>
        <artifactId>bctls-jdk18on</artifactId>
        <version>1.80-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>bouncycastle</groupId>
        <artifactId>test</artifactId>
        <version>1.80-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>org.bouncycastle</groupId>
        <artifactId>bcmls-jdk18on</artifactId>
        <version>1.80-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>org.bouncycastle</groupId>
        <artifactId>bcmail-jdk18on</artifactId>
        <version>1.80-SNAPSHOT</version>
      </dependency>
      <dependency>
        <groupId>org.bouncycastle</groupId>
        <artifactId>bcjmail-jdk18on</artifactId>
        <version>1.80-SNAPSHOT</version>
      </dependency>
    </dependencies>
  </dependencyManagement>
</project>
```
</details>


## Questions

This is the first time I have done anything remotely involved with Gradle, so there may be better way to achieve this.

- in `bom/build.gradle`, I am listing all subproject to be included, verbatim. Should this be resolved on its own somehow?
- Since the new bom-subproject needs to be a "java-platform" artifact, and the root project sets up the "java"-plugin for all subprojects, I needed to exclude the bom from this. Should this be done in another way?
- The other projects does not seem to include a `description`. Should this be omitted in the new bom subproject as well?
- Should the artifact name `bc-bom-$vmrange` be something else, to align with existing naming conventions? E.g. `bcbom`(without a dash)? I think I would prefer e.g. `bouncycastle-bom-jdk18on`, but that may be deviating too far from existing naming.