### PR TITLE
Make CompositePrivateKey::getAlgorithm() consistent with CompositePublicKey::getAlgorithm()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ codesigning.jks
 /prov/src/main/core/
 
 bc-build.user.properties
+
+.DS_Store

--- a/pkix/src/main/java/org/bouncycastle/cms/DefaultCMSSignatureAlgorithmNameGenerator.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/DefaultCMSSignatureAlgorithmNameGenerator.java
@@ -247,6 +247,9 @@ public class DefaultCMSSignatureAlgorithmNameGenerator
         addSimpleAlg(NISTObjectIdentifiers.id_hash_slh_dsa_shake_256s_with_shake256, "SLH-DSA-SHAKE-256S-WITH-SHAKE256");
         addSimpleAlg(NISTObjectIdentifiers.id_hash_slh_dsa_shake_256f_with_shake256, "SLH-DSA-SHAKE-256F-WITH-SHAKE256");
 
+        addSimpleAlg(MiscObjectIdentifiers.id_MLDSA44_ECDSA_P256_SHA256, "MLDSA44-ECDSA-P256-SHA256");
+        addSimpleAlg(MiscObjectIdentifiers.id_MLDSA87_ECDSA_P384_SHA384, "MLDSA87-ECDSA-P384-SHA384");
+
         addSimpleAlg(BCObjectIdentifiers.picnic_signature, "Picnic");
     }
 

--- a/pkix/src/main/java/org/bouncycastle/operator/DefaultDigestAlgorithmIdentifierFinder.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/DefaultDigestAlgorithmIdentifierFinder.java
@@ -14,6 +14,7 @@ import org.bouncycastle.asn1.cryptopro.CryptoProObjectIdentifiers;
 import org.bouncycastle.asn1.eac.EACObjectIdentifiers;
 import org.bouncycastle.asn1.edec.EdECObjectIdentifiers;
 import org.bouncycastle.asn1.gm.GMObjectIdentifiers;
+import org.bouncycastle.asn1.misc.MiscObjectIdentifiers;
 import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
@@ -167,6 +168,11 @@ public class DefaultDigestAlgorithmIdentifierFinder
         digestOids.put(NISTObjectIdentifiers.id_hash_ml_dsa_44_with_sha512, NISTObjectIdentifiers.id_sha512);
         digestOids.put(NISTObjectIdentifiers.id_hash_ml_dsa_65_with_sha512, NISTObjectIdentifiers.id_sha512);
         digestOids.put(NISTObjectIdentifiers.id_hash_ml_dsa_87_with_sha512, NISTObjectIdentifiers.id_sha512);
+
+        //technically these are non-pre-hash composites so MLDSA hashes with SHAKE and ECDSA with SHAxxx
+        //but for experimental we use this, more correct would be to define this only for prehash composites
+        digestOids.put(MiscObjectIdentifiers.id_MLDSA44_ECDSA_P256_SHA256, NISTObjectIdentifiers.id_sha256);
+        digestOids.put(MiscObjectIdentifiers.id_MLDSA87_ECDSA_P384_SHA384, NISTObjectIdentifiers.id_sha384);
 
         digestOids.put(BCObjectIdentifiers.falcon, NISTObjectIdentifiers.id_shake256);
         digestOids.put(BCObjectIdentifiers.falcon_512, NISTObjectIdentifiers.id_shake256);

--- a/prov/src/main/java/org/bouncycastle/jcajce/CompositePrivateKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/CompositePrivateKey.java
@@ -108,7 +108,7 @@ public class CompositePrivateKey implements PrivateKey
 
     public String getAlgorithm()
     {
-        return this.algorithmIdentifier.getId();
+        return CompositeIndex.getAlgorithmName(this.algorithmIdentifier);
     }
 
     public ASN1ObjectIdentifier getAlgorithmIdentifier()


### PR DESCRIPTION
Minor modification. A composite private key returns an OID as a result of getAlgorithm() but a composite public key returns a "human readable name".