### PR TITLE
Move Argon2 memory size exponent check to PGPPBEEncryptedData.checkPa…

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/S2K.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/S2K.java
@@ -159,11 +159,6 @@ public class S2K
             passes = dIn.read();
             parallelism = dIn.read();
             memorySizeExponent = dIn.read();
-            // TODO: should really be 3 + log2(parallelism)
-            if (memorySizeExponent < 3 || memorySizeExponent > Properties.asInteger(Argon2Parameters.MAX_MEMORY_EXP, 30))
-            {
-                throw new IOException("memory size exponent out of range");
-            }
             break;
 
         case GNU_DUMMY_S2K:

--- a/pg/src/main/java/org/bouncycastle/openpgp/PGPPBEEncryptedData.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/PGPPBEEncryptedData.java
@@ -3,6 +3,7 @@ package org.bouncycastle.openpgp;
 import java.io.InputStream;
 
 import org.bouncycastle.bcpg.InputStreamPacket;
+import org.bouncycastle.bcpg.S2K;
 import org.bouncycastle.bcpg.SymmetricEncDataPacket;
 import org.bouncycastle.bcpg.SymmetricEncIntegrityPacket;
 import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
@@ -133,6 +134,7 @@ public class PGPPBEEncryptedData
             PBEDataDecryptorFactory dataDecryptorFactory)
             throws PGPException
     {
+        checkParameterBounds();
         if (keyData.getVersion() == SymmetricKeyEncSessionPacket.VERSION_4)
         {
             // SKESK v4 stores cipher algorithm inside the encrypted session data
@@ -162,6 +164,7 @@ public class PGPPBEEncryptedData
     public PGPSessionKey getSessionKey(PBEDataDecryptorFactory dataDecryptorFactory)
             throws PGPException
     {
+        checkParameterBounds();
         byte[] key = dataDecryptorFactory.makeKeyFromPassPhrase(keyData.getEncAlgorithm(), keyData.getS2K());
 
         int version = getVersion();
@@ -235,6 +238,22 @@ public class PGPPBEEncryptedData
         catch (Exception e)
         {
             throw new PGPException("Exception creating cipher", e);
+        }
+    }
+
+    private void checkParameterBounds()
+            throws PGPException
+    {
+        if (keyData.getS2K().getType() != S2K.ARGON_2)
+        {
+            return;
+        }
+
+        int memorySizeExponent = keyData.getS2K().getMemorySizeExponent();
+        // TODO: should really be 3 + log2(parallelism)
+        if (memorySizeExponent < 3 || memorySizeExponent > org.bouncycastle.util.Properties.asInteger(org.bouncycastle.crypto.params.Argon2Parameters.MAX_MEMORY_EXP, 30))
+        {
+            throw new PGPException("memory size exponent out of range");
         }
     }
 }

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/Argon2S2KTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/Argon2S2KTest.java
@@ -10,11 +10,9 @@ import java.util.Date;
 
 import org.bouncycastle.bcpg.ArmoredInputStream;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
-import org.bouncycastle.bcpg.BCPGInputStream;
 import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.bcpg.S2K;
 import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
-import org.bouncycastle.bcpg.SymmetricKeyEncSessionPacket;
 import org.bouncycastle.openpgp.PGPEncryptedDataGenerator;
 import org.bouncycastle.openpgp.PGPEncryptedDataList;
 import org.bouncycastle.openpgp.PGPException;
@@ -163,15 +161,12 @@ public class Argon2S2KTest
     {
         System.setProperty("org.bouncycastle.argon2.max_memory_exp", "10");
 
-        BCPGInputStream pgpIn = new BCPGInputStream(
-            getClass().getResourceAsStream("poc_argon2_s2k.pgp"));
         try
         {
-            SymmetricKeyEncSessionPacket skesk =
-                (SymmetricKeyEncSessionPacket)pgpIn.readPacket();
+            decryptSymmetricallyEncryptedMessage(TEST_MSG_AES256, TEST_MSG_PASSWORD);
             fail("no exception");
         }
-        catch (IOException e)
+        catch (PGPException e)
         {
             isEquals("memory size exponent out of range", e.getMessage());
         }


### PR DESCRIPTION
…rameterBounds()

This moves the parameter validation out of the packet parsing step into the decryption step.
The exception changed from an IOException to PGPException

Relates to #2283 