### PR TITLE
Make CompositePrivateKey::getAlgorithm() consistent with CompositePublicKey::getAlgorithm()

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/CompositePrivateKey.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/CompositePrivateKey.java
@@ -108,7 +108,7 @@ public class CompositePrivateKey implements PrivateKey
 
     public String getAlgorithm()
     {
-        return this.algorithmIdentifier.getId();
+        return CompositeIndex.getAlgorithmName(this.algorithmIdentifier);
     }
 
     public ASN1ObjectIdentifier getAlgorithmIdentifier()


### PR DESCRIPTION
Minor modification. A composite private key returns an OID as a result of getAlgorithm() but a composite public key returns a "human readable name."