### PR TITLE
Keep PBMAC1s PBKDF2 PRF when initializing from protectionAlgorithm.

### DIFF
--- a/pkix/src/main/java/org/bouncycastle/pkcs/jcajce/JcePBMac1CalculatorBuilder.java
+++ b/pkix/src/main/java/org/bouncycastle/pkcs/jcajce/JcePBMac1CalculatorBuilder.java
@@ -187,6 +187,7 @@ public class JcePBMac1CalculatorBuilder
                 salt = pbeParams.getSalt();
                 iterationCount = BigIntegers.intValueExact(pbeParams.getIterationCount());
                 keySize = BigIntegers.intValueExact(pbeParams.getKeyLength()) * 8;
+                prf = pbeParams.getPrf();
             }
             
             SecretKeyFactory secFact = helper.createSecretKeyFactory("PBKDF2");

--- a/pkix/src/test/java/org/bouncycastle/pkcs/test/PBETest.java
+++ b/pkix/src/test/java/org/bouncycastle/pkcs/test/PBETest.java
@@ -3,9 +3,17 @@ package org.bouncycastle.pkcs.test;
 import java.security.Security;
 
 import junit.framework.TestCase;
+
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
+import org.bouncycastle.asn1.pkcs.PBKDF2Params;
+import org.bouncycastle.asn1.pkcs.PBMAC1Params;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.MacCalculator;
+import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.pkcs.jcajce.JcePBMac1CalculatorBuilder;
+import org.bouncycastle.pkcs.jcajce.JcePBMac1CalculatorProviderBuilder;
 import org.bouncycastle.util.Strings;
 import org.bouncycastle.util.encoders.Hex;
 
@@ -29,4 +37,21 @@ public class PBETest
         assertEquals("55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc", Hex.toHexString((byte[])pbCalculator.getKey().getRepresentation()));
 
     }
+
+    void testPbmac1PrfPropagation() throws OperatorCreationException {
+        AlgorithmIdentifier prf = new AlgorithmIdentifier(NISTObjectIdentifiers.id_hmacWithSHA3_512, null);;
+        AlgorithmIdentifier protectionAlgorithm = new AlgorithmIdentifier(PKCSObjectIdentifiers.id_PBMAC1,
+            new PBMAC1Params(
+                new AlgorithmIdentifier(PKCSObjectIdentifiers.id_PBKDF2, new PBKDF2Params("salt".getBytes(), 1234, 64, prf)),
+                new AlgorithmIdentifier(NISTObjectIdentifiers.id_hmacWithSHA3_512, null)
+            )
+        );
+        MacCalculator calculator = new JcePBMac1CalculatorProviderBuilder()
+                .setProvider(new BouncyCastleProvider()).build().get(protectionAlgorithm, "foobar123".toCharArray());
+        AlgorithmIdentifier actualPrf = PBKDF2Params.getInstance(
+            PBMAC1Params.getInstance(calculator.getKey().getAlgorithmIdentifier().getParameters()).getKeyDerivationFunc().getParameters()
+        ).getPrf();
+        System.out.println("Should be true: " + prf.equals(actualPrf));
+    }
+
 }


### PR DESCRIPTION
(Contributed under the Bouncy Caste License.)

Even though HMAC with SHA3-512 is requested for both PRF and MAC using `JcePBMac1CalculatorProviderBuilder`, the default PRF is used.

ASN.1 example dump:

```
 0 128: SEQUENCE {
  3   9:   OBJECT IDENTIFIER pkcs5PBMAC1 (1 2 840 113549 1 5 14)
 14 115:   SEQUENCE {
 16 100:     SEQUENCE {
 18   9:       OBJECT IDENTIFIER pkcs5PBES2 (1 2 840 113549 1 5 13)
 29  87:       SEQUENCE {
 31  64:         OCTET STRING
       :           61 20 73 61 6C 74 20 73 61 6C 74 79 20 73 61 6C
       :           74 79 20 73 61 6C 74 79 20 73 61 6C 74 79 20 73
       :           61 6C 74 79 20 73 61 6C 74 79 20 73 61 6C 74 79
       :           20 73 61 6C 74 79 20 73 61 6C 74 2D 73 61 6C 74
 97   2:         INTEGER 1024
101   1:         INTEGER 64
104  12:         SEQUENCE {
106   8:           OBJECT IDENTIFIER hmacWithSHA256 (1 2 840 113549 2 9)
116   0:           NULL
       :           }
       :         }
       :       }
118  11:     SEQUENCE {
120   9:       OBJECT IDENTIFIER '2 16 840 1 101 3 4 2 16'
       :       }
       :     }
       :   }
```

This also breaks for example PBMAC1 validation of CMP in EJBCA for any other alg than `hmacWithSHA256`.