### PR TITLE
provide parametrized types for generics

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/anssi/ANSSINamedCurves.java
+++ b/core/src/main/java/org/bouncycastle/asn1/anssi/ANSSINamedCurves.java
@@ -64,9 +64,9 @@ public class ANSSINamedCurves
     };
 
 
-    static final Hashtable objIds = new Hashtable();
-    static final Hashtable curves = new Hashtable();
-    static final Hashtable names = new Hashtable();
+    static final Hashtable<String, ASN1ObjectIdentifier> objIds = new Hashtable<>();
+    static final Hashtable<ASN1ObjectIdentifier, X9ECParametersHolder> curves = new Hashtable<>();
+    static final Hashtable<ASN1ObjectIdentifier, String> names = new Hashtable<>();
 
     static void defineCurve(String name, ASN1ObjectIdentifier oid, X9ECParametersHolder holder)
     {
@@ -106,7 +106,7 @@ public class ANSSINamedCurves
 
     public static X9ECParametersHolder getByOIDLazy(ASN1ObjectIdentifier oid)
     {
-        return (X9ECParametersHolder)curves.get(oid);
+        return curves.get(oid);
     }
 
     /**
@@ -115,10 +115,9 @@ public class ANSSINamedCurves
      *
      * @return the object identifier associated with name, if present.
      */
-    public static ASN1ObjectIdentifier getOID(
-        String name)
+    public static ASN1ObjectIdentifier getOID(String name)
     {
-        return (ASN1ObjectIdentifier)objIds.get(Strings.toLowerCase(name));
+        return objIds.get(Strings.toLowerCase(name));
     }
 
     /**
@@ -127,7 +126,7 @@ public class ANSSINamedCurves
     public static String getName(
         ASN1ObjectIdentifier oid)
     {
-        return (String)names.get(oid);
+        return names.get(oid);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/cryptopro/ECGOST3410NamedCurves.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cryptopro/ECGOST3410NamedCurves.java
@@ -42,6 +42,7 @@ public class ECGOST3410NamedCurves
      */
     static X9ECParametersHolder gostR3410_2001_CryptoPro_A = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             BigInteger mod_p = fromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD97");
@@ -72,6 +73,7 @@ public class ECGOST3410NamedCurves
      */
     static X9ECParametersHolder gostR3410_2001_CryptoPro_B = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             BigInteger mod_p = fromHex("8000000000000000000000000000000000000000000000000000000000000C99");
@@ -102,6 +104,7 @@ public class ECGOST3410NamedCurves
      */
     static X9ECParametersHolder gostR3410_2001_CryptoPro_C = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             BigInteger mod_p = fromHex("9B9F605F5A858107AB1EC85E6B41C8AACF846E86789051D37998F7B9022D759B");
@@ -132,6 +135,7 @@ public class ECGOST3410NamedCurves
      */
     static X9ECParametersHolder id_tc26_gost_3410_12_256_paramSetA = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             BigInteger mod_p = fromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD97");
@@ -162,6 +166,7 @@ public class ECGOST3410NamedCurves
      */
     static X9ECParametersHolder id_tc26_gost_3410_12_512_paramSetA = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             BigInteger mod_p = fromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDC7");
@@ -192,6 +197,7 @@ public class ECGOST3410NamedCurves
      */
     static X9ECParametersHolder id_tc26_gost_3410_12_512_paramSetB = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             BigInteger mod_p = fromHex("8000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006F");
@@ -222,6 +228,7 @@ public class ECGOST3410NamedCurves
      */
     static X9ECParametersHolder id_tc26_gost_3410_12_512_paramSetC = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             BigInteger mod_p = fromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDC7");
@@ -248,9 +255,9 @@ public class ECGOST3410NamedCurves
     };
 
 
