### PR TITLE
Fix SKESK encoding for direct-S2K-encrypted messages

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPEncryptedDataGenerator.java
@@ -229,7 +229,14 @@ public class PGPEncryptedDataGenerator
         for (int i = 0; i < methods.size(); i++)
         {
             PGPKeyEncryptionMethodGenerator method = (PGPKeyEncryptionMethodGenerator)methods.get(i);
-            pOut.writePacket(method.generate(dataEncryptorBuilder, sessionKey));
+            if (directS2K)
+            {
+                pOut.writePacket(method.generate(dataEncryptorBuilder, null));
+            }
+            else
+            {
+                pOut.writePacket(method.generate(dataEncryptorBuilder, sessionKey));
+            }
         }
         try
         {


### PR DESCRIPTION
Messages encrypted with only a single SKESK can optionally make use of the "direct-S2K" method (see https://www.rfc-editor.org/rfc/rfc9580.html#section-5.3.1-4).

During the v6 rework, I apparently made a slight mistake, causing all messages to not use the direct-s2k method anymore by always passing in a non-null session key to the SKESK generation method. Previously, direct-s2k would result in null being passed.

This patch adds  a check that conditionally passes null again, restoring the previous behavior.

Fixes #2208