### PR TITLE
High-Level API #0: Preparations for high-level OpenPGP Key Generator API

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyUtils.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyUtils.java
@@ -30,27 +30,26 @@ public class PublicKeyUtils
         }
     }
 
-//    /**
-//     * Return true, if the public key algorithm that corresponds to the given ID is capable of encryption.
-//     *
-//     * @param publicKeyAlgorithm public key algorithm id
-//     * @return true if algorithm can encrypt
-//     */
-//    public static boolean isEncryptionAlgorithm(int publicKeyAlgorithm)
-//    {
-//        switch (publicKeyAlgorithm)
-//        {
-//        case PublicKeyAlgorithmTags.RSA_GENERAL:
-//        case PublicKeyAlgorithmTags.RSA_ENCRYPT:
-//        case PublicKeyAlgorithmTags.ELGAMAL_ENCRYPT:
-//        case PublicKeyAlgorithmTags.ECDH:
-//        case PublicKeyAlgorithmTags.ELGAMAL_GENERAL:
-//        case PublicKeyAlgorithmTags.DIFFIE_HELLMAN:
-//        case PublicKeyAlgorithmTags.X25519:
-//        case PublicKeyAlgorithmTags.X448:
-//            return true;
-//        default:
-//            return false;
-//        }
-//    }
+    /**
+     * Return true, if the public key algorithm that corresponds to the given ID is capable of encryption.
+     * @param publicKeyAlgorithm public key algorithm id
+     * @return true if algorithm can encrypt
+     */
+    public static boolean isEncryptionAlgorithm(int publicKeyAlgorithm)
+    {
+        switch (publicKeyAlgorithm)
+        {
+        case PublicKeyAlgorithmTags.RSA_GENERAL:
+        case PublicKeyAlgorithmTags.RSA_ENCRYPT:
+        case PublicKeyAlgorithmTags.ELGAMAL_ENCRYPT:
+        case PublicKeyAlgorithmTags.ECDH:
+        case PublicKeyAlgorithmTags.ELGAMAL_GENERAL:
+        case PublicKeyAlgorithmTags.DIFFIE_HELLMAN:
+        case PublicKeyAlgorithmTags.X25519:
+        case PublicKeyAlgorithmTags.X448:
+            return true;
+        default:
+            return false;
+        }
+    }
 }

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataGenerator.java
@@ -89,6 +89,7 @@ public class PGPEncryptedDataGenerator
     // If true, force generation of a session key, even if we only have a single password-based encryption method
     //  and could therefore use the S2K output as session key directly.
     private boolean forceSessionKey = true;
+    private SessionKeyExtractionCallback sessionKeyExtractionCallback = null;
 
     /**
      * Base constructor.
@@ -178,6 +179,11 @@ public class PGPEncryptedDataGenerator
         return sessionInfo;
     }
 
+    public void setSessionKeyExtractionCallback(SessionKeyExtractionCallback callback)
+    {
+        this.sessionKeyExtractionCallback = callback;
+    }
+
     /**
      * Create an OutputStream based on the configured methods.
      * <p>
@@ -250,6 +256,11 @@ public class PGPEncryptedDataGenerator
             // prepend algorithm, append checksum
             sessionInfo = createSessionInfo(defAlgorithm, sessionKey);
             messageKey = sessionKey;
+        }
+
+        if (sessionKeyExtractionCallback != null)
+        {
+            sessionKeyExtractionCallback.extractSessionKey(new PGPSessionKey(defAlgorithm, sessionKey));
         }
 
         PGPDataEncryptor dataEncryptor = dataEncryptorBuilder.build(messageKey);
@@ -578,5 +589,10 @@ public class PGPEncryptedDataGenerator
         {
             this.finish();
         }
+    }
+
+    public interface SessionKeyExtractionCallback
+    {
+        void extractSessionKey(PGPSessionKey sessionKey);
     }
 }

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataList.java
@@ -154,6 +154,11 @@ public class PGPEncryptedDataList
         return (PGPEncryptedData)methods.get(index);
     }
 
+    public InputStreamPacket getEncryptedData()
+    {
+        return data;
+    }
+
     /**
      * Gets the number of encryption methods in this list.
      */

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRingGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPKeyRingGenerator.java
@@ -153,7 +153,7 @@ public class PGPKeyRingGenerator
         this.keySignerBuilder = keySignerBuilder;
 
         PGPSignature certSig = (PGPSignature)originalSecretRing.getPublicKey().getSignatures().next();
