### PR TITLE
PGPSignatureSubpacketGenerator: setXYZ() now removes duplicates.

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignatureSubpacketGenerator.java
@@ -69,10 +69,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setRevocable(boolean isCritical, boolean isRevocable)
     {
-        if (contains(SignatureSubpacketTags.REVOCABLE))
-        {
-            throw new IllegalStateException("Revocable exists in the Signature Subpacket Generator");
-        }
+        removePacketsOfType(SignatureSubpacketTags.REVOCABLE);
         packets.add(new Revocable(isCritical, isRevocable));
     }
 
@@ -97,10 +94,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setExportable(boolean isCritical, boolean isExportable)
     {
-        if (contains(SignatureSubpacketTags.EXPORTABLE))
-        {
-            throw new IllegalStateException("Exportable Certification exists in the Signature Subpacket Generator");
-        }
+        removePacketsOfType(SignatureSubpacketTags.EXPORTABLE);
         packets.add(new Exportable(isCritical, isExportable));
     }
 
@@ -108,10 +102,11 @@ public class PGPSignatureSubpacketGenerator
      * Specify the set of features of the key.
      *
      * @param isCritical true if should be treated as critical, false otherwise.
-     * @param feature    features
+     * @param feature    features bitmap
      */
     public void setFeature(boolean isCritical, byte feature)
     {
+        removePacketsOfType(SignatureSubpacketTags.FEATURES);
         packets.add(new Features(isCritical, feature));
     }
 
@@ -126,6 +121,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setTrust(boolean isCritical, int depth, int trustAmount)
     {
+        removePacketsOfType(SignatureSubpacketTags.TRUST_SIG);
         packets.add(new TrustSignature(isCritical, depth, trustAmount));
     }
 
@@ -150,6 +146,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setKeyExpirationTime(boolean isCritical, long seconds)
     {
+        removePacketsOfType(SignatureSubpacketTags.KEY_EXPIRE_TIME);
         packets.add(new KeyExpirationTime(isCritical, seconds));
     }
 
@@ -175,6 +172,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setSignatureExpirationTime(boolean isCritical, long seconds)
     {
+        removePacketsOfType(SignatureSubpacketTags.EXPIRE_TIME);
         packets.add(new SignatureExpirationTime(isCritical, seconds));
     }
 
@@ -200,6 +198,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setSignatureCreationTime(boolean isCritical, Date date)
     {
+        removePacketsOfType(SignatureSubpacketTags.CREATION_TIME);
         packets.add(new SignatureCreationTime(isCritical, date));
     }
 
@@ -212,6 +211,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setPreferredHashAlgorithms(boolean isCritical, int[] algorithms)
     {
+        removePacketsOfType(SignatureSubpacketTags.PREFERRED_HASH_ALGS);
         packets.add(new PreferredAlgorithms(SignatureSubpacketTags.PREFERRED_HASH_ALGS, isCritical,
             algorithms));
     }
@@ -225,6 +225,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setPreferredSymmetricAlgorithms(boolean isCritical, int[] algorithms)
     {
+        removePacketsOfType(SignatureSubpacketTags.PREFERRED_SYM_ALGS);
         packets.add(new PreferredAlgorithms(SignatureSubpacketTags.PREFERRED_SYM_ALGS, isCritical,
             algorithms));
     }
@@ -238,6 +239,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setPreferredCompressionAlgorithms(boolean isCritical, int[] algorithms)
     {
+        removePacketsOfType(SignatureSubpacketTags.PREFERRED_COMP_ALGS);
         packets.add(new PreferredAlgorithms(SignatureSubpacketTags.PREFERRED_COMP_ALGS, isCritical,
             algorithms));
     }
@@ -254,6 +256,7 @@ public class PGPSignatureSubpacketGenerator
     @Deprecated
     public void setPreferredAEADAlgorithms(boolean isCritical, int[] algorithms)
     {
+        removePacketsOfType(SignatureSubpacketTags.PREFERRED_AEAD_ALGORITHMS);
         packets.add(new PreferredAlgorithms(SignatureSubpacketTags.PREFERRED_AEAD_ALGORITHMS, isCritical,
             algorithms));
     }
@@ -268,6 +271,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setPreferredAEADCiphersuites(boolean isCritical, PreferredAEADCiphersuites.Combination[] algorithms)
     {
+        removePacketsOfType(SignatureSubpacketTags.PREFERRED_AEAD_ALGORITHMS);
         packets.add(new PreferredAEADCiphersuites(isCritical, algorithms));
     }
 
