### PR TITLE
SHA1Digest should not be cloned to MD5Digest

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/util/DigestFactory.java
+++ b/core/src/main/java/org/bouncycastle/crypto/util/DigestFactory.java
@@ -20,7 +20,7 @@ import org.bouncycastle.crypto.digests.SHAKEDigest;
  */
 public final class DigestFactory
 {
-    private static final Map cloneMap = new HashMap();
+    private static final Map<String, Cloner> cloneMap = new HashMap<>();
 
     private static interface Cloner
     {
@@ -29,92 +29,20 @@ public final class DigestFactory
 
     static
     {
-        cloneMap.put(createMD5().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new MD5Digest((MD5Digest)original);
-            }
-        });
-        cloneMap.put(createSHA1().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new MD5Digest((MD5Digest)original);
-            }
-        });
-        cloneMap.put(createSHA224().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new SHA224Digest((SHA224Digest)original);
-            }
-        });
-        cloneMap.put(createSHA256().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return SHA256Digest.newInstance(original);
-            }
-        });
-        cloneMap.put(createSHA384().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new SHA384Digest((SHA384Digest)original);
-            }
-        });
-        cloneMap.put(createSHA512().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new SHA512Digest((SHA512Digest)original);
-            }
-        });
-        cloneMap.put(createSHA3_224().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new SHA3Digest((SHA3Digest)original);
-            }
-        });
-        cloneMap.put(createSHA3_256().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new SHA3Digest((SHA3Digest)original);
-            }
-        });
-        cloneMap.put(createSHA3_384().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new SHA3Digest((SHA3Digest)original);
-            }
-        });
-        cloneMap.put(createSHA3_512().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new SHA3Digest((SHA3Digest)original);
-            }
-        });
+        cloneMap.put(createMD5().getAlgorithmName(), original -> new MD5Digest((MD5Digest)original));
+        cloneMap.put(createSHA1().getAlgorithmName(), original -> new SHA1Digest((SHA1Digest)original));
+        cloneMap.put(createSHA224().getAlgorithmName(), original -> new SHA224Digest((SHA224Digest)original));
+        cloneMap.put(createSHA256().getAlgorithmName(), SHA256Digest::newInstance);
+        cloneMap.put(createSHA384().getAlgorithmName(), original -> new SHA384Digest((SHA384Digest)original));
+        cloneMap.put(createSHA512().getAlgorithmName(), original -> new SHA512Digest((SHA512Digest)original));
+        cloneMap.put(createSHA3_224().getAlgorithmName(), original -> new SHA3Digest((SHA3Digest)original));
+        cloneMap.put(createSHA3_256().getAlgorithmName(), original -> new SHA3Digest((SHA3Digest)original));
+        cloneMap.put(createSHA3_384().getAlgorithmName(), original -> new SHA3Digest((SHA3Digest)original));
+        cloneMap.put(createSHA3_512().getAlgorithmName(), original -> new SHA3Digest((SHA3Digest)original));
 
-        cloneMap.put(createSHAKE128().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new SHAKEDigest((SHAKEDigest)original);
-            }
-        });
+        cloneMap.put(createSHAKE128().getAlgorithmName(), original -> new SHAKEDigest((SHAKEDigest)original));
 
-        cloneMap.put(createSHAKE256().getAlgorithmName(), new Cloner()
-        {
-            public Digest createClone(Digest original)
-            {
-                return new SHAKEDigest((SHAKEDigest)original);
-            }
-        });
+        cloneMap.put(createSHAKE256().getAlgorithmName(), original -> new SHAKEDigest((SHAKEDigest)original));
     }
 
     public static Digest createMD5()
@@ -249,6 +177,6 @@ public final class DigestFactory
 
     public static Digest cloneDigest(Digest hashAlg)
     {
-        return ((Cloner)cloneMap.get(hashAlg.getAlgorithmName())).createClone(hashAlg);
+        return cloneMap.get(hashAlg.getAlgorithmName()).createClone(hashAlg);
     }
 }


### PR DESCRIPTION
Maybe I'm wrong, but it looks like a bug to me if cloning a "SHA-1" digest results in an Md5Digest