### PR TITLE
PGPPBEEncryptedData: Expose keyData member

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPBEEncryptedData.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPBEEncryptedData.java
@@ -122,6 +122,11 @@ public class PGPPBEEncryptedData
         return keyData.getEncAlgorithm();
     }
 
+    public SymmetricKeyEncSessionPacket getKeyData()
+    {
+        return keyData;
+    }
+
     /**
      * Return the symmetric key algorithm required to decrypt the data protected by this object.
      *


### PR DESCRIPTION
PGPPBEEncryptedData: Expose keyData member in order to allow downstream parameter validation

Downstream applications like PGPainless may want to validate SKESK parameters, such as S2K parameters against application policies.
One notable example would be the Argon2 memoryExponent parameter, which - if not guarded - could result in OOM errors for large exponents.