### PR TITLE
Bump Checkstyle from 9.0 to 14.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,13 +262,13 @@ configure(subprojects.findAll {it.name != 'bom'}) {
 
     dependencies {
         checkstyle files("$rootDir/config/checkstyle/lib/methodchecker-1.0.0.jar")
-        checkstyle 'com.puppycrawl.tools:checkstyle:9.0'
+        checkstyle 'com.puppycrawl.tools:checkstyle:14.0.0'
         errorprone "com.google.errorprone:error_prone_core:2.43.0"
     }
 
     checkstyle {
         configFile = file("$rootDir/config/checkstyle/checkstyle.xml");
-        toolVersion = '9.0'; // your choice here
+        toolVersion = '14.0.0';
         sourceSets = [project.sourceSets.main]
     }
 


### PR DESCRIPTION
 **Summary**
  
  - Bumps Checkstyle from 9.0 to 14.0.0 across all subprojects (shared configure(subprojects) block in build.gradle)
  - Updates both the checkstyle dependency coordinate and the toolVersion
  - Resolves 3 CVEs in Checkstyle's transitive dependencies:
    - CVE-2025-48734 (HIGH) — commons-beanutils 1.9.4 → 1.11.0
    - CVE-2023-2976 (MEDIUM) — guava 30.1.1-jre → 33.6.0-jre
    - CVE-2020-8908 (LOW) — guava 30.1.1-jre → 33.6.0-jre
  
  - These are build-tool transitive dependencies of Checkstyle only, none ship in the published BC jars
  - Config-only change; the existing config/checkstyle/checkstyle.xml ruleset is unchanged and fully compatible with 14.0.0