### PR TITLE
Address PKIXNameConstraintValidator Bug

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/x509/PKIXNameConstraintValidator.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/PKIXNameConstraintValidator.java
@@ -1453,6 +1453,10 @@ public class PKIXNameConstraintValidator
                     {
                         intersect.add(dns);
                     }
+                    else if (_permitted.equals(dns))
+                    {
+                        intersect.add(dns);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Addresses a bug in the intersectDNS function of PKIXNameConstraintValidator that treats DNS names with the same value as not within their domain. This leads to an issue where if there exist a certificate root and subordinate with the same name constraint, neither will be recognized.