### PR TITLE
fix: correct AsconCXof128 impl and add tests with ascon-c vectors

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/digests/AsconBaseDigest.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/AsconBaseDigest.java
@@ -53,6 +53,7 @@ abstract class AsconBaseDigest
     {
         p.x0 ^= loadBytes(m_buf, 0, m_bufPos) ^ pad(m_bufPos);
         p.p(12);
+        m_bufPos = 0;
     }
 
     protected void squeeze(byte[] output, int outOff, int len)

--- a/core/src/main/java/org/bouncycastle/crypto/digests/AsconCXof128.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/AsconCXof128.java
@@ -125,8 +125,7 @@ public class AsconCXof128
     private void initState(byte[] z, int zOff, int zLen)
     {
         p.set(7445901275803737603L, 4886737088792722364L, -1616759365661982283L, 3076320316797452470L, -8124743304765850554L);
-        long bitLength = ((long)zLen) << 3;
-        Pack.longToLittleEndian(bitLength, m_buf, 0);
+        p.x0 ^= ((long)zLen) << 3;
         p.p(12);
         update(z, zOff, zLen);
         padAndAbsorb();


### PR DESCRIPTION
The AsconCXof128 algorithm now correctly processes Z0 data, with test code added and validated using ascon-c test vectors.