### PR TITLE
OpenPGPKeyGenerator: Allow for empty UserIDs, prevent newlines/CRs

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPKeyGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPKeyGenerator.java
@@ -380,9 +380,13 @@ public class OpenPGPKeyGenerator
             throws PGPException
         {
             // care - needs to run with Java 5.
-            if (userId == null || userId.trim().length() == 0)
+            if (userId == null)
             {
-                throw new IllegalArgumentException("User-ID cannot be null or empty.");
+                throw new IllegalArgumentException("User-ID cannot be null.");
+            }
+            if (userId.contains("\n") || userId.contains("\r"))
+            {
+                throw new IllegalArgumentException("User-ID cannot contain newlines and/or carriage returns.");
             }
 
             SignatureParameters parameters = Utils.applySignatureParameters(signatureParameters,


### PR DESCRIPTION
While parsing I noticed, that both PGPainless and Sequoia-PGP happily accept empty UserIDs.
Someone hinted me, that this was the only way to create OpenPGP v4 keys without DirectKeySignatures that are "user-id-less" and compatible to old GnuPG versions.

Further, I noticed during fuzzing that newlines and carriage returns break ASCII armor.

Therefore, this PR modifies OpenPGPKeyGenerator to allow empty UserIDs, but forbid newlines/carriage returns.