### PR TITLE
Allow Kangaroo doFinal after doOutput

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/digests/Kangaroo.java
+++ b/core/src/main/java/org/bouncycastle/crypto/digests/Kangaroo.java
@@ -312,12 +312,6 @@ public final class Kangaroo
                            final int pOutOffset,
                            final int pOutLen)
         {
-            /* Check that we are not already outputting */
-            if (squeezing)
-            {
-                throw new IllegalStateException("Already outputting");
-            }
-
             /* Build the required output */
             final int length = doOutput(pOut, pOutOffset, pOutLen);
 


### PR DESCRIPTION
The Kangaroo doFinal call performs a check to ensure that it is not already squeezing, and throws an exception if it is already squeezing. However multiple doOutput calls followed by a doFinal is a valid sequence and is supported on all other Xof models (SHAKE/Blake3/Ascon). 

The check is redundant and should be deleted.