### PR TITLE
AbstractOpenPGPDocumentSignatureGenerator: Properly apply signature c…

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/api/AbstractOpenPGPDocumentSignatureGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/AbstractOpenPGPDocumentSignatureGenerator.java
@@ -251,7 +251,7 @@ public class AbstractOpenPGPDocumentSignatureGenerator<T extends AbstractOpenPGP
         }
 
         return Utils.getPgpSignatureGenerator(implementation, signingKey.getPGPPublicKey(),
-            unlockedKey.getPrivateKey(), parameters, null, null);
+            unlockedKey.getPrivateKey(), parameters, parameters.getSignatureCreationTime(), null);
     }
 
     private int getPreferredHashAlgorithm(OpenPGPCertificate.OpenPGPComponentKey key)

--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPKeyEditor.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPKeyEditor.java
@@ -262,7 +262,7 @@ public class OpenPGPKeyEditor
 
         PGPPublicKey publicPrimaryKey = key.getPrimaryKey().getPGPPublicKey();
 
-        final PGPSignature backSig = Utils.getBackSignature(signingSubkey, backSigParameters, publicPrimaryKey, implementation, null);
+        final PGPSignature backSig = Utils.getBackSignature(signingSubkey, backSigParameters, publicPrimaryKey, implementation, backSigParameters.getSignatureCreationTime());
 
         updateKey(signingSubkey, bindingSigCallback, publicPrimaryKey, new Utils.HashedSubpacketsOperation()
         {


### PR DESCRIPTION
…reation time from SignatureParameters

This fixes OpenPGPMessageGenerator not applying custom signature creation times for message signatures.

```
        // Generate message at t1
        OpenPGPMessageGenerator mGen = api.signAndOrEncryptMessage()
                .addSigningKey(key, new SignatureParameters.Callback() {
                    @Override
                    public SignatureParameters apply(SignatureParameters parameters) {
                        return parameters.setSignatureCreationTime(t1); // this call was ignored, but is fixed with the patch.
                    }
                });
```