### PR TITLE
OpenPGP: Mitigate some RuntimeExceptions uncovered using Fuzzing

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/AEADEncDataPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/AEADEncDataPacket.java
@@ -47,7 +47,15 @@ public class AEADEncDataPacket
         aeadAlgorithm = (byte)in.read();
         chunkSize = (byte)in.read();
 
-        iv = new byte[AEADUtils.getIVLength(aeadAlgorithm)];
+        try
+        {
+            int ivLen = AEADUtils.getIVLength(aeadAlgorithm);
+            iv = new byte[ivLen];
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new MalformedPacketException("Unknown AEAD algorithm ID: " + aeadAlgorithm, e);
+        }
         in.readFully(iv);
     }
 

--- a/pg/src/main/java/org/bouncycastle/bcpg/AEADEncDataPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/AEADEncDataPacket.java
@@ -40,7 +40,7 @@ public class AEADEncDataPacket
         version = (byte)in.read();
         if (version != VERSION_1)
         {
-            throw new UnsupportedPacketVersionException("wrong AEAD packet version: " + version);
+            throw new UnsupportedPacketVersionException("Unknown AEAD packet version: " + version);
         }
 
         algorithm = (byte)in.read();

--- a/pg/src/main/java/org/bouncycastle/bcpg/ECDHPublicBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ECDHPublicBCPGKey.java
@@ -36,12 +36,11 @@ public class ECDHPublicBCPGKey
         super(in);
 
         int length = in.read();
-        byte[] kdfParameters = new byte[length];
-        if (kdfParameters.length != 3)
+        if (length != 3)
         {
-            throw new IllegalStateException("kdf parameters size of 3 expected.");
+            throw new MalformedPacketException("KDF parameters size of 3 expected.");
         }
-
+        byte[] kdfParameters = new byte[length];
         in.readFully(kdfParameters);
 
         reserved = kdfParameters[0];

--- a/pg/src/main/java/org/bouncycastle/bcpg/LiteralDataPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/LiteralDataPacket.java
@@ -31,6 +31,10 @@ public class LiteralDataPacket
 
         format = in.read();
         int    l = in.read();
+        if (l < 0)
+        {
+            throw new MalformedPacketException("File name size cannot be negative.");
+        }
 
         fileName = new byte[l];
         for (int i = 0; i != fileName.length; i++)

