### PR TITLE
Update README for JDK25.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Note: the ./ is required in front of the key file name to tell gpg to look local
 
 ## Building overview
 
-This project can now be built and tested with JDK21. 
+This project can now be built and tested with JDK25.
 
-If the build script detects BC_JDK8, BC_JDK11, BC_JDK17 it will add to the usual test task a dependency on test tasks 
-that specifically use the JVMs addressed by those environmental variables. The script relies on JAVA_HOME for picking up Java 21 if it is use.
+If the build script detects BC_JDK8, BC_JDK11, BC_JDK17, BC_JDK21 it will add to the usual test task a dependency on test tasks 
+that specifically use the JVMs addressed by those environmental variables. The script relies on JAVA_HOME for picking up Java 25 if it is use.
 
 We support testing on specific JVMs as it is the only way to be certain the library is compatible.
 
@@ -43,6 +43,7 @@ The following environmental variables can optionally point to the JAVA_HOME for 
 export BC_JDK8=/path/to/java8
 export BC_JDK11=/path/to/java11
 export BC_JDK17=/path/to/java17
+export BC_JDK21=/path/to/java21
 ```
 
 ## Building
@@ -52,8 +53,8 @@ The project now uses ```gradlew``` which can be invoked for example:
 ```
 # from the root of the project
 
-# Ensure JAVA_HOME points to JDK 21 or higher JAVA_HOME or that
-# gradlew can find a java 21 installation to use.
+# Ensure JAVA_HOME points to JDK 25 or higher JAVA_HOME or that
+# gradlew can find a java 25 installation to use.
 
 
 ./gradlew clean build
@@ -71,9 +72,10 @@ If the env vars are defined:
 export BC_JDK8=/path/to/java8
 export BC_JDK11=/path/to/java11
 export BC_JDK17=/path/to/java17
+export BC_JDK21=/path/to/java21
 ```
 
-If only a Java 21 JDK is present then the normal test task and test21 are run only.
+If only a Java 25 JDK is present then the normal test task and test25 are run only.
 
 
 ## Code Organisation


### PR DESCRIPTION
The build now seems to work on (and require) JDK25 and the BC_JDK21 environment variable should be
added to the list of env variables.