### PR TITLE
Fix engineGetCertificateAlias returning the alias of an unrelated certificate

### DIFF
--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/keystore/pkcs12/PKCS12KeyStoreSpi.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/keystore/pkcs12/PKCS12KeyStoreSpi.java
@@ -438,29 +438,24 @@ public class PKCS12KeyStoreSpi
     public String engineGetCertificateAlias(
         Certificate cert)
     {
-        Enumeration c = certs.elements();
-        Enumeration k = certs.keys();
-
-        while (c.hasMoreElements())
+        // look the certificate up by alias rather than advancing keys() and elements() in
+        // lockstep - IgnoresCaseHashtable.keys() enumerates a copy of the table while
+        // elements() enumerates the original, so the two orders are not required to agree.
+        for (Enumeration k = certs.keys(); k.hasMoreElements();)
         {
-            Certificate tc = (Certificate)c.nextElement();
             String ta = (String)k.nextElement();
 
-            if (tc.equals(cert))
+            if (cert.equals(certs.get(ta)))
             {
                 return ta;
             }
         }
 
-        c = keyCerts.elements();
-        k = keyCerts.keys();
-
-        while (c.hasMoreElements())
+        for (Enumeration k = keyCerts.keys(); k.hasMoreElements();)
         {
-            Certificate tc = (Certificate)c.nextElement();
             String ta = (String)k.nextElement();
 
-            if (tc.equals(cert))
+            if (cert.equals(keyCerts.get(ta)))
             {
                 return ta;
             }

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/PKCS12StoreTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/PKCS12StoreTest.java
@@ -2417,6 +2417,46 @@ public class PKCS12StoreTest
         keyStore.getEntry("cycle", new KeyStore.PasswordProtection("test".toCharArray()));
     }
 
+    private void testGetCertificateAlias()
+        throws Exception
+    {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", BC);
+
+        keyStore.load(null, null);
+
+        // enough entries that the backing table has grown past its initial capacity: a copy of
+        // the table is sized from its entry count instead, so the two end up with different
+        // bucket layouts and any order-dependent pairing of keys() with elements() diverges.
+        KeyPair keyPair = TestUtils.generateRSAKeyPair();
+        int certCount = 12;
+
+        X509Certificate[] certs = new X509Certificate[certCount];
+        String[] aliases = new String[certCount];
+
+        for (int i = 0; i != certCount; i++)
+        {
+            aliases[i] = "cert-" + i;
+            certs[i] = TestUtils.createSelfSignedCert("CN=Test Certificate " + i, "SHA256withRSA", keyPair);
+
+            keyStore.setCertificateEntry(aliases[i], certs[i]);
+        }
+
+        for (int i = 0; i != certCount; i++)
+        {
+            String alias = keyStore.getCertificateAlias(certs[i]);
+
+            if (!aliases[i].equals(alias))
+            {
+                fail("getCertificateAlias returned wrong alias: expected " + aliases[i] + ", got " + alias);
+            }
+        }
+
+        if (keyStore.getCertificateAlias(TestUtils.createSelfSignedCert("CN=Absent", "SHA256withRSA", keyPair)) != null)
+        {
+            fail("getCertificateAlias returned an alias for a certificate that is not in the store");
+        }
+    }
+
     private void testOrphanedCertCleanup()
         throws Exception
     {
@@ -2798,6 +2838,7 @@ public class PKCS12StoreTest
         testPKCS12Store();
         testGOSTStore();
         testChainCycle();
+        testGetCertificateAlias();
         testBCFKSLoad();
         testCertsOnly();
         testJKS();


### PR DESCRIPTION
Fixes #2384.

`PKCS12KeyStoreSpi.engineGetCertificateAlias` walked `certs.elements()` and `certs.keys()` in
lockstep, taking the certificate from one enumeration and the alias from the other. That relies on
both enumerations visiting the table in the same order, which stopped being true in 1.80: a5be993
changed `IgnoresCaseHashtable.keys()` to enumerate `new Hashtable(orig)` while `elements()` still
enumerates `orig`. `new Hashtable(Map)` sizes its bucket array from the entry count, whereas `orig`
reached its capacity by incremental rehashing, so once a store holds enough entries the two layouts
differ and the method returns the alias of an unrelated certificate — silently, with no exception.

Since the copy in `keys()` was introduced deliberately, this fixes the caller instead of reverting
it: the value is now looked up by key, so the result no longer depends on two enumerations agreeing.
The same change is applied to the `keyCerts` loop below it — `keyCerts` is a plain `Hashtable` whose
`keys()` and `elements()` do agree, so it was not broken, but the pairing was the same latent
fragility and removing it costs nothing.

`testGetCertificateAlias` in `PKCS12StoreTest` covers it: 12 certificate entries, then every
certificate is looked up and must return its own alias, plus a negative case for a certificate that
is not in the store. Twelve is chosen so the backing table has grown past its initial capacity — with
only a handful of entries the original and the copy can share a layout and the defect does not
reproduce, which is probably why it went unnoticed. The test fails before this change and passes
after.

Not addressed here: the `prov/src/main/jdk1.3` and `prov/src/main/jdk1.4` copies of this class still
have `return orig.keys();` and so behave correctly today, but their `engineGetCertificateAlias`
carries the same order-dependent pairing. Happy to extend the PR to those trees if you would prefer
them hardened too.

Prepared with AI assistance (noted in the commit trailer), offered under the Bouncy Castle License
per CONTRIBUTING.md.
