### PR TITLE
PGPSecretKey: Document required Direct-Key Signatures.

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPSecretKey.java
@@ -78,7 +78,7 @@ public class PGPSecretKey
      * @param privKey            the private key component.
      * @param pubKey             the public key component.
      * @param checksumCalculator a calculator for the private key checksum
-     * @param isMasterKey        true if the key is a master key, false otherwise.
+     * @param isPrimaryKey       true if the key is a primary key, false otherwise.
      * @param keyEncryptor       an encryptor for the key if required (null otherwise).
      * @throws PGPException if there is an issue creating the secret key packet.
      */
@@ -86,20 +86,20 @@ public class PGPSecretKey
         PGPPrivateKey privKey,
         PGPPublicKey pubKey,
         PGPDigestCalculator checksumCalculator,
-        boolean isMasterKey,
+        boolean isPrimaryKey,
         PBESecretKeyEncryptor keyEncryptor)
         throws PGPException
     {
-        this.pub = buildPublicKey(isMasterKey, pubKey);
-        this.secret = buildSecretKeyPacket(isMasterKey, privKey, pubKey, keyEncryptor, checksumCalculator);
+        this.pub = buildPublicKey(isPrimaryKey, pubKey);
+        this.secret = buildSecretKeyPacket(isPrimaryKey, privKey, pubKey, keyEncryptor, checksumCalculator);
     }
 
-    private static PGPPublicKey buildPublicKey(boolean isMasterKey, PGPPublicKey pubKey)
+    private static PGPPublicKey buildPublicKey(boolean isPrimaryKey, PGPPublicKey pubKey)
     {
         PublicKeyPacket pubPacket = pubKey.publicPk;
 
         // make sure we can actually do what's wanted
-        if (isMasterKey && !(pubKey.isEncryptionKey() && pubPacket.getAlgorithm() != PublicKeyAlgorithmTags.RSA_GENERAL))
+        if (isPrimaryKey && !(pubKey.isEncryptionKey() && pubPacket.getAlgorithm() != PublicKeyAlgorithmTags.RSA_GENERAL))
         {
             PGPPublicKey mstKey = new PGPPublicKey(pubKey);
             mstKey.publicPk = new PublicKeyPacket(pubPacket.getVersion(), pubPacket.getAlgorithm(), pubPacket.getTime(), pubPacket.getKey());
@@ -113,14 +113,14 @@ public class PGPSecretKey
         }
     }
 
-    private static SecretKeyPacket buildSecretKeyPacket(boolean isMasterKey, PGPPrivateKey privKey, PGPPublicKey pubKey, PBESecretKeyEncryptor keyEncryptor, PGPDigestCalculator checksumCalculator)
+    private static SecretKeyPacket buildSecretKeyPacket(boolean isPrimaryKey, PGPPrivateKey privKey, PGPPublicKey pubKey, PBESecretKeyEncryptor keyEncryptor, PGPDigestCalculator checksumCalculator)
         throws PGPException
     {
         BCPGObject secKey = (BCPGObject)privKey.getPrivateKeyDataPacket();
 
         if (secKey == null)
         {
-            return generateSecretKeyPacket(isMasterKey, pubKey.publicPk, SymmetricKeyAlgorithmTags.NULL, new byte[0]);
+            return generateSecretKeyPacket(isPrimaryKey, pubKey.publicPk, SymmetricKeyAlgorithmTags.NULL, new byte[0]);
         }
 
         try
@@ -149,7 +149,7 @@ public class PGPSecretKey
                 if (keyEncryptor.getAeadAlgorithm() != 0)
                 {
                     s2kUsage = SecretKeyPacket.USAGE_AEAD;
-                    return generateSecretKeyPacket(isMasterKey, pubKey.publicPk, encAlgorithm, keyEncryptor.getAeadAlgorithm(), s2kUsage, s2k, iv, encData);
+                    return generateSecretKeyPacket(isPrimaryKey, pubKey.publicPk, encAlgorithm, keyEncryptor.getAeadAlgorithm(), s2kUsage, s2k, iv, encData);
                 }
 
                 if (checksumCalculator != null)
@@ -165,13 +165,13 @@ public class PGPSecretKey
                     s2kUsage = SecretKeyPacket.USAGE_CHECKSUM;
                 }
 
