### PR TITLE
KCCM partial AEAD block

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/modes/KCCMBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/KCCMBlockCipher.java
@@ -216,11 +216,6 @@ public class KCCMBlockCipher
 
         boolean hasAssocText = aadLen > 0;
 
-        if (hasAssocText && aadLen % engine.getBlockSize() != 0)
-        {
-            throw new IllegalArgumentException("padding not supported");
-        }
-
         // The G1 block binds the nonce, data length and MAC-size flag into the MAC and must be
         // processed unconditionally. DSTU 7624 carries the associated-data-present indicator as a flag
         // bit inside G1, so it is not a gate on computing G1: skipping G1 when no AAD is present leaves
@@ -271,9 +266,9 @@ public class KCCMBlockCipher
 
         int assocOff = 0;
         int authLen = aadLen;
-        while (authLen != 0)
+        while (authLen > 0)
         {
-            for (int byteIndex = 0; byteIndex < engine.getBlockSize(); byteIndex++)
+            for (int byteIndex = 0; byteIndex < engine.getBlockSize() && byteIndex < authLen - assocOff; byteIndex++)
             {
                 macBlock[byteIndex] ^= aad[byteIndex + assocOff];
             }

--- a/core/src/main/java/org/bouncycastle/crypto/modes/KCCMBlockCipher.java
+++ b/core/src/main/java/org/bouncycastle/crypto/modes/KCCMBlockCipher.java
@@ -156,6 +156,14 @@ public class KCCMBlockCipher
             throw new IllegalArgumentException("invalid parameters passed to KCCM");
         }
 
+        // TODO Nonce length validation. Should it always be engineBlockSize?
+        if (newNonce.length < engine.getBlockSize())
+        {
+            byte[] tmp = new byte[engine.getBlockSize()];
+            System.arraycopy(newNonce, 0, tmp, 0, newNonce.length);
+            newNonce = tmp;
+        }
+
         // RFC 5116 sec. 2.1 requires a distinct nonce per AEAD encryption under a given key; the
         // DSTU 7624 CCM construction inherits this CCM rule (cf. NIST SP 800-38C), and reuse is
         // catastrophic (CTR keystream reuse plus a forgeable CBC-MAC). That obligation is the


### PR DESCRIPTION
Following the fixes for github #287, the KCCM mode still rejects AEAD data that is not a multiple of the engine blockSize. 

In addition, the nonce is required to be at least as long as the engine blockSize. It should probably be required to be exactly the blockSize, since it is simply processed as a block by the underlying engine, and subsequent bytes are ignored.  