@@ -280,6 +284,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setPreferredAEADCiphersuites(PreferredAEADCiphersuites.Builder builder)
     {
+        removePacketsOfType(SignatureSubpacketTags.PREFERRED_AEAD_ALGORITHMS);
         packets.add(builder.build());
     }
 
@@ -300,6 +305,7 @@ public class PGPSignatureSubpacketGenerator
     @Deprecated
     public void setPreferredLibrePgpEncryptionModes(boolean isCritical, int[] algorithms)
     {
+        removePacketsOfType(SignatureSubpacketTags.LIBREPGP_PREFERRED_ENCRYPTION_MODES);
         packets.add(new LibrePGPPreferredEncryptionModes(isCritical, algorithms));
     }
 
@@ -309,8 +315,22 @@ public class PGPSignatureSubpacketGenerator
      *
      * @param isCritical true if the subpacket should be treated as critical
      * @param uri        key server URI
+     * @deprecated use {@link #addPreferredKeyServer(boolean, String)} instead.
      */
+    @Deprecated
     public void setPreferredKeyServer(boolean isCritical, String uri)
+    {
+        addPreferredKeyServer(isCritical, uri);
+    }
+
+    /**
+     * Specify a preferred key server for the signed user-id / key.
+     * Note, that the key server might also be a http/ftp etc. URI pointing to the key itself.
+     *
+     * @param isCritical true if the subpacket should be treated as critical
+     * @param uri        key server URI
+     */
+    public void addPreferredKeyServer(boolean isCritical, String uri)
     {
         packets.add(new PreferredKeyServer(isCritical, uri));
     }
@@ -341,6 +361,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setKeyFlags(boolean isCritical, int flags)
     {
+        removePacketsOfType(SignatureSubpacketTags.KEY_FLAGS);
         packets.add(new KeyFlags(isCritical, flags));
     }
 
@@ -443,6 +464,7 @@ public class PGPSignatureSubpacketGenerator
 
     public void setPrimaryUserID(boolean isCritical, boolean isPrimaryUserID)
     {
+        removePacketsOfType(SignatureSubpacketTags.PRIMARY_USER_ID);
         packets.add(new PrimaryUserID(isCritical, isPrimaryUserID));
     }
 
@@ -485,6 +507,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setRevocationReason(boolean isCritical, byte reason, String description)
     {
+        removePacketsOfType(SignatureSubpacketTags.REVOCATION_REASON);
         packets.add(new RevocationReason(isCritical, reason, description));
     }
 
@@ -523,6 +546,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setIssuerKeyID(boolean isCritical, long keyID)
     {
+        removePacketsOfType(SignatureSubpacketTags.ISSUER_KEY_ID);
         packets.add(new IssuerKeyID(isCritical, keyID));
     }
 
@@ -536,6 +560,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setSignatureTarget(boolean isCritical, int publicKeyAlgorithm, int hashAlgorithm, byte[] hashData)
     {
+        removePacketsOfType(SignatureSubpacketTags.SIGNATURE_TARGET);
         packets.add(new SignatureTarget(isCritical, publicKeyAlgorithm, hashAlgorithm, hashData));
     }
 
@@ -558,6 +583,7 @@ public class PGPSignatureSubpacketGenerator
      */
     public void setIssuerFingerprint(boolean isCritical, PGPPublicKey publicKey)
     {
+        removePacketsOfType(SignatureSubpacketTags.ISSUER_FINGERPRINT);
         packets.add(new IssuerFingerprint(isCritical, publicKey.getVersion(), publicKey.getFingerprint()));
     }
 


### PR DESCRIPTION
Prior to this chance, calling e.g. setKeyFlags() on a subpacket generator that already contained key flags would introduce a duplicate key flag subpacket. I fixed this behavior by changing all setXYZ() methods to first remove any packet occurrences of the same type.
NOTE: This breaks the current behavior of setRevocable() and setExportable(), as these method previously did a check to see if another packet of the same type was present and threw an IllegalArgumentException. Now, no such exception is thrown and instead the later method invocation takes precedence.

NOTE: If you rely on duplicate packets (e.g. in your tests), you can still introduce duplicates by adding the duplicate packet via addCustomSubpacket(YourPacket).

The motivation behind this change is, that in the `OpenPGPKeyGenerator` API it is not obvious, that for correctly setting
custom key flags on a key, you first need to remove those key flags set by BC by default. Now the API should be straight forward and be doing exactly what the user expects.