### PR TITLE
Reset KGCM associatedText on reInit of initialAssociatedText

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/modes/KGCMBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/KGCMBlockCipher.java
@@ -99,6 +99,7 @@ public class KGCMBlockCipher
 
             newNonce = aeadParameters.getNonce();
             initialAssociatedText = aeadParameters.getAssociatedText();
+			associatedText.reset();
             macSize = macSizeInBits / 8;
             keyParameter = aeadParameters.getKey();
 
@@ -113,6 +114,7 @@ public class KGCMBlockCipher
 
             newNonce = withIV.getIV();
             initialAssociatedText = null;
+			associatedText.reset();
             macSize = blockSize; // Set default mac size
 
             CipherParameters innerParameters = withIV.getParameters();


### PR DESCRIPTION
If initialAssociatedText is specified for KGCM mode, it is immediately applied to associatedText, and the reset() method will automatically re-initialise the associatedText buffer correctly. 

However the associatedText is not cleared on a subsequent init(), leading to an incorrect associatedText buffer for that iteration. 
The buffer needs to be cleared on any init() call.