### PR TITLE
Suppress Lint Warning in getTrustAllTrustManager()

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/est/jcajce/JcaJceUtils.java
+++ b/pkix/src/main/java/org/bouncycastle/est/jcajce/JcaJceUtils.java
@@ -35,6 +35,7 @@ import org.bouncycastle.cert.X509CertificateHolder;
 public class JcaJceUtils
 {
 
+    @SuppressWarnings("TrustAllX509TrustManager")
     public static X509TrustManager getTrustAllTrustManager()
     {
 


### PR DESCRIPTION
This PR suppresses the unnecessary Lint warning for getTrustAllTrustManager() in org.bouncycastle.est.jcajce.JcaJceUtils. Since this method is required for RFC 7030 compliance, adding @SuppressLint("TrustAllX509TrustManager") prevents unnecessary warnings without affecting security.
Changes:
- Annotated getTrustAllTrustManager() with @SuppressWarnings("TrustAllX509TrustManager").

Let me know if further changes are needed. Thanks!