-                return generateSecretKeyPacket(isMasterKey, pubKey.publicPk, encAlgorithm, s2kUsage, s2k, iv, encData);
+                return generateSecretKeyPacket(isPrimaryKey, pubKey.publicPk, encAlgorithm, s2kUsage, s2k, iv, encData);
             }
             else if (pubKey.getVersion() != PublicKeyPacket.VERSION_6)
             {
                 pOut.write(checksum(null, keyData, keyData.length));
             }
-            return generateSecretKeyPacket(isMasterKey, pubKey.publicPk, encAlgorithm, bOut.toByteArray());
+            return generateSecretKeyPacket(isPrimaryKey, pubKey.publicPk, encAlgorithm, bOut.toByteArray());
         }
         catch (PGPException e)
         {
@@ -183,9 +183,9 @@ public class PGPSecretKey
         }
     }
 
-    private static SecretKeyPacket generateSecretKeyPacket(boolean isMasterKey, PublicKeyPacket pubKey, int encAlgorithm, byte[] secKeyData)
+    private static SecretKeyPacket generateSecretKeyPacket(boolean isPrimaryKey, PublicKeyPacket pubKey, int encAlgorithm, byte[] secKeyData)
     {
-        if (isMasterKey)
+        if (isPrimaryKey)
         {
             return new SecretKeyPacket(pubKey, encAlgorithm, null, null, secKeyData);
         }
@@ -195,9 +195,9 @@ public class PGPSecretKey
         }
     }
 
-    private static SecretKeyPacket generateSecretKeyPacket(boolean isMasterKey, PublicKeyPacket pubKey, int encAlgorithm, int s2kusage, S2K s2k, byte[] iv, byte[] secKeyData)
+    private static SecretKeyPacket generateSecretKeyPacket(boolean isPrimaryKey, PublicKeyPacket pubKey, int encAlgorithm, int s2kusage, S2K s2k, byte[] iv, byte[] secKeyData)
     {
-        if (isMasterKey)
+        if (isPrimaryKey)
         {
             return new SecretKeyPacket(pubKey, encAlgorithm, s2kusage, s2k, iv, secKeyData);
         }
@@ -207,9 +207,9 @@ public class PGPSecretKey
         }
     }
 