-    static final Hashtable objIds = new Hashtable();
-    static final Hashtable curves = new Hashtable();
-    static final Hashtable names = new Hashtable();
+    static final Hashtable<String, ASN1ObjectIdentifier> objIds = new Hashtable<>();
+    static final Hashtable<ASN1ObjectIdentifier, X9ECParametersHolder> curves = new Hashtable<>();
+    static final Hashtable<ASN1ObjectIdentifier, String> names = new Hashtable<>();
 
     static void defineCurve(String name, ASN1ObjectIdentifier oid, X9ECParametersHolder holder)
     {
@@ -295,12 +302,12 @@ public class ECGOST3410NamedCurves
 
     public static X9ECParametersHolder getByOIDLazy(ASN1ObjectIdentifier oid)
     {
-        return (X9ECParametersHolder)curves.get(oid);
+        return curves.get(oid);
     }
 
     public static ASN1ObjectIdentifier getOID(String name)
     {
-        return (ASN1ObjectIdentifier)objIds.get(name);
+        return objIds.get(name);
     }
 
     /**
@@ -309,7 +316,7 @@ public class ECGOST3410NamedCurves
     public static String getName(
         ASN1ObjectIdentifier  oid)
     {
-        return (String)names.get(oid);
+        return names.get(oid);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/gm/GMNamedCurves.java
+++ b/core/src/main/java/org/bouncycastle/asn1/gm/GMNamedCurves.java
@@ -65,6 +65,7 @@ public class GMNamedCurves
 
     static X9ECParametersHolder wapip192v1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             BigInteger p = fromHex("BDB6F4FE3E8B1D9E0DA8C0D46F4C318CEFE4AFE3B6B8551F");
@@ -89,9 +90,9 @@ public class GMNamedCurves
     };
 
 
-    static final Hashtable objIds = new Hashtable();
-    static final Hashtable curves = new Hashtable();
-    static final Hashtable names = new Hashtable();
+    static final Hashtable<String, ASN1ObjectIdentifier> objIds = new Hashtable<>();
+    static final Hashtable<ASN1ObjectIdentifier, X9ECParametersHolder> curves = new Hashtable<>();
+    static final Hashtable<ASN1ObjectIdentifier, String> names = new Hashtable<>();
 
     static void defineCurve(String name, ASN1ObjectIdentifier oid, X9ECParametersHolder holder)
     {
@@ -133,7 +134,7 @@ public class GMNamedCurves
 
     public static X9ECParametersHolder getByOIDLazy(ASN1ObjectIdentifier oid)
     {
-        return (X9ECParametersHolder)curves.get(oid);
+        return curves.get(oid);
     }
 
     /**
@@ -145,7 +146,7 @@ public class GMNamedCurves
     public static ASN1ObjectIdentifier getOID(
         String name)
     {
-        return (ASN1ObjectIdentifier)objIds.get(Strings.toLowerCase(name));
+        return objIds.get(Strings.toLowerCase(name));
     }
 
     /**
@@ -154,7 +155,7 @@ public class GMNamedCurves
     public static String getName(
         ASN1ObjectIdentifier oid)
     {
-        return (String)names.get(oid);
+        return names.get(oid);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/nist/NISTNamedCurves.java
+++ b/core/src/main/java/org/bouncycastle/asn1/nist/NISTNamedCurves.java
@@ -15,8 +15,8 @@ import org.bouncycastle.util.Strings;
  */
 public class NISTNamedCurves
 {
-    static final Hashtable objIds = new Hashtable();
-    static final Hashtable names = new Hashtable();
+    static final Hashtable<String, ASN1ObjectIdentifier> objIds = new Hashtable<>();
+    static final Hashtable<ASN1ObjectIdentifier, String> names = new Hashtable<>();
 
     static void defineCurve(String name, ASN1ObjectIdentifier oid)
     {
@@ -79,7 +79,7 @@ public class NISTNamedCurves
      */
     public static ASN1ObjectIdentifier getOID(String name)
     {
-        return (ASN1ObjectIdentifier)objIds.get(Strings.toUpperCase(name));
+        return objIds.get(Strings.toUpperCase(name));
     }
 
     /**
@@ -87,7 +87,7 @@ public class NISTNamedCurves
      */
     public static String getName(ASN1ObjectIdentifier oid)
     {
-        return (String)names.get(oid);
+        return names.get(oid);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/crypto/ec/CustomNamedCurves.java
+++ b/core/src/main/java/org/bouncycastle/crypto/ec/CustomNamedCurves.java
@@ -76,6 +76,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder curve25519 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new Curve25519());
@@ -107,6 +108,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp128r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecP128R1Curve());
@@ -127,6 +129,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp160k1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             GLVTypeBParameters glv = new GLVTypeBParameters(
@@ -160,6 +163,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp160r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecP160R1Curve());
@@ -180,6 +184,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp160r2 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecP160R2Curve());
@@ -200,6 +205,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp192k1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             GLVTypeBParameters glv = new GLVTypeBParameters(
@@ -233,6 +239,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp192r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecP192R1Curve());
@@ -253,6 +260,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp224k1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             GLVTypeBParameters glv = new GLVTypeBParameters(
@@ -286,6 +294,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp224r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecP224R1Curve());
@@ -306,6 +315,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp256k1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             GLVTypeBParameters glv = new GLVTypeBParameters(
@@ -339,6 +349,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp256r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecP256R1Curve());
@@ -359,6 +370,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp384r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecP384R1Curve());
@@ -380,6 +392,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder secp521r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecP521R1Curve());
@@ -401,6 +414,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect113r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT113R1Curve());
@@ -421,6 +435,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect113r2 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT113R2Curve());
@@ -441,6 +456,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect131r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT131R1Curve());
@@ -461,6 +477,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect131r2 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT131R2Curve());
@@ -481,6 +498,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect163k1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT163K1Curve());
@@ -501,6 +519,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect163r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT163R1Curve());
@@ -521,6 +540,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect163r2 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT163R2Curve());
@@ -541,6 +561,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect193r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT193R1Curve());
@@ -561,6 +582,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect193r2 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT193R2Curve());
@@ -581,6 +603,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect233k1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT233K1Curve());
@@ -601,6 +624,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect233r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT233R1Curve());
@@ -621,6 +645,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect239k1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT239K1Curve());
@@ -641,6 +666,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect283k1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT283K1Curve());
@@ -662,6 +688,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect283r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT283R1Curve());
@@ -683,6 +710,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect409k1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT409K1Curve());
@@ -704,6 +732,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect409r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT409R1Curve());
@@ -725,6 +754,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect571k1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT571K1Curve());
@@ -746,6 +776,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sect571r1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SecT571R1Curve());
@@ -767,6 +798,7 @@ public class CustomNamedCurves
      */
     static X9ECParametersHolder sm2p256v1 = new X9ECParametersHolder()
     {
+        @Override
         protected ECCurve createCurve()
         {
             return configureCurve(new SM2P256V1Curve());
@@ -783,11 +815,11 @@ public class CustomNamedCurves
     };
 
 
-    static final Hashtable nameToCurve = new Hashtable();
-    static final Hashtable nameToOID = new Hashtable();
-    static final Hashtable oidToCurve = new Hashtable();
-    static final Hashtable oidToName = new Hashtable();
-    static final Vector names = new Vector();
+    static final Hashtable<String, X9ECParametersHolder> nameToCurve = new Hashtable<>();
+    static final Hashtable<String, ASN1ObjectIdentifier> nameToOID = new Hashtable<>();
+    static final Hashtable<ASN1ObjectIdentifier, X9ECParametersHolder> oidToCurve = new Hashtable<>();
+    static final Hashtable<ASN1ObjectIdentifier, String> oidToName = new Hashtable<>();
+    static final Vector<String> names = new Vector<>();
 
     static void defineCurve(String name, X9ECParametersHolder holder)
     {
@@ -808,7 +840,7 @@ public class CustomNamedCurves
 
     static void defineCurveAlias(String name, ASN1ObjectIdentifier oid)
     {
-        Object curve = oidToCurve.get(oid);
+        X9ECParametersHolder curve = oidToCurve.get(oid);
         if (curve == null)
         {
             throw new IllegalStateException();
@@ -887,7 +919,7 @@ public class CustomNamedCurves
 
     public static X9ECParametersHolder getByNameLazy(String name)
     {
-        return (X9ECParametersHolder)nameToCurve.get(Strings.toLowerCase(name));
+        return nameToCurve.get(Strings.toLowerCase(name));
     }
 
     /**
@@ -905,7 +937,7 @@ public class CustomNamedCurves
 
     public static X9ECParametersHolder getByOIDLazy(ASN1ObjectIdentifier oid)
     {
-        return (X9ECParametersHolder)oidToCurve.get(oid);
+        return oidToCurve.get(oid);
     }
 
     /**
@@ -916,7 +948,7 @@ public class CustomNamedCurves
      */
     public static ASN1ObjectIdentifier getOID(String name)
     {
-        return (ASN1ObjectIdentifier)nameToOID.get(Strings.toLowerCase(name));
+        return nameToOID.get(Strings.toLowerCase(name));
     }
 
     /**
@@ -924,7 +956,7 @@ public class CustomNamedCurves
      */
     public static String getName(ASN1ObjectIdentifier oid)
     {
-        return (String)oidToName.get(oid);
+        return oidToName.get(oid);
     }
 
     /**


### PR DESCRIPTION
The use of generics in the BC code base varies a lot. In many cases, raw types are still used. I think they can be parameterized without causing harm to existing code bases.

What do you think? If you are interested, I can provide a large PR with changes like the ones in this example PR.