### PR TITLE
fix bug in SecretKeyUtil

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/util/SecretKeyUtil.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/util/SecretKeyUtil.java
@@ -11,28 +11,28 @@ import org.bouncycastle.util.Integers;
 
 public class SecretKeyUtil
 {
-    private static Map keySizes = new HashMap();
+    private static Map<ASN1ObjectIdentifier, Integer> keySizes = new HashMap<>();
 
     static
     {
-        keySizes.put(PKCSObjectIdentifiers.des_EDE3_CBC.getId(), Integers.valueOf(192));
+        keySizes.put(PKCSObjectIdentifiers.des_EDE3_CBC, 192);
 
-        keySizes.put(NISTObjectIdentifiers.id_aes128_CBC, Integers.valueOf(128));
-        keySizes.put(NISTObjectIdentifiers.id_aes192_CBC, Integers.valueOf(192));
-        keySizes.put(NISTObjectIdentifiers.id_aes256_CBC, Integers.valueOf(256));
+        keySizes.put(NISTObjectIdentifiers.id_aes128_CBC, 128);
+        keySizes.put(NISTObjectIdentifiers.id_aes192_CBC, 192);
+        keySizes.put(NISTObjectIdentifiers.id_aes256_CBC, 256);
 
-        keySizes.put(NTTObjectIdentifiers.id_camellia128_cbc, Integers.valueOf(128));
-        keySizes.put(NTTObjectIdentifiers.id_camellia192_cbc, Integers.valueOf(192));
-        keySizes.put(NTTObjectIdentifiers.id_camellia256_cbc, Integers.valueOf(256));
+        keySizes.put(NTTObjectIdentifiers.id_camellia128_cbc, 128);
+        keySizes.put(NTTObjectIdentifiers.id_camellia192_cbc, 192);
+        keySizes.put(NTTObjectIdentifiers.id_camellia256_cbc, 256);
     }
 
     public static int getKeySize(ASN1ObjectIdentifier oid)
     {
-        Integer size = (Integer)keySizes.get(oid);
+        Integer size = keySizes.get(oid);
 
         if (size != null)
         {
-            return size.intValue();
+            return size;
         }
 
         return -1;

--- a/prov/src/test/java/org/bouncycastle/jcajce/provider/test/RandomTest.java
+++ b/prov/src/test/java/org/bouncycastle/jcajce/provider/test/RandomTest.java
@@ -2,7 +2,6 @@ package org.bouncycastle.jcajce.provider.test;
 
 import java.security.SecureRandom;
 
-import junit.framework.Assert;
 import junit.framework.TestCase;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
@@ -18,7 +17,7 @@ public class RandomTest
 
         random.nextBytes(rng);
 
-        Assert.assertTrue(checkNonConstant(rng));
+        assertTrue(checkNonConstant(rng));
     }
 
     public void testCheckNonceIVRandom()
@@ -30,7 +29,7 @@ public class RandomTest
 
         random.nextBytes(rng);
 
-        Assert.assertTrue(checkNonConstant(rng));
+        assertTrue(checkNonConstant(rng));
     }
 
     private boolean checkNonConstant(byte[] data)

--- a/prov/src/test/java/org/bouncycastle/jcajce/provider/util/test/AllTests.java
+++ b/prov/src/test/java/org/bouncycastle/jcajce/provider/util/test/AllTests.java
@@ -1,0 +1,48 @@
+package org.bouncycastle.jcajce.provider.util.test;
+
+import junit.extensions.TestSetup;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.test.PrintTestResult;
+
+import java.security.Security;
+
+public class AllTests
+    extends TestCase
+{
+    public static void main(String[] args)
+    {
+
+        PrintTestResult.printResult(junit.textui.TestRunner.run(suite()));
+    }
+
+    public static Test suite()
+    {
+        TestSuite suite = new TestSuite("JCAJCE Provider Util Tests");
+
+        suite.addTestSuite(SecretKeyUtilTest.class);
+
+        return new BCTestSetup(suite);
+    }
+
+    static class BCTestSetup
+        extends TestSetup
+    {
+        public BCTestSetup(Test test)
+        {
+            super(test);
+        }
+
+        protected void setUp()
+        {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+
+        protected void tearDown()
+        {
+            Security.removeProvider("BC");
+        }
+    }
+}

--- a/prov/src/test/java/org/bouncycastle/jcajce/provider/util/test/SecretKeyUtilTest.java
+++ b/prov/src/test/java/org/bouncycastle/jcajce/provider/util/test/SecretKeyUtilTest.java
@@ -1,0 +1,12 @@
+package org.bouncycastle.jcajce.provider.util.test;
+
+import junit.framework.TestCase;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.jcajce.provider.util.SecretKeyUtil;
+
+public class SecretKeyUtilTest extends TestCase {
+
+    public void testgetKeySize() {
+        assertEquals(192, SecretKeyUtil.getKeySize(PKCSObjectIdentifiers.des_EDE3_CBC));
+    }
+}


### PR DESCRIPTION
found a bug (ID string was added to map, not the ASN1ObjectIdentifier), but is this class even used?