### PR TITLE
JSSE: Persist handshake session application data to final session

### DIFF
--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLEngine.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLEngine.java
@@ -686,6 +686,13 @@ class ProvSSLEngine
                 connection.getSession().invalidate();
             }
 
+            // Copy application data from handshake session to final session
+            String[] valueNames = handshakeSession.getValueNames();
+            for (String name : valueNames)
+            {
+                connection.getSession().putValue(name, handshakeSession.getValue(name));
+            }
+
             handshakeSession.getJsseSecurityParameters().clear();
         }
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLSocketDirect.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLSocketDirect.java
@@ -471,6 +471,13 @@ class ProvSSLSocketDirect
                 connection.getSession().invalidate();
             }
 
+            // Copy application data from handshake session to final session
+            String[] valueNames = handshakeSession.getValueNames();
+            for (String name : valueNames)
+            {
+                connection.getSession().putValue(name, handshakeSession.getValue(name));
+            }
+
             handshakeSession.getJsseSecurityParameters().clear();
         }
 

--- a/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLSocketWrap.java
+++ b/tls/src/main/java/org/bouncycastle/jsse/provider/ProvSSLSocketWrap.java
@@ -660,6 +660,13 @@ class ProvSSLSocketWrap
                 connection.getSession().invalidate();
             }
 
+            // Copy application data from handshake session to final session
+            String[] valueNames = handshakeSession.getValueNames();
+            for (String name : valueNames)
+            {
+                connection.getSession().putValue(name, handshakeSession.getValue(name));
+            }
+
             handshakeSession.getJsseSecurityParameters().clear();
         }
 

--- a/tls/src/test/java/org/bouncycastle/jsse/provider/test/SessionDataPersistenceTest.java
+++ b/tls/src/test/java/org/bouncycastle/jsse/provider/test/SessionDataPersistenceTest.java
@@ -1,0 +1,83 @@
+package org.bouncycastle.jsse.provider.test;
+
+import java.security.Security;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
+
+import junit.framework.TestCase;
+
+/**
+ * Test to verify that application data stored in handshake session
+ * persists to the final session after handshake completion.
+ */
+public class SessionDataPersistenceTest extends TestCase
+{
+    static
+    {
+        if (Security.getProvider("BC") == null)
+        {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider("BCJSSE") == null)
+        {
+            Security.addProvider(new BouncyCastleJsseProvider());
+        }
+    }
+
+    public void testHandshakeSessionDataPersistence() throws Exception
+    {
+        SSLContext ctx = SSLContext.getInstance("TLS", "BCJSSE");
+        ctx.init(null, new TrustManager[]{new TestTrustManager()}, null);
+        
+        SSLSocket socket = (SSLSocket) ctx.getSocketFactory().createSocket("www.google.com", 443);
+        socket.startHandshake();
+        
+        // Verify that data stored during handshake is available in final session
+        String result = (String) socket.getSession().getValue("test-data");
+        assertNotNull("Handshake session data should persist to final session", result);
+        assertEquals("test-value", result);
+        
+        socket.close();
+    }
+    
+    private static class TestTrustManager extends X509ExtendedTrustManager
+    {
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, java.net.Socket socket)
+        {
+            // Store test data in handshake session
+            if (socket instanceof SSLSocket)
+            {
+                ((SSLSocket) socket).getHandshakeSession().putValue("test-data", "test-value");
+            }
+        }
+        
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+        
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+        
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, javax.net.ssl.SSLEngine engine) {}
+        
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, javax.net.ssl.SSLEngine engine) {}
+        
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, java.net.Socket socket) {}
+        
+        @Override
+        public X509Certificate[] getAcceptedIssuers() 
+        {
+            return new X509Certificate[0];
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR makes BC JSSE consistent with Oracle JSSE by copying application data stored via `putValue()` in the handshake session to the final session after handshake completion.

## Problem
Previously, data stored during certificate verification (e.g., in custom TrustManager implementations) would be lost when transitioning from handshake session to final session. This created inconsistent behavior compared to Oracle JSSE and broke common use cases.

## Test Results
**Before fix:**
- `BCJSSE: value available: false` (data lost)
- `SunJSSE: value available: true` (data persists)

**After fix:**
- `BCJSSE: value available: true` (data now persists)
- `SunJSSE: value available: true` (unchanged)

## Changes Made
- **ProvSSLEngine.java**: Copy application data in `notifyHandshakeComplete()`
- **ProvSSLSocketDirect.java**: Copy application data in `notifyHandshakeComplete()`
- **ProvSSLSocketWrap.java**: Copy application data in `notifyHandshakeComplete()`
- **SessionDataPersistenceTest.java**: Added test case to verify data persistence

## Code Changes
Added these 4 lines to each `notifyHandshakeComplete()` method:
```java
// Copy application data from handshake session to final session
String[] valueNames = handshakeSession.getValueNames();
for (String name : valueNames)
{
    connection.getSession().putValue(name, handshakeSession.getValue(name));
}
```

## Compatibility
- ✅ **Backward Compatible**: No breaking changes
- ✅ **Minimal Impact**: Only affects session transition logic
- ✅ **Test Coverage**: Includes regression test
- ✅ **Oracle JSSE Compatible**: Aligns behavior with standard implementation

## Use Cases Enabled
- Certificate validation metadata storage
- Security context preservation across handshake
- Custom authentication data persistence
- Protocol negotiation state retention

Fixes #2136