### PR TITLE
Fix symmetric v6 message encryption

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/operator/PBEKeyEncryptionMethodGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/operator/PBEKeyEncryptionMethodGenerator.java
@@ -201,7 +201,7 @@ public abstract class PBEKeyEncryptionMethodGenerator
         return SymmetricKeyEncSessionPacket.createV5Packet(kekAlgorithm, aeadAlgorithm, iv, s2k, esk, tag);
     }
 
-    private ContainedPacket generateV6ESK(int kekAlgorithm, int aeadAlgorithm, byte[] sessionKey)
+    private ContainedPacket generateV6ESK(int kekAlgorithm, int aeadAlgorithm, byte[] sessionInfo)
         throws PGPException
     {
         byte[] ikm = getKey(kekAlgorithm);
@@ -217,6 +217,7 @@ public abstract class PBEKeyEncryptionMethodGenerator
         random.nextBytes(iv);
 
         int tagLen = AEADUtils.getAuthTagLength(aeadAlgorithm);
+        byte[] sessionKey = getSessionKey(sessionInfo);
         byte[] eskAndTag = getEskAndTag(kekAlgorithm, aeadAlgorithm, sessionKey, kek, iv, info);
         byte[] esk = Arrays.copyOfRange(eskAndTag, 0, eskAndTag.length - tagLen);
         byte[] tag = Arrays.copyOfRange(eskAndTag, esk.length, eskAndTag.length);


### PR DESCRIPTION
Commits 7d95b08316f0edf5773b0ea062694ed4b0e2b6ef and ea316319d029e9e1215c44e980509b3bf898cf05 introduced an error where the plain session key was passed in the wrong format causing the session-key wrapper to fail due to an invalid block size.