### PR TITLE
disable DTDs and external entities in KMIPInputStream

### DIFF
--- a/kmip/src/main/java/org/bouncycastle/kmip/wire/KMIPInputStream.java
+++ b/kmip/src/main/java/org/bouncycastle/kmip/wire/KMIPInputStream.java
@@ -64,7 +64,10 @@ public class KMIPInputStream
     public KMIPInputStream(InputStream stream)
         throws XMLStreamException
     {
-        this.eventReader = XMLInputFactory.newInstance().createXMLEventReader(stream);
+        XMLInputFactory factory = XMLInputFactory.newInstance();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+        this.eventReader = factory.createXMLEventReader(stream);
     }
 
     public KMIPMessage[] parse()


### PR DESCRIPTION
1. KMIPInputStream builds its XMLEventReader from a bare XMLInputFactory, so a DOCTYPE in a parsed KMIP message is honoured and external SYSTEM entities get resolved as parse() pulls events.
2. a file:// or http:// entity then turns into a local file read or an outbound request from whichever side parses the message; aiming one at a missing path drops a "No such file or directory" straight out of the parse loop, which is the tell.
Set SUPPORT_DTD=false (and external entities off as a backstop) on the factory before creating the reader. Messages without a doctype parse exactly as before.