### PR TITLE
Fix bad numbering in BIP340Signer comment

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/signers/BIP340Signer.java
+++ b/core/src/main/java/org/bouncycastle/crypto/signers/BIP340Signer.java
@@ -206,7 +206,7 @@ public class BIP340Signer
     {
         BigInteger n = SECP256K1.getN();
 
-        // Step 1: d' = int(sk); fail if d' = 0 or d' >= n.
+        // Step 1-2: d' = int(sk); fail if d' = 0 or d' >= n.
         BigInteger d = privateKey.getD();
         if (d.signum() <= 0 || d.compareTo(n) >= 0)
         {
@@ -215,7 +215,7 @@ public class BIP340Signer
 
         ECMultiplier mult = new FixedPointCombMultiplier();
 
-        // Steps 4-5: P = d' * G; d = d' if has_even_y(P) else n - d'.
+        // Steps 3-4: P = d' * G; d = d' if has_even_y(P) else n - d'.
         ECPoint P_pt = mult.multiply(SECP256K1.getG(), d).normalize();
         if (!hasEvenY(P_pt))
         {
@@ -223,7 +223,7 @@ public class BIP340Signer
         }
         byte[] pBytes = xBytes(P_pt);
 
-        // Steps 6-8: t = bytes(d) XOR H_aux(a); k' = int(H_nonce(t || bytes(P) || m)) mod n; fail if k' = 0.
+        // Steps 5-7: t = bytes(d) XOR H_aux(a); k' = int(H_nonce(t || bytes(P) || m)) mod n; fail if k' = 0.
         byte[] t = BigIntegers.asUnsignedByteArray(X_SIZE, d);
         Bytes.xorTo(X_SIZE, taggedHash(TAG_HASH_AUX, auxRand), t);
 
@@ -240,7 +240,7 @@ public class BIP340Signer
             throw new IllegalStateException("BIP-340 nonce derivation produced zero");
         }
 
-        // Steps 9-10: R = k' * G; k = k' if has_even_y(R) else n - k'.
+        // Steps 8-9: R = k' * G; k = k' if has_even_y(R) else n - k'.
         ECPoint R_pt = mult.multiply(SECP256K1.getG(), k).normalize();
         if (!hasEvenY(R_pt))
         {
@@ -248,7 +248,7 @@ public class BIP340Signer
         }
         byte[] rBytes = xBytes(R_pt);
 
-        // Steps 11-12: e = int(H_challenge(bytes(R) || bytes(P) || m)) mod n; sig = bytes(R) || bytes((k + e*d) mod n).
+        // Steps 10-11: e = int(H_challenge(bytes(R) || bytes(P) || m)) mod n; sig = bytes(R) || bytes((k + e*d) mod n).
         BigInteger e = challengeScalar(rBytes, pBytes, m);
         BigInteger s = k.add(e.multiply(d)).mod(n);
 


### PR DESCRIPTION
Updates step numbering to match the actual number of steps being performed, as outlined in [bip-0340.mediawiki](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#user-content-Default_Signing). Note that these steps:
```
- Let rand = hashBIP0340/nonce(t || bytes(P) || m).
- Let k' = int(rand) mod n.
```
are folded into Step 6.