### PR TITLE
Make the StreamGenerator an AutoCloseable

### DIFF
--- a/pg/src/main/java/org/bouncycastle/openpgp/StreamGenerator.java
+++ b/pg/src/main/java/org/bouncycastle/openpgp/StreamGenerator.java
@@ -4,13 +4,14 @@ import java.io.IOException;
 
 /**
  * Callback interface for generators that produce a stream to be informed when the stream has been
- * closed by the client.
+ * closed by the client. Complies with Java's own {@link AutoCloseable} interface
  */
-interface StreamGenerator
+interface StreamGenerator extends AutoCloseable
 {
     /**
      * Signal that the stream has been closed.
      */
+    @Override
     void close()
         throws IOException;
 }


### PR DESCRIPTION
This would allow `StreamGenerator` to be used with try-with-resources