### PR TITLE
Fix ClassCastException when trying to verify misplaced subkey binding…

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
@@ -1949,7 +1949,7 @@ public class OpenPGPCertificate
                     throw new IncorrectOpenPGPSignatureException(this, "Key Signature is not correct.");
                 }
             }
-            catch (PGPException e)
+            catch (PGPException | ClassCastException e)
             {
                 this.isCorrect = false;
                 throw new PGPSignatureException("Key Signature could not be verified.", e);
@@ -1982,7 +1982,7 @@ public class OpenPGPCertificate
                     throw new IncorrectOpenPGPSignatureException(this, "UserID Signature is not correct.");
                 }
             }
-            catch (PGPException e)
+            catch (PGPException | ClassCastException e)
             {
                 this.isCorrect = false;
                 throw new PGPSignatureException("UserID Signature could not be verified.", e);
@@ -2015,7 +2015,7 @@ public class OpenPGPCertificate
                     throw new IncorrectOpenPGPSignatureException(this, "UserAttribute Signature is not correct.");
                 }
             }
-            catch (PGPException e)
+            catch (PGPException | ClassCastException e)
             {
                 this.isCorrect = false;
                 throw new PGPSignatureException("Could not verify UserAttribute Signature.", e);


### PR DESCRIPTION
… signatures

Misplaced subkey binding signatures could result in the Signer being initialized using the wrong key material,
causing ClassCastExceptions.
This patch catches those exceptions and rethrows them as gracefully handled PGPSIgnatureExceptions.