### PR TITLE
Signature Packet format fixes

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
@@ -398,7 +398,7 @@ public class SignaturePacket
             byte[]                  signatureEncoding,
             byte[]                  salt)
     {
-        super(SIGNATURE);
+        super(SIGNATURE, true);
 
         this.version = version;
         this.signatureType = signatureType;
@@ -428,7 +428,7 @@ public class SignaturePacket
         MPInteger[] signature,
         byte[] salt)
     {
-        super(SIGNATURE);
+        super(SIGNATURE, true);
 
         this.version = version;
         this.signatureType = signatureType;

--- a/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
@@ -353,7 +353,22 @@ public class SignaturePacket
         byte[]                  fingerPrint,
         MPInteger[]             signature)
     {
-        super(SIGNATURE);
+        this(version, false, signatureType, keyID, keyAlgorithm, hashAlgorithm, hashedData, unhashedData, fingerPrint, signature);
+    }
+
+    public SignaturePacket(
+            int                     version,
+            boolean                 hasNewPacketFormat,
+            int                     signatureType,
+            long                    keyID,
+            int                     keyAlgorithm,
+            int                     hashAlgorithm,
+            SignatureSubpacket[]    hashedData,
+            SignatureSubpacket[]    unhashedData,
+            byte[]                  fingerPrint,
+            MPInteger[]             signature)
+    {
+        super(SIGNATURE, hasNewPacketFormat);
 
         this.version = version;
         this.signatureType = signatureType;

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -198,7 +198,7 @@ public class PGPSignature
      */
     public static final int THIRD_PARTY_CONFIRMATION = 0x50;
 
-    private final SignaturePacket sigPck;
+    final SignaturePacket sigPck;
     private final TrustPacket trustPck;
 
     private volatile PGPContentVerifier verifier;
@@ -1034,6 +1034,8 @@ public class PGPSignature
         SignatureSubpacket[] unhashed = (SignatureSubpacket[])merged.toArray(new SignatureSubpacket[0]);
         return new PGPSignature(
             new SignaturePacket(
+                sig1.getVersion(),
+                sig1.sigPck.hasNewPacketFormat(),
                 sig1.getSignatureType(),
                 sig1.getKeyID(),
                 sig1.getKeyAlgorithm(),


### PR DESCRIPTION
This PR does:
* Fix `PGPSignature.join()` to retain the signature packet length encoding format of the base signature. Previously, the merged result signature object would have its packet length format forced to `LEGACY`, no matter what the input signatures were encoded with. This would result in mismatches when doing comparisons between encodings in PGPainless' tests.
* Fix `PGPSignatureSubpacketGenerator.addEmbeddedSignature()` to retrieve the encoding of the embedded signature in legacy format. Otherwise, signatures using the new packet length encoding format, which might have a different header length would result in broken embedded sigs, since the wrong number of header bytes would be cut stripped off.
* Set the packet length encoding format of salted (= recently specified) signatures to the new packet format. This is done in an effort to begin phasing out producing the legacy packet length format.