-    private static SecretKeyPacket generateSecretKeyPacket(boolean isMasterKey, PublicKeyPacket pubKey, int encAlgorithm, int aeadAlgorithm, int s2kUsage, S2K s2K, byte[] iv, byte[] secKeyData)
+    private static SecretKeyPacket generateSecretKeyPacket(boolean isPrimaryKey, PublicKeyPacket pubKey, int encAlgorithm, int aeadAlgorithm, int s2kUsage, S2K s2K, byte[] iv, byte[] secKeyData)
     {
-        if (isMasterKey)
+        if (isPrimaryKey)
         {
             return new SecretKeyPacket(pubKey, encAlgorithm, aeadAlgorithm, s2kUsage, s2K, iv, secKeyData);
         }
@@ -250,10 +250,10 @@ public class PGPSecretKey
     }
 
     /**
-     * Construct a PGPSecretKey sub-key using the passed in private/public key pair and binding it to the master key pair.
+     * Construct a PGPSecretKey sub-key using the passed in private/public key pair and binding it to the primary key pair.
      * The secret key checksum is calculated using the passed in checksum calculator.
      *
-     * @param masterKeyPair              the master public/private keys for the new subkey.
+     * @param primaryKeyPair             the primary public/private keys for the new subkey.
      * @param keyPair                    the public/private keys to use.
      * @param checksumCalculator         a calculator for the private key checksum
      * @param certificationSignerBuilder the builder for generating the certification.
@@ -261,21 +261,21 @@ public class PGPSecretKey
      * @throws PGPException if there is an issue creating the secret key packet or the certification.
      */
     public PGPSecretKey(
-        PGPKeyPair masterKeyPair,
+        PGPKeyPair primaryKeyPair,
         PGPKeyPair keyPair,
         PGPDigestCalculator checksumCalculator,
         PGPContentSignerBuilder certificationSignerBuilder,
         PBESecretKeyEncryptor keyEncryptor)
         throws PGPException
     {
-        this(masterKeyPair, keyPair, checksumCalculator, null, null, certificationSignerBuilder, keyEncryptor);
+        this(primaryKeyPair, keyPair, checksumCalculator, null, null, certificationSignerBuilder, keyEncryptor);
     }
 
     /**
-     * Construct a PGPSecretKey sub-key using the passed in private/public key pair and binding it to the master key pair.
+     * Construct a PGPSecretKey sub-key using the passed in private/public key pair and binding it to the primary key pair.
      * The secret key checksum is calculated using the passed in checksum calculator.
      *
-     * @param masterKeyPair              the master public/private keys for the new subkey.
+     * @param primaryKeyPair             the primary public/private keys for the new subkey.
      * @param keyPair                    the public/private keys to use.
      * @param checksumCalculator         calculator for PGP key checksums.
      * @param hashedPcks                 the hashed packets to be added to the certification.
@@ -285,7 +285,7 @@ public class PGPSecretKey
      * @throws PGPException if there is an issue creating the secret key packet or the certification.
      */
     public PGPSecretKey(
-        PGPKeyPair masterKeyPair,
+        PGPKeyPair primaryKeyPair,
         PGPKeyPair keyPair,
         PGPDigestCalculator checksumCalculator,
         PGPSignatureSubpacketVector hashedPcks,
@@ -297,9 +297,9 @@ public class PGPSecretKey
         //
         // generate the certification
         //
-        PGPSignatureGenerator sGen = new PGPSignatureGenerator(certificationSignerBuilder, masterKeyPair.getPublicKey());
+        PGPSignatureGenerator sGen = new PGPSignatureGenerator(certificationSignerBuilder, primaryKeyPair.getPublicKey());
 
-        sGen.init(PGPSignature.SUBKEY_BINDING, masterKeyPair.getPrivateKey());
+        sGen.init(PGPSignature.SUBKEY_BINDING, primaryKeyPair.getPrivateKey());
 
         // do some basic checking if we are a signing key.
         if (!keyPair.getPublicKey().isEncryptionKey())
@@ -314,7 +314,7 @@ public class PGPSecretKey
 
                 try
                 {
-                    subGen.addEmbeddedSignature(false, signatureGenerator.generateCertification(masterKeyPair.getPublicKey(), keyPair.getPublicKey()));
+                    subGen.addEmbeddedSignature(false, signatureGenerator.generateCertification(primaryKeyPair.getPublicKey(), keyPair.getPublicKey()));
 
                     hashedPcks = subGen.generate();
                 }
@@ -334,7 +334,7 @@ public class PGPSecretKey
 
         List<PGPSignature> subSigs = new ArrayList<PGPSignature>();
 
-        subSigs.add(sGen.generateCertification(masterKeyPair.getPublicKey(), keyPair.getPublicKey()));
+        subSigs.add(sGen.generateCertification(primaryKeyPair.getPublicKey(), keyPair.getPublicKey()));
 
         // replace the public key packet structure with a public subkey one.
         PGPPublicKey pubSubKey = new PGPPublicKey(keyPair.getPublicKey(), null, subSigs);
@@ -353,7 +353,7 @@ public class PGPSecretKey
      * key in order for it to be considered valid.
      *
      * @param certificationLevel         the type of certification to be added.
-     * @param keyPair                    the public/private keys to use.
+     * @param keyPair                    the primary public/private keys to use.
      * @param id                         the id to bind to the key.
      * @param checksumCalculator         a calculator for the private key checksum.
      * @param hashedPcks                 the hashed packets to be added to the certification.
@@ -430,9 +430,9 @@ public class PGPSecretKey
     }
 
     /**
-     * Return true if this is a master key.
+     * Return true if this is a primary key.
      *
-     * @return true if a master key.
+     * @return true if a primary key.
      */
     public boolean isMasterKey()
     {
@@ -442,7 +442,7 @@ public class PGPSecretKey
     /**
      * Detect if the Secret Key's Private Key is empty or not
      *
-     * @return boolean whether or not the private key is empty
+     * @return boolean whether the private key is empty
      */
     public boolean isPrivateKeyEmpty()
     {


### PR DESCRIPTION
This PR adds documentation, explaining to the user that when creating a v6 key with certain PGPSecretKey constructors, they need to manually add a direct-key signature in order to be deemed valid. This addresses #2229 

Additionally, this PR contains a commit replacing the term "master key" with the more adequate "primary key" (within argument names and javadoc documentation). Feel free to pick desired changes.
