### PR TITLE
OpenPGPCertificate: Allow getting encryption keys by purpose

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
@@ -907,14 +907,33 @@ public class OpenPGPCertificate
      */
     public List<OpenPGPComponentKey> getEncryptionKeys(Date evaluationTime)
     {
+        return getEncryptionKeys(evaluationTime, KeyFlags.ENCRYPT_COMMS, KeyFlags.ENCRYPT_STORAGE);
+    }
+
+    /**
+     * Return a list of all keys that are - at evaluation time - valid encryption keys and carry any of the given
+     * key flags.
+     * <b>
+     * Note: To get all keys that have EITHER flag A or B, call <pre>getEncryptionKeys(evalTime, A, B)</pre>.
+     * To instead get all keys that have BOTH flags A AND B, call <pre>getEncryptionKeys(evalTime, A &amp; B)</pre>.
+     *
+     * @see KeyFlags
+     *
+     * @param evaluationTime evaluation time
+     * @param keyFlags key flags
+     * @return keys with the given flags
+     */
+    public List<OpenPGPComponentKey> getEncryptionKeys(Date evaluationTime, final int... keyFlags)
+    {
         return filterKeys(evaluationTime, new KeyFilter()
         {
             @Override
             public boolean test(OpenPGPComponentKey key, Date time)
             {
-                return key.isEncryptionKey(time);
+                return key.isEncryptionKey(time, keyFlags);
             }
         });
+
     }
 
     /**
@@ -2132,12 +2151,28 @@ public class OpenPGPCertificate
         }
 
         /**
-         * Return true, if the is - at evaluation time - marked as an encryption key.
+         * Return true, if the key is - at evaluation time - marked as an encryption key.
          *
          * @param evaluationTime evaluation time
          * @return true if key is an encryption key at evaluation time, false otherwise
          */
         public boolean isEncryptionKey(Date evaluationTime)
+        {
+            return isEncryptionKey(evaluationTime, KeyFlags.ENCRYPT_COMMS, KeyFlags.ENCRYPT_STORAGE);
+        }
+
+        /**
+         * Return true, if the key is - at evaluation time - marked as an encryption key and carries any of the given
+         * key flags.
+         * <b>
+         * Note: To check if the key has EITHER flag A or B, call <pre>isEncryptionKey(evalTime, A, B)</pre>.
+         * To instead check, if the key has BOTH flags A AND B, call <pre>isEncryptionKey(evalTime, A &amp; B)</pre>.
+         *
+         * @param evaluationTime evaluation time
+         * @param keyFlags key flags
+         * @return true if the key is an encryption key for any of the given key flags
+         */
+        public boolean isEncryptionKey(Date evaluationTime, int... keyFlags)
         {
             if (!rawPubkey.isEncryptionKey())
             {
@@ -2145,8 +2180,7 @@ public class OpenPGPCertificate
                 return false;
             }
 
-            return hasKeyFlags(evaluationTime, KeyFlags.ENCRYPT_STORAGE) ||
-                hasKeyFlags(evaluationTime, KeyFlags.ENCRYPT_COMMS);
+            return hasKeyFlags(evaluationTime, keyFlags);
         }
 
         /**

--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
@@ -219,9 +219,9 @@ public class OpenPGPCertificate
      * <pre>
      * keys = getComponentKeysWithFlag(date, KeyFlags.ENCRYPT_COMMS, KeyFlags.ENCRYPT_STORAGE);
      * </pre>
-     * If you instead want to access all keys, that have BOTH flags, you need to <pre>&amp;</pre> both flags:
+     * If you instead want to access all keys, that have BOTH flags, you need to <pre>|</pre> both flags:
      * <pre>
-     * keys = getComponentKeysWithFlag(date, KeyFlags.ENCRYPT_COMMS &amp; KeyFlags.ENCRYPT_STORAGE);
+     * keys = getComponentKeysWithFlag(date, KeyFlags.ENCRYPT_COMMS | KeyFlags.ENCRYPT_STORAGE);
      * </pre>
      *
      * @param evaluationTime reference time
@@ -915,7 +915,7 @@ public class OpenPGPCertificate
      * key flags.
      * <b>
      * Note: To get all keys that have EITHER flag A or B, call <pre>getEncryptionKeys(evalTime, A, B)</pre>.
-     * To instead get all keys that have BOTH flags A AND B, call <pre>getEncryptionKeys(evalTime, A &amp; B)</pre>.
+     * To instead get all keys that have BOTH flags A AND B, call <pre>getEncryptionKeys(evalTime, A | B)</pre>.
      *
      * @see KeyFlags
      *
@@ -1353,7 +1353,7 @@ public class OpenPGPCertificate
          * Return <pre>true</pre>, if the key has any of the given key flags.
          * <p>
          * Note: To check if the key has EITHER flag A or B, call <pre>hasKeyFlags(evalTime, A, B)</pre>.
-         * To instead check, if the key has BOTH flags A AND B, call <pre>hasKeyFlags(evalTime, A &amp; B)</pre>.
+         * To instead check, if the key has BOTH flags A AND B, call <pre>hasKeyFlags(evalTime, A | B)</pre>.
          *
          * @param evaluationTime evaluation time
          * @param flags          key flags (see {@link KeyFlags} for possible values)
@@ -2166,7 +2166,7 @@ public class OpenPGPCertificate
          * key flags.
          * <b>
          * Note: To check if the key has EITHER flag A or B, call <pre>isEncryptionKey(evalTime, A, B)</pre>.
-         * To instead check, if the key has BOTH flags A AND B, call <pre>isEncryptionKey(evalTime, A &amp; B)</pre>.
+         * To instead check, if the key has BOTH flags A AND B, call <pre>isEncryptionKey(evalTime, A | B)</pre>.
          *
          * @param evaluationTime evaluation time
          * @param keyFlags key flags


### PR DESCRIPTION
The OpenPGP protocol defines two different encryption key flags: ENCRYPT_STORAGE and ENCRYPT_COMMS.

This PR adds methods to select encryption keys of a certificate by passing in key flags as array of masks.
This allows the user to encrypt a message for a specific use-case, such as data in transmission or data at rest.