### PR TITLE
OpenPGPCertificate: Add methods missing for Web-of-Trust implementations

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
@@ -1098,7 +1098,14 @@ public class OpenPGPCertificate
         return getPrimaryKey().getKeyExpirationDateAt(evaluationTime);
     }
 
-    public List<OpenPGPComponentSignature> getAllThirdPartySignatures()
+    /**
+     * Return a list containing all third-party issued key signatures on the primary key (delegations
+     * and revocations).
+     * Note: This list DOES NOT contain third-party certifications over user-ids.
+     *
+     * @return third-party key signatures
+     */
+    public List<OpenPGPComponentSignature> getAllThirdPartyKeySignatures()
     {
         List<OpenPGPComponentSignature> signatures = new ArrayList<>();
         signatures.addAll(getPrimaryKey().getThirdPartyCertifications());
@@ -1111,9 +1118,13 @@ public class OpenPGPCertificate
      * third-party {@link OpenPGPCertificate} on this certificates primary key.
      * A delegation is a signature of type {@link PGPSignature#DIRECT_KEY}, which represents a
      * delegation of trust and can be used to mark the certificate as a trusted introducer.
+     * Each delegation is returned as an {@link OpenPGPSignatureChain} where the delegation
+     * is the leaf link prepended by the binding signature chain of the issuing third-party
+     * certificate component at delegation signature creation time.
      *
      * @param thirdPartyCertificate third-party certificate which issued the delegation signatures
-     * @return all delegations by the third-party certificate over this certificate
+     * @return full signature chains of all delegations by the third-party certificate over this
+     *         certificate
      */
     public OpenPGPSignatureChains getDelegationsBy(OpenPGPCertificate thirdPartyCertificate)
     {
@@ -1124,10 +1135,13 @@ public class OpenPGPCertificate
     /**
      * Return an {@link OpenPGPSignatureChain} from the given 3rd-party certificate to this certificate,
      * which represents a delegation of trust.
+     * The delegation is returned as an {@link OpenPGPSignatureChain} where the delegation
+     * is the leaf link prepended by the binding signature chain of the issuing third-party
+     * certificate component at delegation signature creation time.
      * If no delegation signature is found, return null.
      *
      * @param thirdPartyCertificate {@link OpenPGPCertificate} of a 3rd party.
-     * @return chain containing the latest delegation issued by the 3rd-party certificate
+     * @return full signature chain of the latest delegation issued by the 3rd-party certificate
      */
     public OpenPGPSignatureChain getDelegationBy(OpenPGPCertificate thirdPartyCertificate)
     {
@@ -1137,11 +1151,15 @@ public class OpenPGPCertificate
     /**
      * Return an {@link OpenPGPSignatureChain} from the given 3rd-party certificate to this certificate,
      * which represents a delegation of trust at evaluation time.
+     * The delegation is returned as an {@link OpenPGPSignatureChain} where the delegation
+     * is the leaf link prepended by the binding signature chain of the issuing third-party
+     * certificate component at delegation signature creation time.
      * If no delegation signature is found, return null.
      *
      * @param thirdPartyCertificate {@link OpenPGPCertificate} of a 3rd party.
      * @param evaluationTime        reference time
-     * @return chain containing the (at evaluation time) latest delegation issued by the 3rd-party certificate
+     * @return full signature chain of the (at evaluation time) latest delegation issued by the
+     *         3rd-party certificate
      */
     public OpenPGPSignatureChain getDelegationBy(
         OpenPGPCertificate thirdPartyCertificate,
@@ -1155,9 +1173,13 @@ public class OpenPGPCertificate
      * third-party {@link OpenPGPCertificate} on this certificates primary key.
      * A delegation revocation is a signature of type {@link PGPSignature#KEY_REVOCATION}, which revokes an earlier
      * delegation of trust.
+     * Each revocation is returned as an {@link OpenPGPSignatureChain} where the revocation
+     * is the leaf link prepended by the binding signature chain of the issuing third-party
+     * certificate component at revocation signature creation time.
      *
      * @param thirdPartyCertificate third-party certificate which issued the revocation signatures
-     * @return all revocations by the third-party certificate over this certificate
+     * @return full signature chains for all revocations by the third-party certificate over this
+     *         certificate
      */
     public OpenPGPSignatureChains getRevocationsBy(OpenPGPCertificate thirdPartyCertificate)
     {
@@ -1167,9 +1189,13 @@ public class OpenPGPCertificate
     /**
      * Return an {@link OpenPGPSignatureChain} from the given 3rd-party certificate to this certificate,
      * which represents a revocation of trust.
+     * The revocation is returned as an {@link OpenPGPSignatureChain} where the revocation
+     * is the leaf link prepended by the binding signature chain of the issuing third-party
+     * certificate component at revocation signature creation time.
      *
      * @param thirdPartyCertificate {@link OpenPGPCertificate} of a 3rd party.
-     * @return chain containing the latest revocation issued by the 3rd party certificate
+     * @return full signature chain containing the latest revocation issued by the 3rd party
+     *         certificate
      */
     public OpenPGPSignatureChain getRevocationBy(OpenPGPCertificate thirdPartyCertificate)
     {
@@ -1179,10 +1205,14 @@ public class OpenPGPCertificate
     /**
      * Return an {@link OpenPGPSignatureChain} from the given 3rd-party certificate to this certificate,
      * which (at evaluation time) represents a revocation of trust.
+     * The revocation is returned as an {@link OpenPGPSignatureChain} where the revocation
+     * is the leaf link prepended by the binding signature chain of the issuing third-party
+     * certificate component at revocation signature creation time.
      *
      * @param thirdPartyCertificate {@link OpenPGPCertificate} of a 3rd party.
      * @param evaluationTime        reference time
-     * @return chain containing the (at evaluation time) latest revocation issued by the 3rd party certificate
+     * @return full signature chain containing the (at evaluation time) latest revocation issued
+     *         by the 3rd party certificate
      */
     public OpenPGPSignatureChain getRevocationBy(
         OpenPGPCertificate thirdPartyCertificate,
@@ -2845,17 +2875,31 @@ public class OpenPGPCertificate
             return primaryKey;
         }
 
+        /**
+         * Return all third-party certification signatures issued by the third-party certificate over
+         * this component.
+         * Each certification is returned as an {@link OpenPGPSignatureChain} where the certification
+         * is the leaf link prepended by the binding signature chain of the issuing third-party
+         * certificate component at certification signature creation time.
+         *
+         * @param thirdPartyCertificate third-party certificate
+         * @return all certifications by the third-party cert as full signature chains
+         */
         public OpenPGPSignatureChains getCertificationsBy(OpenPGPCertificate thirdPartyCertificate)
         {
             return getThirdPartySignatureChainsBy(thirdPartyCertificate)
                     .getCertifications();
         }
+
         /**
-         * Return the latest {@link OpenPGPSignatureChain} containing a certification issued by the given
-         * 3rd-party certificate over this identity component.
+         * Return the latest third-party certification signature issued by the third-party certificate
+         * over this component.
+         * The certification is returned as an {@link OpenPGPSignatureChain} where the certification
+         * is the leaf link prepended by the binding signature chain of the issuing third-party
+         * certificate component at certification signature creation time.
          *
-         * @param thirdPartyCertificate certificate of a 3rd party
-         * @return 3rd party certification
+         * @param thirdPartyCertificate third-party certificate
+         * @return latest certification by the third-party cert as full signature chain
          */
         public OpenPGPSignatureChain getCertificationBy(OpenPGPCertificate thirdPartyCertificate)
         {
@@ -2863,12 +2907,15 @@ public class OpenPGPCertificate
         }
 
         /**
-         * Return the latest (at evaluation time) {@link OpenPGPSignatureChain} containing a certification
-         * issued by the given 3rd-party certificate over this identity component.
+         * Return the - at evaluation time - latest third-party certification signature issued by the
+         * third-party certificate over this component.
+         * The certification is returned as an {@link OpenPGPSignatureChain} where the certification
+         * is the leaf link prepended by the binding signature chain of the issuing third-party
+         * certificate component at certification signature creation time.
          *
-         * @param evaluationTime        reference time
-         * @param thirdPartyCertificate certificate of a 3rd party
-         * @return 3rd party certification
+         * @param thirdPartyCertificate third-party certificate
+         * @param evaluationTime reference time
+         * @return at reference time latest certification by the third-party cert as full signature chain
          */
         public OpenPGPSignatureChain getCertificationBy(
             OpenPGPCertificate thirdPartyCertificate,
@@ -2877,6 +2924,16 @@ public class OpenPGPCertificate
             return getCertificationsBy(thirdPartyCertificate).getCertificationAt(evaluationTime);
         }
 
+        /**
+         * Return all third-party revocation signatures issued by the third-party certificate over
+         * this component.
+         * Each revocation is returned as an {@link OpenPGPSignatureChain} where the revocation is the
+         * leaf link prepended by the binding signature chain of the issuing third-party certificate
+         * component at revocation signature creation time.
+         *
+         * @param thirdPartyCertificate third-party certificate
+         * @return all revocations by the third-party cert as full signature chains
+         */
         public OpenPGPSignatureChains getRevocationsBy(OpenPGPCertificate thirdPartyCertificate)
         {
             return getMergedDanglingExternalSignatureChainEndsFrom(thirdPartyCertificate)
@@ -2884,11 +2941,14 @@ public class OpenPGPCertificate
         }
 
         /**
-         * Return the latest {@link OpenPGPSignatureChain} containing a revocation issued by the given
-         * 3rd-party certificate over this identity component.
+         * Return the latest third-party revocation signature issued by the third-party certificate
+         * over this component.
+         * The revocation is returned as an {@link OpenPGPSignatureChain} where the revocation is the
+         * leaf link prepended by the binding signature chain of the issuing third-party certificate
+         * component at revocation signature creation time.
          *
-         * @param thirdPartyCertificate certificate of a 3rd party
-         * @return 3rd party revocation signature
+         * @param thirdPartyCertificate third-party certificate
+         * @return latest revocation by the third-party cert as full signature chain
          */
         public OpenPGPSignatureChain getRevocationBy(OpenPGPCertificate thirdPartyCertificate)
         {
@@ -2896,12 +2956,15 @@ public class OpenPGPCertificate
         }
 
         /**
-         * Return the latest (at evaluation time) {@link OpenPGPSignatureChain} containing a revocation issued by the given
-         * 3rd-party certificate over this identity component.
+         * Return the - at evaluation time - latest third-party revocation signature issued by the
+         * third-party certificate over this component.
+         * The revocation is returned as an {@link OpenPGPSignatureChain} where the revocation is the
+         * leaf link prepended by the binding signature chain of the issuing third-party certificate
+         * component at revocation signature creation time.
          *
-         * @param thirdPartyCertificate certificate of a 3rd party
-         * @param evaluationTime        reference time
-         * @return 3rd party revocation signature
+         * @param thirdPartyCertificate third-party certificate
+         * @param evaluationTime reference time
+         * @return at reference time latest revocation by the third-party cert as full signature chain
          */
         public OpenPGPSignatureChain getRevocationBy(
             OpenPGPCertificate thirdPartyCertificate,

--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
@@ -713,7 +713,8 @@ public class OpenPGPCertificate
                                                        Date evaluationDate)
     {
         // Check if there are signatures at all for the component
-        OpenPGPSignatureChains chainsForComponent = getAllSignatureChainsFor(component);
+        OpenPGPSignatureChains chainsForComponent = getAllSignatureChainsFor(component)
+                .fromOrigin(origin);
         boolean isPrimaryKey = component == getPrimaryKey();
         if (isPrimaryKey && chainsForComponent.getCertificationAt(evaluationDate) == null)
         {
@@ -721,19 +722,17 @@ public class OpenPGPCertificate
             OpenPGPUserId primaryUserId = getPrimaryUserId(evaluationDate);
             if (primaryUserId != null)
             {
-                chainsForComponent.addAll(getAllSignatureChainsFor(primaryUserId));
+                chainsForComponent.addAll(getAllSignatureChainsFor(primaryUserId).fromOrigin(origin));
             }
         }
 
-        // Isolate chains which originate from the passed origin key component
-        OpenPGPSignatureChains fromOrigin = chainsForComponent.fromOrigin(origin);
-        if (fromOrigin == null)
+        if (chainsForComponent == null)
         {
             return null;
         }
 
         // Return chain that currently takes precedence
-        return fromOrigin.getChainAt(evaluationDate);
+        return chainsForComponent.getChainAt(evaluationDate);
     }
 
     private OpenPGPSignatureChains getSelfSignatureChainsFor(OpenPGPCertificateComponent component)

--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
@@ -736,6 +736,11 @@ public class OpenPGPCertificate
         return fromOrigin.getChainAt(evaluationDate);
     }
 
+    private OpenPGPSignatureChains getSelfSignatureChainsFor(OpenPGPCertificateComponent component)
+    {
+        return getAllSignatureChainsFor(component).fromOrigin(getPrimaryKey());
+    }
+
     /**
      * Return all {@link OpenPGPSignatureChain OpenPGPSignatureChains} binding the given
      * {@link OpenPGPCertificateComponent}.
@@ -979,8 +984,7 @@ public class OpenPGPCertificate
      */
     private OpenPGPSignatureChain getPreferenceSignature(Date evaluationTime)
     {
-        OpenPGPSignatureChain directKeyBinding = getPrimaryKey().getSignatureChains()
-            .fromOrigin(getPrimaryKey())
+        OpenPGPSignatureChain directKeyBinding = getPrimaryKey().getSelfSignatureChains()
             .getCertificationAt(evaluationTime);
 
         if (directKeyBinding != null)
@@ -991,8 +995,8 @@ public class OpenPGPCertificate
         List<OpenPGPSignatureChain> uidBindings = new ArrayList<OpenPGPSignatureChain>();
         for (Iterator<OpenPGPUserId> it = getPrimaryKey().getUserIDs().iterator(); it.hasNext(); )
         {
-            OpenPGPSignatureChain uidBinding = getAllSignatureChainsFor(it.next())
-                .fromOrigin(getPrimaryKey()).getCertificationAt(evaluationTime);
+            OpenPGPSignatureChain uidBinding = getSelfSignatureChainsFor(it.next())
+                    .getCertificationAt(evaluationTime);
 
             if (uidBinding != null)
             {
@@ -1226,6 +1230,16 @@ public class OpenPGPCertificate
         }
 
         /**
+         * Return all self-signature chains on components of this certificate.
+         *
+         * @return self-signature chains
+         */
+        protected OpenPGPSignatureChains getSelfSignatureChains()
+        {
+            return getSignatureChains().fromOrigin(getCertificate().getPrimaryKey());
+        }
+
+        /**
          * Return the (at evaluation time) latest self certification signature binding this component.
          *
          * @param evaluationTime reference time
@@ -1233,8 +1247,7 @@ public class OpenPGPCertificate
          */
         public OpenPGPComponentSignature getCertification(Date evaluationTime)
         {
-            OpenPGPSignatureChain certification = getSignatureChains()
-                    .fromOrigin(getCertificate().getPrimaryKey())
+            OpenPGPSignatureChain certification = getSelfSignatureChains()
                     .getCertificationAt(evaluationTime);
             if (certification != null)
             {
@@ -1251,8 +1264,7 @@ public class OpenPGPCertificate
          */
         public OpenPGPComponentSignature getRevocation(Date evaluationTime)
         {
-            OpenPGPSignatureChain revocation = getSignatureChains()
-                    .fromOrigin(getCertificate().getPrimaryKey())
+            OpenPGPSignatureChain revocation = getSelfSignatureChains()
                     .getRevocationAt(evaluationTime);
             if (revocation != null)
             {
@@ -1533,8 +1545,7 @@ public class OpenPGPCertificate
          */
         protected OpenPGPSignature.OpenPGPSignatureSubpacket getApplyingSubpacket(Date evaluationTime, int subpacketType)
         {
-            OpenPGPSignatureChain binding = getSignatureChains()
-                    .fromOrigin(getCertificate().getPrimaryKey())
+            OpenPGPSignatureChain binding = getSelfSignatureChains()
                     .getCertificationAt(evaluationTime);
             if (binding == null)
             {
@@ -2149,8 +2160,7 @@ public class OpenPGPCertificate
         @Override
         public OpenPGPComponentSignature getLatestSelfSignature(Date evaluationTime)
         {
-            OpenPGPSignatureChain currentDKChain = getSignatureChains()
-                .fromOrigin(getCertificate().getPrimaryKey())
+            OpenPGPSignatureChain currentDKChain = getSelfSignatureChains()
                 .getChainAt(evaluationTime);
             if (currentDKChain != null && !currentDKChain.chainLinks.isEmpty())
             {
@@ -2338,8 +2348,7 @@ public class OpenPGPCertificate
         public OpenPGPComponentSignature getLatestDirectKeySelfSignature(Date evaluationTime)
         {
             OpenPGPSignatureChain currentDKChain = getCertificate()
-                .getAllSignatureChainsFor(this)
-                .fromOrigin(this)
+                .getSelfSignatureChainsFor(this)
                 .getCertificationAt(evaluationTime);
             if (currentDKChain != null && !currentDKChain.chainLinks.isEmpty())
             {
@@ -2368,8 +2377,7 @@ public class OpenPGPCertificate
         public OpenPGPComponentSignature getLatestKeyRevocationSelfSignature(Date evaluationTime)
         {
             OpenPGPSignatureChain currentRevocationChain = getCertificate()
-                .getAllSignatureChainsFor(this)
-                .fromOrigin(this)
+                .getSelfSignatureChainsFor(this)
                 .getRevocationAt(evaluationTime);
             if (currentRevocationChain != null && !currentRevocationChain.chainLinks.isEmpty())
             {
@@ -2718,8 +2726,7 @@ public class OpenPGPCertificate
         @Override
         public OpenPGPComponentSignature getLatestSelfSignature(Date evaluationTime)
         {
-            OpenPGPSignatureChain currentChain = getSignatureChains()
-                    .fromOrigin(getPrimaryKey())
+            OpenPGPSignatureChain currentChain = getSelfSignatureChains()
                     .getChainAt(evaluationTime);
             if (currentChain != null && !currentChain.chainLinks.isEmpty())
             {

--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
@@ -3017,6 +3017,53 @@ public class OpenPGPCertificate
      * An {@link OpenPGPSignatureChain} can either be a certification
      * ({@link #isCertification()}), e.g. it represents a positive binding,
      * or it can be a revocation ({@link #isRevocation()}) which invalidates a positive binding.
+     * <p>
+     * Example:
+     * <pre>
+     *           [PRIMARY KEY 0xAAAA]<--------_
+     *            /         \       \         |
+     *           /           \       \__(DIRECT KEY SIG #0)
+     *   (USERID BINDING #1) |
+     *          |    (SUBKEY BINDING #2)
+     *          v           |
+     *  [USERID Alice]      v
+     *                  [SUBKEY 0xAABB]
+     * </pre>
+     * Here, the certificates components are bound like follows:
+     * <ul>
+     *     <li>Primary Key {@code 0xAAAA}: {@code [0xAAAA->#0->0xAAAA]}</li>
+     *     <li>UserID {@code Alice}: {@code [0xAAAA->#0->#1->Alice]}</li>
+     *     <li>Subkey {@code 0xAABB}: {@code [0xAAAA->#0->#2->0xAABB]}</li>
+     * </ul>
+     * Note: If the certificate does not carry a direct-key self-signature, the primary user-id
+     * binding would be used as root link in its place.
+     * A binding can also be a revocation. In such case, the whole chain represents a revocation.
+     * <p>
+     * In Web-of-Trust scenarios, signature chains can span multiple certificates.
+     * <p>
+     * Example:
+     * <pre>
+     *                               ________________
+     *                              v               |
+     *               [PRIMARY KEY 0xAAAA]---(DIRECT KEY SIG #0)
+     *               /         |     \
+     *  (USERID BINDING #1)    |      \
+     *        |                |  (DELEGATION #2)-->[PRIMARY KEY 0xBBBB]
+     *        |                \                            |
+     *        v                 \                  (USERID BINDING #3)
+     * [USERID Alice]      (CERTIFICATION #4)               |
+     *                             \                        v
+     *                              \________________>[USERID Bob]
+     * </pre>
+     * Here, Alice delegated trust to Bob by issuing a direct key delegation signature ({@code #0})
+     * over Bobs primary key, as well as a 3rd-party certification signature for UserID Bob.
+     * Now there are the following paths of trust from Alice's certificate down to Bobs certificate:
+     * <ul>
+     *     <li>Bobs Certificate (primary key {@code 0xBBBB}): {@code [0xAAAA->#0->#2->0xBBBB}</li>
+     *     <li>Bobs UserID {@code Bob}: {@code [0xAAAA->#0->#4->Bob}</li>
+     * </ul>
+     * Note, that certificate {@code 0xAAAA} holds signatures {@code #0,#1}, while
+     * certificate {@code 0xBBBB} holds signatures {@code #2,#3,#4}.
      */
     public static class OpenPGPSignatureChain
         implements Comparable<OpenPGPSignatureChain>, Iterable<OpenPGPSignatureChain.Link>

--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
@@ -1725,6 +1725,17 @@ public class OpenPGPCertificate
         /**
          * Verify this signature.
          *
+         * @throws PGPSignatureException if the signature cannot be verified successfully
+         */
+        public void verify()
+            throws PGPSignatureException
+        {
+            verify(getIssuerCertificate().implementation);
+        }
+
+        /**
+         * Verify this signature.
+         *
          * @param implementation OpenPGP implementation
          * @throws PGPSignatureException if the signature cannot be verified successfully
          */

--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
@@ -3083,7 +3083,8 @@ public class OpenPGPCertificate
      * <p>
      * Example:
      * <pre>
-     *           [PRIMARY KEY 0xAAAA]<--------_
+     *                           v-----------\
+     *           [PRIMARY KEY 0xAAAA]         \
      *            /         \       \         |
      *           /           \       \__(DIRECT KEY SIG #0)
      *   (USERID BINDING #1) |

--- a/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/api/OpenPGPCertificate.java
@@ -1098,6 +1098,29 @@ public class OpenPGPCertificate
         return getPrimaryKey().getKeyExpirationDateAt(evaluationTime);
     }
 
+    public List<OpenPGPComponentSignature> getAllThirdPartySignatures()
+    {
+        List<OpenPGPComponentSignature> signatures = new ArrayList<>();
+        signatures.addAll(getPrimaryKey().getThirdPartyCertifications());
+        signatures.addAll(getPrimaryKey().getThirdPartyRevocations());
+        return signatures;
+    }
+
+    /**
+     * Return all {@link OpenPGPSignatureChains} that represent delegations by the given
+     * third-party {@link OpenPGPCertificate} on this certificates primary key.
+     * A delegation is a signature of type {@link PGPSignature#DIRECT_KEY}, which represents a
+     * delegation of trust and can be used to mark the certificate as a trusted introducer.
+     *
+     * @param thirdPartyCertificate third-party certificate which issued the delegation signatures
+     * @return all delegations by the third-party certificate over this certificate
+     */
+    public OpenPGPSignatureChains getDelegationsBy(OpenPGPCertificate thirdPartyCertificate)
+    {
+        return getPrimaryKey().getThirdPartySignatureChainsBy(thirdPartyCertificate)
+                .getCertifications();
+    }
+
     /**
      * Return an {@link OpenPGPSignatureChain} from the given 3rd-party certificate to this certificate,
      * which represents a delegation of trust.
@@ -1124,11 +1147,23 @@ public class OpenPGPCertificate
         OpenPGPCertificate thirdPartyCertificate,
         Date evaluationTime)
     {
-        OpenPGPSignatureChains chainsBy = getPrimaryKey().
-            getMergedDanglingExternalSignatureChainEndsFrom(thirdPartyCertificate, evaluationTime);
-        return chainsBy.getCertificationAt(evaluationTime);
+        return getDelegationsBy(thirdPartyCertificate).getCertificationAt(evaluationTime);
     }
 
+    /**
+     * Return all {@link OpenPGPSignatureChains} that represent revocations of delegations by the given
+     * third-party {@link OpenPGPCertificate} on this certificates primary key.
+     * A delegation revocation is a signature of type {@link PGPSignature#KEY_REVOCATION}, which revokes an earlier
+     * delegation of trust.
+     *
+     * @param thirdPartyCertificate third-party certificate which issued the revocation signatures
+     * @return all revocations by the third-party certificate over this certificate
+     */
+    public OpenPGPSignatureChains getRevocationsBy(OpenPGPCertificate thirdPartyCertificate)
+    {
+        return getPrimaryKey().getThirdPartySignatureChainsBy(thirdPartyCertificate)
+                .getRevocations();
+    }
     /**
      * Return an {@link OpenPGPSignatureChain} from the given 3rd-party certificate to this certificate,
      * which represents a revocation of trust.
@@ -1153,9 +1188,8 @@ public class OpenPGPCertificate
         OpenPGPCertificate thirdPartyCertificate,
         Date evaluationTime)
     {
-        OpenPGPSignatureChains chainsBy = getPrimaryKey()
-            .getMergedDanglingExternalSignatureChainEndsFrom(thirdPartyCertificate, evaluationTime);
-        return chainsBy.getRevocationAt(evaluationTime);
+        return getRevocationsBy(thirdPartyCertificate)
+                .getRevocationAt(evaluationTime);
     }
 
     /**
@@ -1239,6 +1273,28 @@ public class OpenPGPCertificate
         }
 
         /**
+         * Return all third-party signature chains originating from the given certificate on this certificate.
+         *
+         * @param thirdPartyCertificate third-party certificate
+         * @return all signature chains over this component which originate at the given third-party certificate.
+         */
+        protected OpenPGPSignatureChains getThirdPartySignatureChainsBy(
+                OpenPGPCertificate thirdPartyCertificate)
+        {
+            return getMergedDanglingExternalSignatureChainEndsFrom(thirdPartyCertificate);
+        }
+
+        /**
+         * Return the latest self-signature certification binding this component.
+         *
+         * @return latest component certification signature
+         */
+        public OpenPGPComponentSignature getCertification()
+        {
+            return getCertification(new Date());
+        }
+
+        /**
          * Return the (at evaluation time) latest self certification signature binding this component.
          *
          * @param evaluationTime reference time
@@ -1256,6 +1312,16 @@ public class OpenPGPCertificate
         }
 
         /**
+         * Return the latest revocation signature on this component.
+         *
+         * @return latest revocation
+         */
+        public OpenPGPComponentSignature getRevocation()
+        {
+            return getRevocation(new Date());
+        }
+
+        /**
          * Return the (at evaluation time) latest self revocation signature revoking this component.
          *
          * @param evaluationTime reference time
@@ -1270,6 +1336,46 @@ public class OpenPGPCertificate
                 return revocation.getSignature();
             }
             return null;
+        }
+
+        /**
+         * Return a list of all third-party-issued certifying
+         * {@link OpenPGPComponentSignature OpenPGPComponentSignatures} on this component.
+         *
+         * @return all third-party issued certification signatures on this component.
+         */
+        public List<OpenPGPComponentSignature> getThirdPartyCertifications()
+        {
+            OpenPGPSignatureChains allChains = getSignatureChains();
+            List<OpenPGPComponentSignature> thirdPartyCertifications = new ArrayList<>();
+            for (OpenPGPSignatureChain chain : allChains)
+            {
+                if (chain.isCertification() && chain.getRootLinkIssuer() == null)
+                {
+                    thirdPartyCertifications.add(chain.getSignature());
+                }
+            }
+            return thirdPartyCertifications;
+        }
+
+        /**
+         * Return a list of all third-party-issued revoking
+         * {@link OpenPGPComponentSignature OpenPGPComponentSignatures} on this component.
+         *
+         * @return all third-party issued revocation signatures on this component.
+         */
+        public List<OpenPGPComponentSignature> getThirdPartyRevocations()
+        {
+            OpenPGPSignatureChains allChains = getSignatureChains();
+            List<OpenPGPComponentSignature> thirdPartyRevocations = new ArrayList<>();
+            for (OpenPGPSignatureChain chain : allChains)
+            {
+                if (chain.isRevocation() && chain.getRootLinkIssuer() == null)
+                {
+                    thirdPartyRevocations.add(chain.getSignature());
+                }
+            }
+            return thirdPartyRevocations;
         }
 
         /**
@@ -1596,36 +1702,35 @@ public class OpenPGPCertificate
         }
 
         /**
-         * Iterate over signatures issued over this component by the given 3rd-party certificate,
-         * merge them with the (at evaluation time) valid self-certification chain and return the
-         * results.
-         *
-         * @param thirdPartyCertificate certificate of a 3rd party
-         * @param evaluationTime        reference time
-         * @return all 3rd party signatures on this component, merged with their issuer chains
+         * Find all third-party {@link OpenPGPComponentSignature component signatures} on this component, which
+         * were issued by the given third-party certificate. Find the {@link OpenPGPSignatureChains} binding the
+         * issuing component key and append the third-party signatures as leaf links. Return all such chains.
+         * This is a utility method for third-party signature chain evaluation.
+         * @param thirdPartyCertificate third-party certificate
+         * @return dangling external signatures with issuer signature chains prepended
          */
         protected OpenPGPSignatureChains getMergedDanglingExternalSignatureChainEndsFrom(
-            OpenPGPCertificate thirdPartyCertificate,
-            Date evaluationTime)
+                OpenPGPCertificate thirdPartyCertificate)
         {
             OpenPGPSignatureChains chainsBy = new OpenPGPSignatureChains(this);
 
-            OpenPGPSignatureChains allChains = getCertificate().getAllSignatureChainsFor(this)
-                .getChainsAt(evaluationTime);
+            OpenPGPSignatureChains allChains = getCertificate().getAllSignatureChainsFor(this);
+
             for (Iterator<OpenPGPSignatureChain> it = allChains.iterator(); it.hasNext(); )
             {
                 OpenPGPSignatureChain.Link rootLink = it.next().getRootLink();
-                for (Iterator<OpenPGPComponentKey> it2 = thirdPartyCertificate.getKeys().iterator(); it2.hasNext(); )
+                for (Iterator<OpenPGPComponentKey> thirdPartyKeys = thirdPartyCertificate.getKeys().iterator(); thirdPartyKeys.hasNext(); )
                 {
-                    OpenPGPComponentKey issuerKey = it2.next();
+                    OpenPGPComponentKey issuerKey = thirdPartyKeys.next();
                     if (KeyIdentifier.matches(
-                        rootLink.getSignature().getKeyIdentifiers(),
-                        issuerKey.getKeyIdentifier(),
-                        true))
+                            rootLink.getSignature().getKeyIdentifiers(),
+                            issuerKey.getKeyIdentifier(),
+                            true))
                     {
-                        OpenPGPSignatureChain externalChain = issuerKey.getSignatureChains().getChainAt(evaluationTime);
+                        OpenPGPSignatureChain externalChain = issuerKey.getSelfSignatureChains()
+                                .getChainAt(rootLink.getSignature().getCreationTime());
                         externalChain = externalChain.plus(
-                            new OpenPGPComponentSignature(rootLink.signature.getSignature(), issuerKey, this));
+                                new OpenPGPComponentSignature(rootLink.signature.getSignature(), issuerKey, this));
                         chainsBy.add(externalChain);
                     }
                 }
@@ -2740,6 +2845,11 @@ public class OpenPGPCertificate
             return primaryKey;
         }
 
+        public OpenPGPSignatureChains getCertificationsBy(OpenPGPCertificate thirdPartyCertificate)
+        {
+            return getThirdPartySignatureChainsBy(thirdPartyCertificate)
+                    .getCertifications();
+        }
         /**
          * Return the latest {@link OpenPGPSignatureChain} containing a certification issued by the given
          * 3rd-party certificate over this identity component.
@@ -2764,8 +2874,13 @@ public class OpenPGPCertificate
             OpenPGPCertificate thirdPartyCertificate,
             Date evaluationTime)
         {
-            OpenPGPSignatureChains chainsBy = getMergedDanglingExternalSignatureChainEndsFrom(thirdPartyCertificate, evaluationTime);
-            return chainsBy.getCertificationAt(evaluationTime);
+            return getCertificationsBy(thirdPartyCertificate).getCertificationAt(evaluationTime);
+        }
+
+        public OpenPGPSignatureChains getRevocationsBy(OpenPGPCertificate thirdPartyCertificate)
+        {
+            return getMergedDanglingExternalSignatureChainEndsFrom(thirdPartyCertificate)
+                    .getRevocations();
         }
 
         /**
@@ -2792,8 +2907,7 @@ public class OpenPGPCertificate
             OpenPGPCertificate thirdPartyCertificate,
             Date evaluationTime)
         {
-            OpenPGPSignatureChains chainsBy = getMergedDanglingExternalSignatureChainEndsFrom(thirdPartyCertificate, evaluationTime);
-            return chainsBy.getRevocationAt(evaluationTime);
+            return getRevocationsBy(thirdPartyCertificate).getRevocationAt(evaluationTime);
         }
 
         @Override
@@ -2894,10 +3008,12 @@ public class OpenPGPCertificate
     /**
      * Chain of {@link OpenPGPSignature signatures}.
      * Such a chain originates from a certificates primary key and points towards some certificate component that
-     * is bound to the certificate.
+     * is bound to a certificate.
      * As for example a subkey can only be bound by a primary key that holds either at least one
      * direct-key self-signature or at least one user-id binding signature, multiple signatures may form
      * a validity chain.
+     * Another example is a third-party certification over a user-id or certificates primary key. Here, the chain
+     * originates from the certifiers primary key and ends at the user-id or primary key of the signee.
      * An {@link OpenPGPSignatureChain} can either be a certification
      * ({@link #isCertification()}), e.g. it represents a positive binding,
      * or it can be a revocation ({@link #isRevocation()}) which invalidates a positive binding.
@@ -3537,6 +3653,44 @@ public class OpenPGPCertificate
         public boolean isEmpty()
         {
             return chains.isEmpty();
+        }
+
+        /**
+         * Filter for certifications.
+         *
+         * @return certification signature chains
+         */
+        public OpenPGPSignatureChains getCertifications()
+        {
+            OpenPGPSignatureChains certifications = new OpenPGPSignatureChains(targetComponent);
+            for (Iterator<OpenPGPSignatureChain> it = chains.iterator(); it.hasNext(); )
+            {
+                OpenPGPSignatureChain chain = it.next();
+                if (chain.isCertification())
+                {
+                    certifications.add(chain);
+                }
+            }
+            return certifications;
+        }
+
+        /**
+         * Filter for revocations.
+         *
+         * @return revocation signature chains
+         */
+        public OpenPGPSignatureChains getRevocations()
+        {
+            OpenPGPSignatureChains revocations = new OpenPGPSignatureChains(targetComponent);
+            for (Iterator<OpenPGPSignatureChain> it = chains.iterator(); it.hasNext(); )
+            {
+                OpenPGPSignatureChain chain = it.next();
+                if (chain.isRevocation())
+                {
+                    revocations.add(chain);
+                }
+            }
+            return revocations;
         }
 
         /**


### PR DESCRIPTION
This PR contains a number of patches I came up with when porting [pgpainless-wot](https://github.com/pgpainless/pgpainless-wot) to the high-level OpenPGP API (https://github.com/pgpainless/pgpainless-wot/pull/1)

https://github.com/bcgit/bc-java/commit/35b3fd768757454894136c455e40c1a63f29fe64 aims to reduce the errorprone-ness of the way signature chains are handled internally, by clearly separating signature chains of self-signatures and third-party signatures.

https://github.com/bcgit/bc-java/commit/4bcefcfb90d6eb3ae46cd480b0570d4909330d57 is a bugfix for `getSignatureChainsFor()` formerly returning self-signatures when querying for third-party signatures originating from a third-party certificate.

Lastly, https://github.com/bcgit/bc-java/commit/5a32a0f659d55e3c1f6936e1a1b4f55c9b5c2aca adds API methods required to access signature chains of third-party certifications and revocations when building a network graph for web-of-trust calculations.

Note, that the signature of `.getMergedDanglingExternalSignatureChainEndsFrom()` changed, but this method is only used internally, so it shouldn't be an issue backwards-compatibility-wise.