### PR TITLE
Abstract core KEM functionality out of DHKEM 2/2

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/hpke/HPKE.java
+++ b/core/src/main/java/org/bouncycastle/crypto/hpke/HPKE.java
@@ -70,6 +70,25 @@ public class HPKE
 
     }
 
+    public HPKE(byte mode, short kemId, short kdfId, short aeadId, KEM kem, int encSize)
+    {
+        this.mode = mode;
+        this.kemId = kemId;
+        this.kdfId = kdfId;
+        this.aeadId = aeadId;
+        this.hkdf = new HKDF(kdfId);
+        this.kem = kem;
+        if (aeadId == aead_AES_GCM128)
+        {
+            Nk = 16;
+        }
+        else
+        {
+            Nk = 32;
+        }
+        this.encSize = encSize;
+    }
+
     public int getEncSize()
     {
         return kem.getEncryptionSize();


### PR DESCRIPTION
This change was missed in the initial port of #1664. Without this change, customers cannot provide a non-DH KEM