### PR TITLE
Fix Strings.split() to handle delimiters at position 0

### DIFF
--- a/core/src/main/java/org/bouncycastle/util/Strings.java
+++ b/core/src/main/java/org/bouncycastle/util/Strings.java
@@ -333,7 +333,7 @@ public final class Strings
         while (moreTokens)
         {
             int tokenLocation = input.indexOf(delimiter);
-            if (tokenLocation > 0)
+            if (tokenLocation >= 0)
             {
                 subString = input.substring(0, tokenLocation);
                 v.addElement(subString);

--- a/core/src/test/java/org/bouncycastle/util/utiltest/AllTests.java
+++ b/core/src/test/java/org/bouncycastle/util/utiltest/AllTests.java
@@ -19,6 +19,7 @@ public class AllTests
         suite.addTestSuite(IPTest.class);
         suite.addTestSuite(BigIntegersTest.class);
         suite.addTestSuite(ArraysTest.class);
+        suite.addTestSuite(StringsTest.class);
         return new BCTestSetup(suite);
     }
 

--- a/core/src/test/java/org/bouncycastle/util/utiltest/StringsTest.java
+++ b/core/src/test/java/org/bouncycastle/util/utiltest/StringsTest.java
@@ -1,0 +1,67 @@
+package org.bouncycastle.util.utiltest;
+
+import junit.framework.TestCase;
+import org.bouncycastle.util.Strings;
+
+public class StringsTest
+    extends TestCase
+{
+    public void testSplitWithLeadingDelimiter()
+    {
+        String[] parts = Strings.split(".permitted", '.');
+        assertEquals(2, parts.length);
+        assertEquals("", parts[0]);
+        assertEquals("permitted", parts[1]);
+    }
+
+    public void testSplitDomainWithLeadingDot()
+    {
+        String[] parts = Strings.split(".example.domain.com", '.');
+        assertEquals(4, parts.length);
+        assertEquals("", parts[0]);
+        assertEquals("example", parts[1]);
+        assertEquals("domain", parts[2]);
+        assertEquals("com", parts[3]);
+    }
+
+    public void testSplitNormalDomain()
+    {
+        String[] parts = Strings.split("example.domain.com", '.');
+        assertEquals(3, parts.length);
+        assertEquals("example", parts[0]);
+        assertEquals("domain", parts[1]);
+        assertEquals("com", parts[2]);
+    }
+
+    public void testSplitNoDelimiter()
+    {
+        String[] parts = Strings.split("nodots", '.');
+        assertEquals(1, parts.length);
+        assertEquals("nodots", parts[0]);
+    }
+
+    public void testSplitTrailingDelimiter()
+    {
+        String[] parts = Strings.split("trailing.", '.');
+        assertEquals(2, parts.length);
+        assertEquals("trailing", parts[0]);
+        assertEquals("", parts[1]);
+    }
+
+    public void testSplitOnlyDelimiter()
+    {
+        String[] parts = Strings.split(".", '.');
+        assertEquals(2, parts.length);
+        assertEquals("", parts[0]);
+        assertEquals("", parts[1]);
+    }
+
+    public void testSplitConsecutiveDelimiters()
+    {
+        String[] parts = Strings.split("a..b", '.');
+        assertEquals(3, parts.length);
+        assertEquals("a", parts[0]);
+        assertEquals("", parts[1]);
+        assertEquals("b", parts[2]);
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/bcgit/bc-java/issues/1481

The split method incorrectly treated delimiters at index 0 as 'no delimiter found' because the condition used 'tokenLocation > 0' instead of '>= 0'.

This caused issues in PKIXNameConstraintValidator.withinDomain() when processing DNS name constraints with leading dots (e.g., '.example.com'). The method would return the entire string as a single element instead of properly splitting it, causing certificate validation to fail when both Root CA and Subordinate CA had the same dNSName in NameConstraints.

Fix: Change 'tokenLocation > 0' to 'tokenLocation >= 0'

Before: Strings.split(".permitted", '.') -> [".permitted"]
After:  Strings.split(".permitted", '.') -> ["", "permitted"]