--- a/pg/src/main/java/org/bouncycastle/bcpg/MalformedPacketException.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/MalformedPacketException.java
@@ -1,0 +1,23 @@
+package org.bouncycastle.bcpg;
+
+import java.io.IOException;
+
+public class MalformedPacketException
+    extends IOException
+{
+
+    public MalformedPacketException(String message)
+    {
+        super(message);
+    }
+
+    public MalformedPacketException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public MalformedPacketException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/pg/src/main/java/org/bouncycastle/bcpg/OctetArrayBCPGKey.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/OctetArrayBCPGKey.java
@@ -10,11 +10,16 @@ public abstract class OctetArrayBCPGKey
     extends BCPGObject
     implements BCPGKey
 {
+    public static int MAX_LEN = 2 * 1024 * 1024; // 2mb; McEliece keys can get ~1mb in size, so allow some margin
     private final byte[] key;
 
     OctetArrayBCPGKey(int length, BCPGInputStream in)
         throws IOException
     {
+        if (length > MAX_LEN)
+        {
+            throw new IOException("Max key length (" + MAX_LEN + ") exceeded (" + length + ")");
+        }
         key = new byte[length];
         in.readFully(key);
     }

--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyEncSessionPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyEncSessionPacket.java
@@ -55,6 +55,10 @@ public class PublicKeyEncSessionPacket
         else if (version == VERSION_6)
         {
             int keyInfoLen = in.read();
+            if (keyInfoLen < 0)
+            {
+                throw new MalformedPacketException("Key Info Length cannot be negative: " + keyInfoLen);
+            }
             if (keyInfoLen == 0)
             {
                 // anon recipient

--- a/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/PublicKeyPacket.java
@@ -150,6 +150,10 @@ public class PublicKeyPacket
         {
             // TODO: Use keyOctets to be able to parse unknown keys
             keyOctets = StreamUtil.read4OctetLength(in);
+            if (keyOctets < 0)
+            {
+                throw new MalformedPacketException("Octet length cannot be negative.");
+            }
         }
 
         parseKey(in, algorithm, keyOctets);

--- a/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
@@ -176,11 +176,26 @@ public class SignaturePacket
             SignatureSubpacket p = (SignatureSubpacket)vec.elementAt(i);
             if (p instanceof IssuerKeyID)
             {
-                keyID = ((IssuerKeyID)p).getKeyID();
+                try
+                {
+                    keyID = ((IssuerKeyID) p).getKeyID();
+                }
+                catch (IllegalArgumentException e)
+                {
+                    // Too short key-id
+                    throw new MalformedPacketException("Malformed IssuerKeyId subpacket.", e);
+                }
             }
             else if (p instanceof SignatureCreationTime)
             {
-                creationTime = ((SignatureCreationTime)p).getTime().getTime();
+                try
+                {
+                    creationTime = ((SignatureCreationTime) p).getTime().getTime();
+                }
+                catch (IllegalStateException e)
+                {
+                    throw new MalformedPacketException("Malformed SignatureCreationTime subpacket.", e);
+                }
             }
 
             hashedData[i] = p;

--- a/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignaturePacket.java
@@ -18,6 +18,8 @@ import org.bouncycastle.util.io.Streams;
 public class SignaturePacket
     extends ContainedPacket implements PublicKeyAlgorithmTags
 {
+    public static int MAX_SUBPACKET_LEN = 2 * 1024 * 1024; // 2mb, allows for embedded McEliece keys for example.
+
     public static final int VERSION_2 = 2;
     public static final int VERSION_3 = 3;
     public static final int VERSION_4 = 4;  // https://datatracker.ietf.org/doc/rfc4880/
@@ -213,6 +215,14 @@ public class SignaturePacket
         else
         {
             hashedLength = StreamUtil.read2OctetLength(in);
+        }
+        if (hashedLength < 0)
+        {
+            throw new MalformedPacketException("Signature subpackets encoding length cannot be negative.");
+        }
+        if (hashedLength > MAX_SUBPACKET_LEN)
+        {
+            throw new MalformedPacketException("Signature subpackets encoding length (" + hashedLength + ") exceeds max limit (" + MAX_SUBPACKET_LEN + ")");
         }
         byte[] hashed = new byte[hashedLength];
 

--- a/pg/src/main/java/org/bouncycastle/bcpg/SignatureSubpacketInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SignatureSubpacketInputStream.java
@@ -128,58 +128,65 @@ public class SignatureSubpacketInputStream
             }
         }
 
-        switch (type)
+        try
         {
-        case CREATION_TIME:
-            return new SignatureCreationTime(isCritical, isLongLength, data);
-        case EMBEDDED_SIGNATURE:
-            return new EmbeddedSignature(isCritical, isLongLength, data);
-        case KEY_EXPIRE_TIME:
-            return new KeyExpirationTime(isCritical, isLongLength, data);
-        case EXPIRE_TIME:
-            return new SignatureExpirationTime(isCritical, isLongLength, data);
-        case REVOCABLE:
-            return new Revocable(isCritical, isLongLength, data);
-        case EXPORTABLE:
-            return new Exportable(isCritical, isLongLength, data);
-        case FEATURES:
-            return new Features(isCritical, isLongLength, data);
-        case ISSUER_KEY_ID:
-            return new IssuerKeyID(isCritical, isLongLength, data);
-        case TRUST_SIG:
-            return new TrustSignature(isCritical, isLongLength, data);
-        case PREFERRED_COMP_ALGS:
-        case PREFERRED_HASH_ALGS:
-        case PREFERRED_SYM_ALGS:
-            return new PreferredAlgorithms(type, isCritical, isLongLength, data);
-        case LIBREPGP_PREFERRED_ENCRYPTION_MODES:
-            return new LibrePGPPreferredEncryptionModes(isCritical, isLongLength, data);
-        case PREFERRED_AEAD_ALGORITHMS:
-            return new PreferredAEADCiphersuites(isCritical, isLongLength, data);
-        case PREFERRED_KEY_SERV:
-            return new PreferredKeyServer(isCritical, isLongLength, data);
-        case KEY_FLAGS:
-            return new KeyFlags(isCritical, isLongLength, data);
-        case POLICY_URL:
-            return new PolicyURI(isCritical, isLongLength, data);
-        case PRIMARY_USER_ID:
-            return new PrimaryUserID(isCritical, isLongLength, data);
-        case SIGNER_USER_ID:
-            return new SignerUserID(isCritical, isLongLength, data);
-        case NOTATION_DATA:
-            return new NotationData(isCritical, isLongLength, data);
-        case REG_EXP:
-            return new RegularExpression(isCritical, isLongLength, data);
-        case REVOCATION_REASON:
-            return new RevocationReason(isCritical, isLongLength, data);
-        case REVOCATION_KEY:
-            return new RevocationKey(isCritical, isLongLength, data);
-        case SIGNATURE_TARGET:
-            return new SignatureTarget(isCritical, isLongLength, data);
-        case ISSUER_FINGERPRINT:
-            return new IssuerFingerprint(isCritical, isLongLength, data);
-        case INTENDED_RECIPIENT_FINGERPRINT:
-            return new IntendedRecipientFingerprint(isCritical, isLongLength, data);
+            switch (type)
+            {
+                case CREATION_TIME:
+                    return new SignatureCreationTime(isCritical, isLongLength, data);
+                case EMBEDDED_SIGNATURE:
+                    return new EmbeddedSignature(isCritical, isLongLength, data);
+                case KEY_EXPIRE_TIME:
+                    return new KeyExpirationTime(isCritical, isLongLength, data);
+                case EXPIRE_TIME:
+                    return new SignatureExpirationTime(isCritical, isLongLength, data);
+                case REVOCABLE:
+                    return new Revocable(isCritical, isLongLength, data);
+                case EXPORTABLE:
+                    return new Exportable(isCritical, isLongLength, data);
+                case FEATURES:
+                    return new Features(isCritical, isLongLength, data);
+                case ISSUER_KEY_ID:
+                    return new IssuerKeyID(isCritical, isLongLength, data);
+                case TRUST_SIG:
+                    return new TrustSignature(isCritical, isLongLength, data);
+                case PREFERRED_COMP_ALGS:
+                case PREFERRED_HASH_ALGS:
+                case PREFERRED_SYM_ALGS:
+                    return new PreferredAlgorithms(type, isCritical, isLongLength, data);
+                case LIBREPGP_PREFERRED_ENCRYPTION_MODES:
+                    return new LibrePGPPreferredEncryptionModes(isCritical, isLongLength, data);
+                case PREFERRED_AEAD_ALGORITHMS:
+                    return new PreferredAEADCiphersuites(isCritical, isLongLength, data);
+                case PREFERRED_KEY_SERV:
+                    return new PreferredKeyServer(isCritical, isLongLength, data);
+                case KEY_FLAGS:
+                    return new KeyFlags(isCritical, isLongLength, data);
+                case POLICY_URL:
+                    return new PolicyURI(isCritical, isLongLength, data);
+                case PRIMARY_USER_ID:
+                    return new PrimaryUserID(isCritical, isLongLength, data);
+                case SIGNER_USER_ID:
+                    return new SignerUserID(isCritical, isLongLength, data);
+                case NOTATION_DATA:
+                    return new NotationData(isCritical, isLongLength, data);
+                case REG_EXP:
+                    return new RegularExpression(isCritical, isLongLength, data);
+                case REVOCATION_REASON:
+                    return new RevocationReason(isCritical, isLongLength, data);
+                case REVOCATION_KEY:
+                    return new RevocationKey(isCritical, isLongLength, data);
+                case SIGNATURE_TARGET:
+                    return new SignatureTarget(isCritical, isLongLength, data);
+                case ISSUER_FINGERPRINT:
+                    return new IssuerFingerprint(isCritical, isLongLength, data);
+                case INTENDED_RECIPIENT_FINGERPRINT:
+                    return new IntendedRecipientFingerprint(isCritical, isLongLength, data);
+            }
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new MalformedPacketException("Malformed signature subpacket.", e);
         }
 
         return new SignatureSubpacket(type, isCritical, isLongLength, data);

--- a/pg/src/main/java/org/bouncycastle/bcpg/SymmetricKeyEncSessionPacket.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/SymmetricKeyEncSessionPacket.java
@@ -81,7 +81,14 @@ public class SymmetricKeyEncSessionPacket
             }
             else
             {
-                ivLen = AEADUtils.getIVLength(aeadAlgorithm);
+                try
+                {
+                    ivLen = AEADUtils.getIVLength(aeadAlgorithm);
+                }
+                catch (IllegalArgumentException e)
+                {
+                    throw new IOException(e.getMessage(), e);
+                }
             }
 
             s2k = new S2K(in);

--- a/pg/src/main/java/org/bouncycastle/bcpg/attr/ImageAttribute.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/attr/ImageAttribute.java
@@ -37,8 +37,16 @@ public class ImageAttribute
         byte[]    data)
     {
         super(UserAttributeSubpacketTags.IMAGE_ATTRIBUTE, forceLongLength, data);
+        if (data.length < 4)
+        {
+            throw new IllegalArgumentException("Malformed ImageAttribute. Data length too short: " + data.length);
+        }
         
         hdrLength = ((data[1] & 0xff) << 8) | (data[0] & 0xff);
+        if (data.length < hdrLength)
+        {
+            throw new IllegalArgumentException("Malformed ImageAttribute. Header length exceeds data length.");
+        }
         version = data[2] & 0xff;
         encoding = data[3] & 0xff;
         

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/IntendedRecipientFingerprint.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/IntendedRecipientFingerprint.java
@@ -20,7 +20,7 @@ public class IntendedRecipientFingerprint
         boolean    isLongLength,
         byte[]     data)
     {
-        super(SignatureSubpacketTags.INTENDED_RECIPIENT_FINGERPRINT, critical, isLongLength, data);
+        super(SignatureSubpacketTags.INTENDED_RECIPIENT_FINGERPRINT, critical, isLongLength, verifyData(data));
     }
 
     public IntendedRecipientFingerprint(
@@ -30,6 +30,15 @@ public class IntendedRecipientFingerprint
     {
         super(SignatureSubpacketTags.INTENDED_RECIPIENT_FINGERPRINT, critical, false,
             Arrays.prepend(fingerprint, (byte)keyVersion));
+    }
+
+    private static byte[] verifyData(byte[] data)
+    {
+        if (data.length < 1)
+        {
+            throw new IllegalArgumentException("Data too short. Expect at least one octet of key version number.");
+        }
+        return data;
     }
 
     public int getKeyVersion()

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/IssuerFingerprint.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/IssuerFingerprint.java
@@ -22,7 +22,7 @@ public class IssuerFingerprint
         boolean    isLongLength,
         byte[]     data)
     {
-        super(SignatureSubpacketTags.ISSUER_FINGERPRINT, critical, isLongLength, data);
+        super(SignatureSubpacketTags.ISSUER_FINGERPRINT, critical, isLongLength, verifyData(data));
     }
 
     public IssuerFingerprint(
@@ -32,6 +32,15 @@ public class IssuerFingerprint
     {
         super(SignatureSubpacketTags.ISSUER_FINGERPRINT, critical, false,
             Arrays.prepend(fingerprint, (byte)keyVersion));
+    }
+
+    private static byte[] verifyData(byte[] data)
+    {
+        if (data.length < 1)
+        {
+            throw new IllegalArgumentException("Data too short. Expect at least one octet of key version.");
+        }
+        return data;
     }
 
     public int getKeyVersion()

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/NotationData.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/NotationData.java
@@ -27,7 +27,7 @@ public class NotationData
         boolean isLongLength,
         byte[] data)
     {
-        super(SignatureSubpacketTags.NOTATION_DATA, critical, isLongLength, data);
+        super(SignatureSubpacketTags.NOTATION_DATA, critical, isLongLength, verifyData(data));
     }
 
     public NotationData(
@@ -37,6 +37,21 @@ public class NotationData
         String notationValue)
     {
         super(SignatureSubpacketTags.NOTATION_DATA, critical, false, createData(humanReadable, notationName, notationValue));
+    }
+
+    private static byte[] verifyData(byte[] data)
+    {
+        if (data.length < 8)
+        {
+            throw new IllegalArgumentException("Malformed notation data encoding (too short): " + data.length);
+        }
+        int nameLength = (((data[HEADER_FLAG_LENGTH] & 0xff) << 8) + (data[HEADER_FLAG_LENGTH + 1] & 0xff));
+        int valueLength = (((data[HEADER_FLAG_LENGTH + HEADER_NAME_LENGTH] & 0xff) << 8) + (data[HEADER_FLAG_LENGTH + HEADER_NAME_LENGTH + 1] & 0xff));
+        if (nameLength + valueLength + 4 > data.length)
+        {
+            throw new IllegalArgumentException("Malformed notation data encoding.");
+        }
+        return data;
     }
 
     private static byte[] createData(boolean humanReadable, String notationName, String notationValue)

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/RegularExpression.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/RegularExpression.java
@@ -23,7 +23,7 @@ public class RegularExpression
             byte[] data)
     {
         super(SignatureSubpacketTags.REG_EXP, critical, isLongLength, data);
-        if (data[data.length - 1] != 0)
+        if (data.length == 0 || data[data.length - 1] != 0)
         {
             throw new IllegalArgumentException("data in regex missing null termination");
         }

--- a/pg/src/main/java/org/bouncycastle/bcpg/sig/SignatureExpirationTime.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/sig/SignatureExpirationTime.java
@@ -29,7 +29,7 @@ public class SignatureExpirationTime
         boolean    isLongLength,
         byte[]     data)
     {
-        super(SignatureSubpacketTags.EXPIRE_TIME, critical, isLongLength, data);
+        super(SignatureSubpacketTags.EXPIRE_TIME, critical, isLongLength, verifyData(data));
     }
 
     public SignatureExpirationTime(
@@ -37,6 +37,15 @@ public class SignatureExpirationTime
         long       seconds)
     {
         super(SignatureSubpacketTags.EXPIRE_TIME, critical, false, Utils.timeToBytes(seconds));
+    }
+
+    private static byte[] verifyData(byte[] data)
+    {
+        if (data.length != 4)
+        {
+            throw new IllegalArgumentException("Malformed data length. Expected 4, got " + data.length);
+        }
+        return data;
     }
 
     /**

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSignature.java
@@ -804,12 +804,20 @@ public class PGPSignature
                 byte[] b = BigIntegers.asUnsignedByteArray(sigValues[1].getValue());
                 if (a.length + b.length > Ed25519.SIGNATURE_SIZE)
                 {
+                    if (a.length > Ed448.PUBLIC_KEY_SIZE || b.length > Ed448.SIGNATURE_SIZE)
+                    {
+                        throw new PGPException("Malformed Ed448 signature encoding (too long).");
+                    }
                     signature = new byte[Ed448.SIGNATURE_SIZE];
                     System.arraycopy(a, 0, signature, Ed448.PUBLIC_KEY_SIZE - a.length, a.length);
                     System.arraycopy(b, 0, signature, Ed448.SIGNATURE_SIZE - b.length, b.length);
                 }
                 else
                 {
+                    if (a.length > Ed25519.PUBLIC_KEY_SIZE || b.length > Ed25519.SIGNATURE_SIZE)
+                    {
+                        throw new PGPException("Malformed Ed25519 signature encoding (too long).");
+                    }
                     signature = new byte[Ed25519.SIGNATURE_SIZE];
                     System.arraycopy(a, 0, signature, Ed25519.PUBLIC_KEY_SIZE - a.length, a.length);
                     System.arraycopy(b, 0, signature, Ed25519.SIGNATURE_SIZE - b.length, b.length);


### PR DESCRIPTION
Hey!

I did run junit-jazzer agains some PGPainless functions and uncovered some bugs in the bcpg codebase.

The commits in this PR harmonize the way malformed or strange packets are handled, by preventing runtime exceptions, such as IndexOutOfBounds, NegativeArraySize, IllegalArgumentExceptions and OutOfMemory errors.

I'm only just getting started with fuzzing, but I can highly recommend it!