### PR TITLE
ArmoredInputStream: CSF - Fix handling of dash-prefixed messages

### DIFF
--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredInputStream.java
@@ -146,6 +146,7 @@ public class ArmoredInputStream
     boolean restart = false;
     StringList headerList = Strings.newList();
     int lastC = 0;
+    int lookAhead = -1;
     boolean isEndOfStream;
 
     private boolean validateAllowedHeaders = false;
@@ -450,6 +451,12 @@ public class ArmoredInputStream
 
         if (clearText)
         {
+            if (lookAhead != -1)
+            {
+                c = lookAhead;
+                lookAhead = -1;
+                return c;
+            }
             c = in.read();
 
             if (c == '\r' || (c == '\n' && lastC != '\r'))
@@ -458,20 +465,26 @@ public class ArmoredInputStream
             }
             else if (newLineFound && c == '-')
             {
-                c = in.read();
-                if (c == '-')            // a header, not dash escaped
+                lookAhead = in.read();
+                if (lookAhead == '-')            // a header, not dash escaped
                 {
                     clearText = false;
                     start = true;
                     restart = true;
                 }
-                else if (c == ' ')                   // a space - must be a dash escape
+                else if (lookAhead == ' ')       // a space - must be a dash escape
                 {
+                    // remove dash escaping
                     c = in.read();
+                    lookAhead = -1;
                 }
-                else if (csfRejectPrefixedDashes)
+                else
                 {
-                    throw new ArmoredInputException("Prefixed dash without trailing space encountered. CSF-signed message malformed.");
+                    // malformed message
+                    if (csfRejectPrefixedDashes)
+                    {
+                        throw new ArmoredInputException("Prefixed dash without trailing space encountered. CSF-signed message malformed.");
+                    }
                 }
                 newLineFound = false;
             }
@@ -716,7 +729,8 @@ public class ArmoredInputStream
             return this;
         }
 
