### PR TITLE
use FIDO_ED_25519 for parsing fido ed25519 keys

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/util/OpenSSHPublicKeyUtil.java
+++ b/core/src/main/java/org/bouncycastle/crypto/util/OpenSSHPublicKeyUtil.java
@@ -203,7 +203,7 @@ public class OpenSSHPublicKeyUtil
 
             result = new Ed25519PublicKeyParameters(pubKeyBytes, 0);
         }
-        else if (FIDO2_EC_P256.equals(magic))
+        else if (FIDO_ED_25519.equals(magic))
         {
             byte[] pubKeyBytes = buffer.readBlock();
             if (pubKeyBytes.length != Ed25519PublicKeyParameters.KEY_SIZE)


### PR DESCRIPTION
Just a small fix. The comparison for ed25510 Fido2 Keys was probably done against the wrong static variable. 
So "magic" is compared twice against FIDO2_EC_P256 and the FIDO_ED_25519 was missing.

 Closes issue #2266 