-        List hashedVec = new ArrayList();
+        List<SignatureSubpacket> hashedVec = new ArrayList<SignatureSubpacket>();
         PGPSignatureSubpacketVector existing = certSig.getHashedSubPackets();
         for (int i = 0; i != existing.size(); i++)
         {
@@ -164,7 +164,7 @@ public class PGPKeyRingGenerator
             hashedVec.add(existing.packets[i]);
         }
         this.hashedPcks = new PGPSignatureSubpacketVector(
-            (SignatureSubpacket[])hashedVec.toArray(new SignatureSubpacket[hashedVec.size()]));
+            hashedVec.toArray(new SignatureSubpacket[0]));
         this.unhashedPcks = certSig.getUnhashedSubPackets();
 
         keys.addAll(originalSecretRing.keys);
@@ -323,9 +323,7 @@ public class PGPKeyRingGenerator
             }
 
             sGen.setUnhashedSubpackets(unhashedPcks);
-
-            List subSigs = new ArrayList();
-
+            List<PGPSignature> subSigs = new ArrayList<PGPSignature>();
             subSigs.add(sGen.generateCertification(primaryKey.getPublicKey(), keyPair.getPublicKey()));
 
             // replace the public key packet structure with a public subkey one.
@@ -362,14 +360,14 @@ public class PGPKeyRingGenerator
      */
     public PGPPublicKeyRing generatePublicKeyRing()
     {
-        Iterator it = keys.iterator();
-        List pubKeys = new ArrayList();
+        Iterator<PGPSecretKey> it = keys.iterator();
+        List<PGPPublicKey> pubKeys = new ArrayList<PGPPublicKey>();
 
-        pubKeys.add(((PGPSecretKey)it.next()).getPublicKey());
+        pubKeys.add((it.next()).getPublicKey());
 
         while (it.hasNext())
         {
-            pubKeys.add(((PGPSecretKey)it.next()).getPublicKey());
+            pubKeys.add((it.next()).getPublicKey());
         }
 
         return new PGPPublicKeyRing(pubKeys);

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketGenerator.java
@@ -649,9 +649,9 @@ public class PGPSignatureSubpacketGenerator
     public boolean hasSubpacket(
         int type)
     {
-        for (int i = 0; i != packets.size(); i++)
+        for (SignatureSubpacket packet : packets)
         {
-            if (((SignatureSubpacket)packets.get(i)).getType() == type)
+            if (packet.getType() == type)
             {
                 return true;
             }
@@ -670,17 +670,17 @@ public class PGPSignatureSubpacketGenerator
     public SignatureSubpacket[] getSubpackets(
         int type)
     {
-        List list = new ArrayList();
+        List<SignatureSubpacket> list = new ArrayList<>();
 
-        for (int i = 0; i != packets.size(); i++)
+        for (SignatureSubpacket packet : packets)
         {
-            if (((SignatureSubpacket)packets.get(i)).getType() == type)
+            if (packet.getType() == type)
             {
-                list.add(packets.get(i));
+                list.add(packet);
             }
         }
 
-        return (SignatureSubpacket[])list.toArray(new SignatureSubpacket[]{});
+        return list.toArray(new SignatureSubpacket[0]);
     }
 
     public PGPSignatureSubpacketVector generate()
@@ -691,9 +691,9 @@ public class PGPSignatureSubpacketGenerator
 
     private boolean contains(int type)
     {
-        for (int i = 0; i < packets.size(); ++i)
+        for (SignatureSubpacket packet : packets)
         {
-            if (((SignatureSubpacket)packets.get(i)).getType() == type)
+            if (packet.getType() == type)
             {
                 return true;
             }

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketVector.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketVector.java
@@ -116,7 +116,7 @@ public class PGPSignatureSubpacketVector
     public SignatureSubpacket[] getSubpackets(
         int type)
     {
-        List list = new ArrayList();
+        List<SignatureSubpacket> list = new ArrayList<>();
 
         for (int i = 0; i != packets.length; i++)
         {
@@ -126,20 +126,20 @@ public class PGPSignatureSubpacketVector
             }
         }
 
-        return (SignatureSubpacket[])list.toArray(new SignatureSubpacket[]{});
+        return list.toArray(new SignatureSubpacket[0]);
     }
 
     public PGPSignatureList getEmbeddedSignatures()
         throws PGPException
     {
         SignatureSubpacket[] sigs = getSubpackets(SignatureSubpacketTags.EMBEDDED_SIGNATURE);
-        ArrayList l = new ArrayList();
+        ArrayList<PGPSignature> l = new ArrayList<>();
 
-        for (int i = 0; i < sigs.length; i++)
+        for (SignatureSubpacket sig : sigs)
         {
             try
             {
-                l.add(new PGPSignature(SignaturePacket.fromByteArray(sigs[i].getData())));
+                l.add(new PGPSignature(SignaturePacket.fromByteArray(sig.getData())));
             }
             catch (IOException e)
             {
@@ -147,7 +147,7 @@ public class PGPSignatureSubpacketVector
             }
         }
 
-        return new PGPSignatureList((PGPSignature[])l.toArray(new PGPSignature[l.size()]));
+        return new PGPSignatureList(l.toArray(new PGPSignature[0]));
     }
 
     public NotationData[] getNotationDataOccurrences()
@@ -179,7 +179,7 @@ public class PGPSignatureSubpacketVector
     public NotationData[] getNotationDataOccurrences(String notationName)
     {
         NotationData[] notations = getNotationDataOccurrences();
-        List<NotationData> notationsWithName = new ArrayList<NotationData>();
+        List<NotationData> notationsWithName = new ArrayList<>();
         for (int i = 0; i != notations.length; i++)
         {
             NotationData notation = notations[i];
@@ -188,7 +188,7 @@ public class PGPSignatureSubpacketVector
                 notationsWithName.add(notation);
             }
         }
-        return (NotationData[])notationsWithName.toArray(new NotationData[0]);
+        return notationsWithName.toArray(new NotationData[0]);
     }
 
     public long getIssuerKeyID()

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/AEADSecretKeyEncryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/AEADSecretKeyEncryptorBuilder.java
@@ -1,0 +1,21 @@
+package org.bouncycastle.openpgp.operator;
+
+import org.bouncycastle.bcpg.PublicKeyPacket;
+
+/**
+ * Implementation provider for AEAD-based {@link PBESecretKeyEncryptor PBESecretKeyEncryptors}.
+ */
+public interface AEADSecretKeyEncryptorBuilder
+{
+    /**
+     * Build a new {@link PBESecretKeyEncryptor} using the given passphrase.
+     * Note: As the AEAD protection mechanism includes the public key packet of the key into the calculation,
+     * if the key you want to protect is supposed to be a subkey, you need to convert it to one <b>before</b>
+     * calling this method. See {@link org.bouncycastle.openpgp.PGPKeyPair#asSubkey(KeyFingerPrintCalculator)}.
+     *
+     * @param passphrase passphrase
+     * @param pubKey public primary or subkey packet
+     * @return encryptor using AEAD
+     */
+    PBESecretKeyEncryptor build(char[] passphrase, PublicKeyPacket pubKey);
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PBESecretKeyDecryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PBESecretKeyDecryptorBuilder.java
@@ -1,0 +1,9 @@
+package org.bouncycastle.openpgp.operator;
+
+import org.bouncycastle.openpgp.PGPException;
+
+public interface PBESecretKeyDecryptorBuilder
+{
+    PBESecretKeyDecryptor build(char[] passphrase)
+            throws PGPException;
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PBESecretKeyDecryptorBuilderProvider.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PBESecretKeyDecryptorBuilderProvider.java
@@ -1,0 +1,15 @@
+package org.bouncycastle.openpgp.operator;
+
+import org.bouncycastle.openpgp.PGPException;
+
+/**
+ * Provider for {@link PBESecretKeyDecryptorBuilder} instances.
+ * The purpose of this class is to act as an abstract factory, whose subclasses can decide, which concrete
+ * implementation of {@link PBESecretKeyDecryptorBuilder} (builder for objects that can unlock encrypted
+ * secret keys) to return.
+ */
+public interface PBESecretKeyDecryptorBuilderProvider
+{
+    PBESecretKeyDecryptorBuilder provide()
+            throws PGPException;
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PGPAEADDataEncryptor.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PGPAEADDataEncryptor.java
@@ -4,8 +4,7 @@ package org.bouncycastle.openpgp.operator;
 /**
  * A data encryptor, using AEAD.
  * There are two different flavours of AEAD encryption used with OpenPGP.
- * OpenPGP v5 AEAD is slightly different from v6 AEAD.
- * <p>
+ * LibrePGP (v5) AEAD is slightly different from RFC9580 (v6) AEAD.
  * {@link PGPAEADDataEncryptor} instances are generally not constructed directly, but obtained from a
  * {@link PGPDataEncryptorBuilder}.
  * </p>

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcAEADSecretKeyEncryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcAEADSecretKeyEncryptorBuilder.java
@@ -8,9 +8,11 @@ import org.bouncycastle.bcpg.PacketTags;
 import org.bouncycastle.bcpg.PublicKeyPacket;
 import org.bouncycastle.bcpg.S2K;
 import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.operator.AEADSecretKeyEncryptorBuilder;
 import org.bouncycastle.openpgp.operator.PBESecretKeyEncryptor;
 
 public class BcAEADSecretKeyEncryptorBuilder
+        implements AEADSecretKeyEncryptorBuilder
 {
 
     private int aeadAlgorithm;

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPBESecretKeyDecryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPBESecretKeyDecryptorBuilder.java
@@ -3,9 +3,11 @@ package org.bouncycastle.openpgp.operator.bc;
 import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptor;
+import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptorBuilder;
 import org.bouncycastle.openpgp.operator.PGPDigestCalculatorProvider;
 
 public class BcPBESecretKeyDecryptorBuilder
+        implements PBESecretKeyDecryptorBuilder
 {
     private PGPDigestCalculatorProvider calculatorProvider;
 

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPBESecretKeyDecryptorBuilderProvider.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/bc/BcPBESecretKeyDecryptorBuilderProvider.java
@@ -1,0 +1,14 @@
+package org.bouncycastle.openpgp.operator.bc;
+
+import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptorBuilder;
+import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptorBuilderProvider;
+
+public class BcPBESecretKeyDecryptorBuilderProvider
+        implements PBESecretKeyDecryptorBuilderProvider
+{
+    @Override
+    public PBESecretKeyDecryptorBuilder provide()
+    {
+        return new BcPBESecretKeyDecryptorBuilder(new BcPGPDigestCalculatorProvider());
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaAEADSecretKeyEncryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaAEADSecretKeyEncryptorBuilder.java
@@ -13,9 +13,11 @@ import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
 import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
 import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
 import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.operator.AEADSecretKeyEncryptorBuilder;
 import org.bouncycastle.openpgp.operator.PBESecretKeyEncryptor;
 
 public class JcaAEADSecretKeyEncryptorBuilder
+        implements AEADSecretKeyEncryptorBuilder
 {
     private int aeadAlgorithm;
     private int symmetricAlgorithm;

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyDecryptorBuilder.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyDecryptorBuilder.java
@@ -15,9 +15,11 @@ import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPUtil;
 import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptor;
+import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptorBuilder;
 import org.bouncycastle.openpgp.operator.PGPDigestCalculatorProvider;
 
 public class JcePBESecretKeyDecryptorBuilder
+        implements PBESecretKeyDecryptorBuilder
 {
     private OperatorHelper helper = new OperatorHelper(new DefaultJcaJceHelper());
     private PGPDigestCalculatorProvider calculatorProvider;

--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyDecryptorBuilderProvider.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcePBESecretKeyDecryptorBuilderProvider.java
@@ -1,0 +1,23 @@
+package org.bouncycastle.openpgp.operator.jcajce;
+
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptorBuilder;
+import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptorBuilderProvider;
+
+public class JcePBESecretKeyDecryptorBuilderProvider
+        implements PBESecretKeyDecryptorBuilderProvider
+{
+    private final JcaPGPDigestCalculatorProviderBuilder digestCalculatorProviderBuilder;
+
+    public JcePBESecretKeyDecryptorBuilderProvider(JcaPGPDigestCalculatorProviderBuilder digestCalculatorProviderBuilder)
+    {
+        this.digestCalculatorProviderBuilder = digestCalculatorProviderBuilder;
+    }
+
+    @Override
+    public PBESecretKeyDecryptorBuilder provide()
+            throws PGPException
+    {
+        return new JcePBESecretKeyDecryptorBuilder(digestCalculatorProviderBuilder.build());
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/bcpg/test/AbstractPacketTest.java
+++ b/pg/src/test/java/org/bouncycastle/bcpg/test/AbstractPacketTest.java
@@ -118,7 +118,7 @@ public abstract class AbstractPacketTest
      */
     public void isNotNull(Object value)
     {
-        isNotNull("Value is not null.", value);
+        isNotNull("Value is null.", value);
     }
 
     /**


### PR DESCRIPTION
This is part 1 of the split-up patch adding a high-level key generator API.
This one is focussed on changes required in `/openpgp/`, `/openpgp/operator/` and `/bcpg/`.

It also contains the fix from #1882 (the test will be included in the second PR).