-        public Builder setRejectPrefixedDashesInCSFMessages(boolean rejectDashes) {
+        public Builder setRejectPrefixedDashesInCSFMessages(boolean rejectDashes)
+        {
             this.csfRejectPrefixedDashes = rejectDashes;
             return this;
         }

--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredInputStream.java
@@ -149,6 +149,7 @@ public class ArmoredInputStream
     boolean isEndOfStream;
 
     private boolean validateAllowedHeaders = false;
+    private boolean csfRejectPrefixedDashes = true;
     private List<String> allowedHeaders = defaultAllowedHeaders();
 
     /**
@@ -199,6 +200,7 @@ public class ArmoredInputStream
         this.detectMissingChecksum = builder.detectMissingCRC;
         this.crc = builder.ignoreCRC ? null : new FastCRC24();
         this.validateAllowedHeaders = builder.validateAllowedHeaders;
+        this.csfRejectPrefixedDashes = builder.csfRejectPrefixedDashes;
         this.allowedHeaders = builder.allowedHeaders;
 
         if (hasHeaders)
@@ -463,9 +465,13 @@ public class ArmoredInputStream
                     start = true;
                     restart = true;
                 }
-                else                   // a space - must be a dash escape
+                else if (c == ' ')                   // a space - must be a dash escape
                 {
                     c = in.read();
+                }
+                else if (csfRejectPrefixedDashes)
+                {
+                    throw new ArmoredInputException("Prefixed dash without trailing space encountered. CSF-signed message malformed.");
                 }
                 newLineFound = false;
             }
@@ -683,6 +689,7 @@ public class ArmoredInputStream
         private boolean detectMissingCRC = false;
         private boolean ignoreCRC = false;
         private boolean validateAllowedHeaders = false;
+        private boolean csfRejectPrefixedDashes = false;
         private List<String> allowedHeaders = defaultAllowedHeaders();
 
         private Builder()
@@ -706,6 +713,11 @@ public class ArmoredInputStream
         public Builder setValidateClearsignedMessageHeaders(boolean validateHeaders)
         {
             this.validateAllowedHeaders = validateHeaders;
+            return this;
+        }
+
+        public Builder setRejectPrefixedDashesInCSFMessages(boolean rejectDashes) {
+            this.csfRejectPrefixedDashes = rejectDashes;
             return this;
         }
 

--- a/pg/src/main/java/org/bouncycastle/bcpg/ArmoredInputStream.java
+++ b/pg/src/main/java/org/bouncycastle/bcpg/ArmoredInputStream.java
@@ -689,7 +689,7 @@ public class ArmoredInputStream
         private boolean detectMissingCRC = false;
         private boolean ignoreCRC = false;
         private boolean validateAllowedHeaders = false;
-        private boolean csfRejectPrefixedDashes = false;
+        private boolean csfRejectPrefixedDashes = true;
         private List<String> allowedHeaders = defaultAllowedHeaders();
 
         private Builder()

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/ArmoredInputStreamCSFRejectPrefixedDashTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/ArmoredInputStreamCSFRejectPrefixedDashTest.java
@@ -1,0 +1,59 @@
+package org.bouncycastle.openpgp.test;
+
+import org.bouncycastle.bcpg.ArmoredInputException;
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.Security;
+
+import org.bouncycastle.util.test.SimpleTest;
+import org.bouncycastle.util.io.Streams;
+
+public class ArmoredInputStreamCSFRejectPrefixedDashTest
+        extends SimpleTest {
+
+    public String getName()
+    {
+        return "ArmoredInputStreamCSFRejectPrefixedDashTest";
+    }
+
+    public static void main(String[] args)
+    {
+        Security.addProvider(new BouncyCastleProvider());
+
+        runTest(new ArmoredInputStreamCSFRejectPrefixedDashTest());
+    }
+
+    public void performTest()
+            throws IOException
+    {
+        // signature was created over "payload", but this malformed variant as "-X" prefixed.
+        String malformed = "-----BEGIN PGP SIGNED MESSAGE-----\n" +
+                "Hash: SHA512\n" +
+                "\n" +
+                "-Xpayload\n" +
+                "-----BEGIN PGP SIGNATURE-----\n" +
+                "Version: PGPainless\n" +
+                "\n" +
+                "wnUEABYKACcFgmoz+AoJEF0ybVyS+fXHFqEE/9HfXX3exPsb+/QfXTJtXJL59ccA\n" +
+                "AMmDAP4yxWVmaDycXXgNWuKtyHmWegY+TAQoS2FCrg0KZO/kuQEAnvg8YxQLcL7I\n" +
+                "WbRs9RZtPLc+jgUKBbz/bode8TkqyQU=\n" +
+                "=PIAb\n" +
+                "-----END PGP SIGNATURE-----";
+
+        ByteArrayInputStream bIn = new ByteArrayInputStream(malformed.getBytes(StandardCharsets.UTF_8));
+        ArmoredInputStream aIn = ArmoredInputStream.builder()
+                .setRejectPrefixedDashesInCSFMessages(true)
+                .build(bIn);
+
+        try {
+            Streams.drain(aIn);
+            fail("Prefixed dash in CSF message MUST be rejected if configured to do so.");
+        } catch (ArmoredInputException e) {
+            isEquals("Prefixed dash without trailing space encountered. CSF-signed message malformed.", e.getMessage());
+        }
+    }
+}

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/ArmoredInputStreamCSFRejectPrefixedDashTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/ArmoredInputStreamCSFRejectPrefixedDashTest.java
@@ -5,6 +5,7 @@ import org.bouncycastle.bcpg.ArmoredInputStream;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.Security;
@@ -49,11 +50,26 @@ public class ArmoredInputStreamCSFRejectPrefixedDashTest
                 .setRejectPrefixedDashesInCSFMessages(true)
                 .build(bIn);
 
-        try {
+        try
+        {
             Streams.drain(aIn);
             fail("Prefixed dash in CSF message MUST be rejected if configured to do so.");
-        } catch (ArmoredInputException e) {
-            isEquals("Prefixed dash without trailing space encountered. CSF-signed message malformed.", e.getMessage());
         }
+        catch (ArmoredInputException e)
+        {
+            isEquals("Exception message mismatch", "Prefixed dash without trailing space encountered. CSF-signed message malformed.", e.getMessage());
+        }
+
+        bIn = new ByteArrayInputStream(malformed.getBytes(StandardCharsets.UTF_8));
+        aIn = ArmoredInputStream.builder()
+                .setRejectPrefixedDashesInCSFMessages(false)
+                .build(bIn);
+
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        while (aIn.isClearText())
+        {
+            bOut.write(aIn.read());
+        }
+        isTrue("Malformed payload MUST be returned unaltered", bOut.toString().startsWith("-Xpayload"));
     }
 }

--- a/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
+++ b/pg/src/test/java/org/bouncycastle/openpgp/test/RegressionTest.java
@@ -41,6 +41,7 @@ public class RegressionTest
         new ArmoredInputStreamTest(),
         new ArmoredInputStreamBackslashTRVFTest(),
         new ArmoredInputStreamCRCErrorGetsThrownTest(),
+        new ArmoredInputStreamCSFRejectPrefixedDashTest(),
         new ArmoredInputStreamIngoreMissingCRCSum(),
         new ArmoredOutputStreamTest(),
         new PGPSessionKeyTest(),


### PR DESCRIPTION
This PR fixes the way BC handles messages created using the signature framework (csf) that contain malformed prefixed dashes.

When creating a cleartext signed message, all lines in the payload that start with a dash (`-`) need to be prefixed with `- ` (dash minus).

The `ArmoredInputStream` does assume, that a line in a CSF signed message that starts with `-` is either a header if the second character is also an `-`, or it is a dash-escape with the second character being *blindly* assumed to be a space.

This leads to situations where a cleartext signature over "payload" also checks out if the CSF message payload is modified to "-Xpayload".

The PR fixes this behavior by checking whether the second character is a space. If not, it emits the line as is, or throws an exception if configured to do so.

It adds a builder method `.setRejectPrefixedDashesInCSFMessages()` that can be used to configure the `ArmoredInputStream` to reject such messages as malformed.