### PR TITLE
Mechanism to configure AES-GCM in TLS 1.2 with custom nonce generator

### DIFF
--- a/tls/src/main/java/org/bouncycastle/jsse/provider/GcmTls12NonceGeneratorUtil.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/GcmTls12NonceGeneratorUtil.java
@@ -1,0 +1,25 @@
+package org.bouncycastle.jsse.provider;
+
+import org.bouncycastle.tls.crypto.TlsNonceGenerator;
+
+final public class GcmTls12NonceGeneratorUtil
+{
+    private static TlsNonceGeneratorFactory tlsNonceGeneratorFactory = null;
+
+    public static void setGcmTlsNonceGeneratorFactory(final TlsNonceGeneratorFactory factory)
+    {
+        tlsNonceGeneratorFactory = factory;
+    }
+
+    public static boolean isGcmFipsNonceGeneratorFactorySet()
+    {
+        return tlsNonceGeneratorFactory != null;
+    }
+
+    public static TlsNonceGenerator createGcmFipsNonceGenerator(final byte[] baseNonce, final int counterSizeInBits)
+    {
+        return tlsNonceGeneratorFactory != null
+                ? tlsNonceGeneratorFactory.create(baseNonce, counterSizeInBits)
+                : null;
+    }
+}

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/TlsNonceGeneratorFactory.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/TlsNonceGeneratorFactory.java
@@ -1,0 +1,8 @@
+package org.bouncycastle.jsse.provider;
+
+import org.bouncycastle.tls.crypto.TlsNonceGenerator;
+
+public interface TlsNonceGeneratorFactory
+{
+    TlsNonceGenerator create(byte[] baseNonce, int counterSizeInBits);
+}

--- a/tls/src/test/java/org/bouncycastle/tls/test/AllTests.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/AllTests.java
@@ -1,5 +1,6 @@
 package org.bouncycastle.tls.test;
 
+import org.bouncycastle.jsse.provider.GcmTls12NonceGeneratorUtil;
 import org.bouncycastle.test.PrintTestResult;
 
 import junit.extensions.TestSetup;
@@ -14,6 +15,13 @@ public class AllTests
         throws Exception
     {
         PrintTestResult.printResult(junit.textui.TestRunner.run(suite()));
+        PrintTestResult.printResult(junit.textui.TestRunner.run(suiteWithCustomNonceGeneratorForTls12()));
+    }
+
+    public static Test suiteWithCustomNonceGeneratorForTls12() throws Exception
+    {
+        GcmTls12NonceGeneratorUtil.setGcmTlsNonceGeneratorFactory(TestTlsNonceGeneratorFactory.INSTANCE);
+        return suite();
     }
 
     public static Test suite()

--- a/tls/src/test/java/org/bouncycastle/tls/test/TestNonceGenerator.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/TestNonceGenerator.java
@@ -1,0 +1,51 @@
+package org.bouncycastle.tls.test;
+
+import org.bouncycastle.tls.crypto.TlsNonceGenerator;
+
+import java.util.Arrays;
+
+class TestNonceGenerator implements TlsNonceGenerator
+{
+    private final byte[] baseNonce;
+    private final long counterMask;
+    private final int counterBytes;
+
+    private long counterValue;
+    private boolean counterExhausted;
+
+    TestNonceGenerator(final byte[] baseNonce, final int counterBits)
+    {
+        this.baseNonce = Arrays.copyOf(baseNonce, baseNonce.length);
+        this.counterMask = -1L >>> (64 - counterBits);
+        this.counterBytes = (counterBits + 7) / 8;
+
+        this.counterValue = 0L;
+        this.counterExhausted = false;
+    }
+
+    @Override
+    public byte[] generateNonce(final int size)
+    {
+        if (size != baseNonce.length)
+        {
+            throw new IllegalArgumentException("requested length is not equal to the length of the base nonce.");
+        }
+
+        if (counterExhausted)
+        {
+            throw new IllegalStateException("TLS nonce generator exhausted");
+        }
+
+        final byte[] nonce = Arrays.copyOf(baseNonce, baseNonce.length);
+        final int offset = baseNonce.length - counterBytes;
+
+        for (int i = 0; i < counterBytes; i++)
+        {
+            nonce[offset + i] ^= (byte)(counterValue >>> ((counterBytes - 1 - i) * 8));
+        }
+
+        counterExhausted |= ((++counterValue & counterMask) == 0);
+
+        return nonce;
+    }
+}

--- a/tls/src/test/java/org/bouncycastle/tls/test/TestTlsNonceGeneratorFactory.java
+++ b/tls/src/test/java/org/bouncycastle/tls/test/TestTlsNonceGeneratorFactory.java
@@ -1,0 +1,19 @@
+package org.bouncycastle.tls.test;
+
+import org.bouncycastle.jsse.provider.TlsNonceGeneratorFactory;
+import org.bouncycastle.tls.crypto.TlsNonceGenerator;
+
+class TestTlsNonceGeneratorFactory implements TlsNonceGeneratorFactory {
+    public static final TlsNonceGeneratorFactory INSTANCE = new TestTlsNonceGeneratorFactory();
+
+    private TestTlsNonceGeneratorFactory()
+    {
+        // no op
+    }
+
+    @Override
+    public TlsNonceGenerator create(final byte[] baseNonce, final int counterSizeInBits)
+    {
+        return new TestNonceGenerator(baseNonce, counterSizeInBits);
+    }
+}


### PR DESCRIPTION
This code enables a builder to override the default nonce generator class for BouncyCastleJsseProvider. For developers who wish to use an alternative provider which exposes its nonce generator.