### PR TITLE
verify mls membership and confirmation tags in constant time

### DIFF
--- a/mls/src/main/java/org/bouncycastle/mls/codec/PublicMessage.java
+++ b/mls/src/main/java/org/bouncycastle/mls/codec/PublicMessage.java
@@ -94,7 +94,7 @@ public class PublicMessage
         if (content.sender.senderType == SenderType.MEMBER)
         {
             byte[] membershipTag = membershipMac(suite, membership_key, context);
-            if (!Arrays.areEqual(membershipTag, membership_tag))
+            if (!Arrays.constantTimeAreEqual(membershipTag, membership_tag))
             {
                 // throw tagMisMatch error!
                 throw new IOException("incorrect membership tag");

--- a/mls/src/main/java/org/bouncycastle/mls/protocol/Group.java
+++ b/mls/src/main/java/org/bouncycastle/mls/protocol/Group.java
@@ -624,7 +624,7 @@ public class Group
 
         // Verify confirmation tag
         byte[] confirmationTag = keySchedule.confirmationTag(transcriptHash.getConfirmed());
-        if (!Arrays.equals(confirmationTag, groupInfo.getConfirmationTag()))
+        if (!org.bouncycastle.util.Arrays.constantTimeAreEqual(confirmationTag, groupInfo.getConfirmationTag()))
         {
             throw new Exception("Confirmation failed to verify");
         }
@@ -820,7 +820,7 @@ public class Group
         // Verify the confirmation MAC
         byte[] confirmationTag = next.keySchedule.confirmationTag(next.transcriptHash.getConfirmed());
 
-        if (!Arrays.equals(auth.getConfirmationTag(), confirmationTag))
+        if (!org.bouncycastle.util.Arrays.constantTimeAreEqual(confirmationTag, auth.getConfirmationTag()))
         {
             throw new Exception("Confirmation failed to verify");
         }


### PR DESCRIPTION
found by auditing mls MAC verification: `PublicMessage.unprotect` and `Group` compared a secret-keyed HMAC membership/confirmation tag against the wire value with early-exit `Arrays.areEqual`/`Arrays.equals`, a byte-by-byte timing oracle reachable from `Group.handle(byte[])`, so all three sites now use `Arrays.constantTimeAreEqual` like the rest of the library.