### PR TITLE
SecretKeyPacket: Properly pass newPacketFormat down to PublicKeyPacket

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SecretKeyPacket.java
@@ -146,11 +146,11 @@ public class SecretKeyPacket
 
         if (this instanceof SecretSubkeyPacket)
         {
-            pubKeyPacket = new PublicSubkeyPacket(in);
+            pubKeyPacket = new PublicSubkeyPacket(in, newPacketFormat);
         }
         else
         {
-            pubKeyPacket = new PublicKeyPacket(in);
+            pubKeyPacket = new PublicKeyPacket(in, newPacketFormat);
         }
 
         int version = pubKeyPacket.getVersion();
@@ -342,7 +342,7 @@ public class SecretKeyPacket
         byte[] iv,
         byte[] secKeyData)
     {
-        super(keyTag);
+        super(keyTag, pubKeyPacket.hasNewPacketFormat());
 
         this.pubKeyPacket = pubKeyPacket;
         this.encAlgorithm = encAlgorithm;


### PR DESCRIPTION
When parsing a `PGPSecretKeyRing` from a PGPObjectFactory and comparing its encoding, I noticed that the packet format of the public key component was erroneously set to use the legacy packet format, although the test vector was using the new format.

The cause of this issue was, that the newPacketFormat flag was not passed down to the PubicKeyPacket constructor from within the SecretKeyPacket constructor.